### PR TITLE
fix(client): show token usage on replies when Show Cost is enabled

### DIFF
--- a/docs/chat-chain-changes/2026-07-27-show-cost-token-usage-in-replies.md
+++ b/docs/chat-chain-changes/2026-07-27-show-cost-token-usage-in-replies.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-07-27
-pr: pending
+pr: 2240
 feature: Show Cost token usage on chat replies
 impact: When display.show_cost is enabled, the latest completed assistant reply shows cumulative session input/output token usage.
 ---

--- a/docs/chat-chain-changes/2026-07-27-show-cost-token-usage-in-replies.md
+++ b/docs/chat-chain-changes/2026-07-27-show-cost-token-usage-in-replies.md
@@ -1,0 +1,10 @@
+---
+date: 2026-07-27
+pr: pending
+feature: Show Cost token usage on chat replies
+impact: When display.show_cost is enabled, the latest completed assistant reply shows cumulative session input/output token usage.
+---
+
+The Display setting already persisted `show_cost`, but chat replies never rendered
+it. MessageItem now reads the setting and surfaces the active session's
+`inputTokens` / `outputTokens` on the latest completed assistant message.

--- a/docs/chat-chain-changes/2026-08-03-message-run-id-usage.md
+++ b/docs/chat-chain-changes/2026-08-03-message-run-id-usage.md
@@ -6,8 +6,9 @@ impact: Messages now store their originating run_id so provider usage can be att
 ---
 
 The `messages` table gains a `run_id` column (`TEXT NOT NULL DEFAULT ''`).
-All assistant tool-call flush sites (bridge, ekko, coding-agent, response-stream)
-now pass the active run id into `addMessage` so it is persisted with the row.
+All assistant tool-call flush sites (bridge, ekko `handle-ekko-agent-run.ts`,
+coding-agent, response-stream) now pass the active run id into `addMessage`
+so it is persisted with the row.
 
 `getConversationMessagesPaginated` calls `attachRunUsageToMessages` before
 returning history. That helper joins `session_usage` by `run_id` (trying

--- a/docs/chat-chain-changes/2026-08-03-message-run-id-usage.md
+++ b/docs/chat-chain-changes/2026-08-03-message-run-id-usage.md
@@ -1,0 +1,19 @@
+---
+date: 2026-08-03
+pr: 2240
+feature: Per-message run_id persistence and usage read-back
+impact: Messages now store their originating run_id so provider usage can be attached on history read-back, surviving refresh and reload.
+---
+
+The `messages` table gains a `run_id` column (`TEXT NOT NULL DEFAULT ''`).
+All assistant tool-call flush sites (bridge, ekko, coding-agent, response-stream)
+now pass the active run id into `addMessage` so it is persisted with the row.
+
+`getConversationMessagesPaginated` calls `attachRunUsageToMessages` before
+returning history. That helper joins `session_usage` by `run_id` (trying
+`hermes`, `ekko_agent`, `coding_agent` sources in order) and returns usage
+on the matching assistant row.
+
+The client `HermesMessage` interface surfaces `run_id` and `usage`.
+`mapHermesMessages` passes them through to the `Message` object so
+`MessageItem` renders usage on reloaded conversations without a live run.

--- a/packages/client/src/api/studio/sessions.ts
+++ b/packages/client/src/api/studio/sessions.ts
@@ -120,6 +120,15 @@ export interface HermesMessage {
   token_count: number | null
   finish_reason: string | null
   reasoning: string | null
+  run_id?: string | null
+  usage?: {
+    input: number
+    output: number
+    cacheRead?: number
+    cacheWrite?: number
+    reasoning?: number
+    apiCalls?: number
+  } | null
 }
 
 export interface WorkspaceRunChangeFileSummary {

--- a/packages/client/src/components/hermes/chat/MessageItem.vue
+++ b/packages/client/src/components/hermes/chat/MessageItem.vue
@@ -373,6 +373,22 @@ function formatTokenCount(value: number): string {
   return String(value);
 }
 
+const messageRunUsage = computed(() => {
+  const usage = props.message.usage;
+  if (!usage) return null;
+  const input = Number(usage.input || 0);
+  const output = Number(usage.output || 0);
+  const cacheRead = Number(usage.cacheRead || 0);
+  const reasoning = Number(usage.reasoning || 0);
+  if (input <= 0 && output <= 0 && cacheRead <= 0 && reasoning <= 0) return null;
+  return {
+    input,
+    output,
+    cacheRead,
+    reasoning,
+  };
+});
+
 const showTokenUsage = computed(() => {
   if (!settingsStore.display.show_cost) return false;
   if (props.message.role !== 'assistant') return false;
@@ -381,33 +397,24 @@ const showTokenUsage = computed(() => {
   const visibleBody = (parsedThinking.value.body || props.message.content || '').trim();
   if (!visibleBody) return false;
 
-  const session = chatStore.activeSession;
-  if (!session) return false;
-  const inputTokens = Number(session.inputTokens || 0);
-  const outputTokens = Number(session.outputTokens || 0);
-  if (inputTokens <= 0 && outputTokens <= 0) return false;
-
-  // Session usage is cumulative. Surface it once on the latest completed reply
-  // so "Show Cost" actually appears in the conversation instead of only as a
-  // dead settings toggle.
-  const messages = session.messages || [];
-  for (let i = messages.length - 1; i >= 0; i -= 1) {
-    const message = messages[i];
-    if (message.role !== 'assistant') continue;
-    if (message.isStreaming || message.systemType === 'error') continue;
-    const body = String(message.content || '').trim();
-    if (!body) continue;
-    return message.id === props.message.id;
-  }
-  return false;
+  // Prefer provider-recorded usage for THIS reply/run. Session-level counters
+  // are cumulative context estimates and must not be shown as reply cost.
+  return messageRunUsage.value != null;
 });
 
 const tokenUsageLabel = computed(() => {
-  const session = chatStore.activeSession;
-  if (!session) return '';
+  const usage = messageRunUsage.value;
+  if (!usage) return '';
+  if (usage.cacheRead > 0) {
+    return t('chat.tokenUsageWithCache', {
+      input: formatTokenCount(usage.input),
+      cache: formatTokenCount(usage.cacheRead),
+      output: formatTokenCount(usage.output),
+    });
+  }
   return t('chat.tokenUsage', {
-    input: formatTokenCount(Number(session.inputTokens || 0)),
-    output: formatTokenCount(Number(session.outputTokens || 0)),
+    input: formatTokenCount(usage.input),
+    output: formatTokenCount(usage.output),
   });
 });
 

--- a/packages/client/src/components/hermes/chat/MessageItem.vue
+++ b/packages/client/src/components/hermes/chat/MessageItem.vue
@@ -367,6 +367,50 @@ function formatDuration(ms: number): string {
 
 const timeStr = computed(() => formatChatTimestamp(props.message.timestamp));
 
+function formatTokenCount(value: number): string {
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
+  return String(value);
+}
+
+const showTokenUsage = computed(() => {
+  if (!settingsStore.display.show_cost) return false;
+  if (props.message.role !== 'assistant') return false;
+  if (props.message.isStreaming || isAgentError.value) return false;
+
+  const visibleBody = (parsedThinking.value.body || props.message.content || '').trim();
+  if (!visibleBody) return false;
+
+  const session = chatStore.activeSession;
+  if (!session) return false;
+  const inputTokens = Number(session.inputTokens || 0);
+  const outputTokens = Number(session.outputTokens || 0);
+  if (inputTokens <= 0 && outputTokens <= 0) return false;
+
+  // Session usage is cumulative. Surface it once on the latest completed reply
+  // so "Show Cost" actually appears in the conversation instead of only as a
+  // dead settings toggle.
+  const messages = session.messages || [];
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const message = messages[i];
+    if (message.role !== 'assistant') continue;
+    if (message.isStreaming || message.systemType === 'error') continue;
+    const body = String(message.content || '').trim();
+    if (!body) continue;
+    return message.id === props.message.id;
+  }
+  return false;
+});
+
+const tokenUsageLabel = computed(() => {
+  const session = chatStore.activeSession;
+  if (!session) return '';
+  return t('chat.tokenUsage', {
+    input: formatTokenCount(Number(session.inputTokens || 0)),
+    output: formatTokenCount(Number(session.outputTokens || 0)),
+  });
+});
+
 function isImage(type: string): boolean {
   return type.startsWith("image/");
 }
@@ -1254,6 +1298,11 @@ onBeforeUnmount(() => {
               <span></span><span></span><span></span>
             </span>
           </div>
+          <span
+            v-if="showTokenUsage"
+            class="message-usage"
+            :title="tokenUsageLabel"
+          >{{ tokenUsageLabel }}</span>
           <div class="message-meta">
             <button
               v-if="canPlaySpeech"
@@ -1865,6 +1914,21 @@ onBeforeUnmount(() => {
   }
   50% {
     opacity: 0.5;
+  }
+}
+
+.message-usage {
+  display: inline-flex;
+  align-items: center;
+  margin-top: 4px;
+  padding: 0 4px;
+  font-size: 11px;
+  color: $text-muted;
+  white-space: nowrap;
+  user-select: none;
+
+  .dark & {
+    color: #999999;
   }
 }
 

--- a/packages/client/src/i18n/locales/de.ts
+++ b/packages/client/src/i18n/locales/de.ts
@@ -1020,6 +1020,7 @@ export default {
     stopSpeech: 'Stoppen',
     speechNotSupported: 'Sprachwiedergabe in diesem Browser nicht unterstützt',
     tokenUsage: '{input} rein · {output} raus',
+    tokenUsageWithCache: '{input} rein · {cache} Cache · {output} raus',
     searchEnterHint: 'Enter zum Öffnen · Esc zum Schließen',
     searchHint: 'Cmd/Ctrl+K',
     searchScope: 'Suchbereich: nur lokale Web-UI-Sitzungsdatenbank; schreibgeschützte Hermes-Verlaufssitzungen sind nicht enthalten.',

--- a/packages/client/src/i18n/locales/de.ts
+++ b/packages/client/src/i18n/locales/de.ts
@@ -1019,6 +1019,7 @@ export default {
     resumeSpeech: 'Fortsetzen',
     stopSpeech: 'Stoppen',
     speechNotSupported: 'Sprachwiedergabe in diesem Browser nicht unterstützt',
+    tokenUsage: '{input} rein · {output} raus',
     searchEnterHint: 'Enter zum Öffnen · Esc zum Schließen',
     searchHint: 'Cmd/Ctrl+K',
     searchScope: 'Suchbereich: nur lokale Web-UI-Sitzungsdatenbank; schreibgeschützte Hermes-Verlaufssitzungen sind nicht enthalten.',

--- a/packages/client/src/i18n/locales/en.ts
+++ b/packages/client/src/i18n/locales/en.ts
@@ -1126,6 +1126,7 @@ export default {
     resumeSpeech: 'Resume',
     stopSpeech: 'Stop',
     speechNotSupported: 'Voice playback not supported in this browser',
+    tokenUsage: '{input} in · {output} out',
   },
 
   workflow: {

--- a/packages/client/src/i18n/locales/en.ts
+++ b/packages/client/src/i18n/locales/en.ts
@@ -1127,6 +1127,7 @@ export default {
     stopSpeech: 'Stop',
     speechNotSupported: 'Voice playback not supported in this browser',
     tokenUsage: '{input} in · {output} out',
+    tokenUsageWithCache: '{input} in · {cache} cache · {output} out',
   },
 
   workflow: {

--- a/packages/client/src/i18n/locales/es.ts
+++ b/packages/client/src/i18n/locales/es.ts
@@ -1020,6 +1020,7 @@ export default {
     stopSpeech: 'Detener',
     speechNotSupported: 'Reproducción de voz no soportada en este navegador',
     tokenUsage: '{input} entrada · {output} salida',
+    tokenUsageWithCache: '{input} entrada · {cache} caché · {output} salida',
     searchEnterHint: 'Enter para abrir · Esc para cerrar',
     searchHint: 'Cmd/Ctrl+K',
     searchScope: 'Alcance de búsqueda: solo base de datos local de sesiones de Web UI; no incluye sesiones históricas Hermes de solo lectura.',

--- a/packages/client/src/i18n/locales/es.ts
+++ b/packages/client/src/i18n/locales/es.ts
@@ -1019,6 +1019,7 @@ export default {
     resumeSpeech: 'Reanudar',
     stopSpeech: 'Detener',
     speechNotSupported: 'Reproducción de voz no soportada en este navegador',
+    tokenUsage: '{input} entrada · {output} salida',
     searchEnterHint: 'Enter para abrir · Esc para cerrar',
     searchHint: 'Cmd/Ctrl+K',
     searchScope: 'Alcance de búsqueda: solo base de datos local de sesiones de Web UI; no incluye sesiones históricas Hermes de solo lectura.',

--- a/packages/client/src/i18n/locales/fr.ts
+++ b/packages/client/src/i18n/locales/fr.ts
@@ -1019,6 +1019,7 @@ export default {
     resumeSpeech: 'Reprendre',
     stopSpeech: 'Arrêter',
     speechNotSupported: 'Reproduction vocale non prise en charge dans ce navigateur',
+    tokenUsage: '{input} entrées · {output} sorties',
     searchEnterHint: 'Entrée pour ouvrir · Échap pour fermer',
     searchHint: 'Cmd/Ctrl+K',
     searchScope: 'Portée de recherche : base locale des sessions Web UI uniquement ; les sessions d’historique Hermes en lecture seule ne sont pas incluses.',

--- a/packages/client/src/i18n/locales/fr.ts
+++ b/packages/client/src/i18n/locales/fr.ts
@@ -1020,6 +1020,7 @@ export default {
     stopSpeech: 'Arrêter',
     speechNotSupported: 'Reproduction vocale non prise en charge dans ce navigateur',
     tokenUsage: '{input} entrées · {output} sorties',
+    tokenUsageWithCache: '{input} entrées · {cache} cache · {output} sorties',
     searchEnterHint: 'Entrée pour ouvrir · Échap pour fermer',
     searchHint: 'Cmd/Ctrl+K',
     searchScope: 'Portée de recherche : base locale des sessions Web UI uniquement ; les sessions d’historique Hermes en lecture seule ne sont pas incluses.',

--- a/packages/client/src/i18n/locales/ja.ts
+++ b/packages/client/src/i18n/locales/ja.ts
@@ -1019,6 +1019,7 @@ export default {
     resumeSpeech: '再開',
     stopSpeech: '停止',
     speechNotSupported: 'このブラウザは音声読み上げをサポートしていません',
+    tokenUsage: '入力 {input} · 出力 {output}',
     searchEnterHint: 'Enter で開く · Esc で閉じる',
     searchHint: 'Cmd/Ctrl+K',
     searchScope: '検索範囲: Web UI のローカルセッション DB のみ。読み取り専用の Hermes 履歴セッションは含まれません。',

--- a/packages/client/src/i18n/locales/ja.ts
+++ b/packages/client/src/i18n/locales/ja.ts
@@ -1020,6 +1020,7 @@ export default {
     stopSpeech: '停止',
     speechNotSupported: 'このブラウザは音声読み上げをサポートしていません',
     tokenUsage: '入力 {input} · 出力 {output}',
+    tokenUsageWithCache: '入力 {input} · キャッシュ {cache} · 出力 {output}',
     searchEnterHint: 'Enter で開く · Esc で閉じる',
     searchHint: 'Cmd/Ctrl+K',
     searchScope: '検索範囲: Web UI のローカルセッション DB のみ。読み取り専用の Hermes 履歴セッションは含まれません。',

--- a/packages/client/src/i18n/locales/ko.ts
+++ b/packages/client/src/i18n/locales/ko.ts
@@ -1020,6 +1020,7 @@ export default {
     stopSpeech: '중지',
     speechNotSupported: '이 브라우저는 음성 재생을 지원하지 않습니다',
     tokenUsage: '입력 {input} · 출력 {output}',
+    tokenUsageWithCache: '입력 {input} · 캐시 {cache} · 출력 {output}',
     searchEnterHint: 'Enter로 열기 · Esc로 닫기',
     searchHint: 'Cmd/Ctrl+K',
     searchScope: '검색 범위: Web UI 로컬 세션 DB만 포함하며 읽기 전용 Hermes 기록 세션은 포함하지 않습니다.',

--- a/packages/client/src/i18n/locales/ko.ts
+++ b/packages/client/src/i18n/locales/ko.ts
@@ -1019,6 +1019,7 @@ export default {
     resumeSpeech: '재개',
     stopSpeech: '중지',
     speechNotSupported: '이 브라우저는 음성 재생을 지원하지 않습니다',
+    tokenUsage: '입력 {input} · 출력 {output}',
     searchEnterHint: 'Enter로 열기 · Esc로 닫기',
     searchHint: 'Cmd/Ctrl+K',
     searchScope: '검색 범위: Web UI 로컬 세션 DB만 포함하며 읽기 전용 Hermes 기록 세션은 포함하지 않습니다.',

--- a/packages/client/src/i18n/locales/pt.ts
+++ b/packages/client/src/i18n/locales/pt.ts
@@ -1019,6 +1019,7 @@ export default {
     resumeSpeech: 'Retomar',
     stopSpeech: 'Parar',
     speechNotSupported: 'Reprodução de voz não suportada neste navegador',
+    tokenUsage: '{input} entrada · {output} saída',
     searchEnterHint: 'Enter para abrir · Esc para fechar',
     searchHint: 'Cmd/Ctrl+K',
     searchScope: 'Escopo da busca: apenas banco local de sessões da Web UI; sessões históricas Hermes somente leitura não são incluídas.',

--- a/packages/client/src/i18n/locales/pt.ts
+++ b/packages/client/src/i18n/locales/pt.ts
@@ -1020,6 +1020,7 @@ export default {
     stopSpeech: 'Parar',
     speechNotSupported: 'Reprodução de voz não suportada neste navegador',
     tokenUsage: '{input} entrada · {output} saída',
+    tokenUsageWithCache: '{input} entrada · {cache} cache · {output} saída',
     searchEnterHint: 'Enter para abrir · Esc para fechar',
     searchHint: 'Cmd/Ctrl+K',
     searchScope: 'Escopo da busca: apenas banco local de sessões da Web UI; sessões históricas Hermes somente leitura não são incluídas.',

--- a/packages/client/src/i18n/locales/ru.ts
+++ b/packages/client/src/i18n/locales/ru.ts
@@ -978,6 +978,7 @@ export default {
     stopSpeech: 'Остановить',
     speechNotSupported: 'Этот браузер не поддерживает воспроизведение речи',
     tokenUsage: '{input} вх · {output} вых',
+    tokenUsageWithCache: '{input} вх · {cache} кэш · {output} вых',
   },
 
 

--- a/packages/client/src/i18n/locales/ru.ts
+++ b/packages/client/src/i18n/locales/ru.ts
@@ -977,6 +977,7 @@ export default {
     resumeSpeech: 'Продолжить',
     stopSpeech: 'Остановить',
     speechNotSupported: 'Этот браузер не поддерживает воспроизведение речи',
+    tokenUsage: '{input} вх · {output} вых',
   },
 
 

--- a/packages/client/src/i18n/locales/zh-TW.ts
+++ b/packages/client/src/i18n/locales/zh-TW.ts
@@ -1088,6 +1088,7 @@ export default {
     resumeSpeech: '繼續',
     stopSpeech: '停止',
     speechNotSupported: '此瀏覽器不支援語音播放',
+    tokenUsage: '{input} 輸入 · {output} 輸出',
     modelSetFailed: '設定模型失敗',
     modelSet: '模型已設定',
     modelSwitching: '正在切換模型...',

--- a/packages/client/src/i18n/locales/zh-TW.ts
+++ b/packages/client/src/i18n/locales/zh-TW.ts
@@ -1089,6 +1089,7 @@ export default {
     stopSpeech: '停止',
     speechNotSupported: '此瀏覽器不支援語音播放',
     tokenUsage: '{input} 輸入 · {output} 輸出',
+    tokenUsageWithCache: '{input} 輸入 · {cache} 快取 · {output} 輸出',
     modelSetFailed: '設定模型失敗',
     modelSet: '模型已設定',
     modelSwitching: '正在切換模型...',

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -1126,6 +1126,7 @@ export default {
     resumeSpeech: '继续',
     stopSpeech: '停止',
     speechNotSupported: '此浏览器不支持语音播放',
+    tokenUsage: '{input} 输入 · {output} 输出',
   },
 
   workflow: {

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -1127,6 +1127,7 @@ export default {
     stopSpeech: '停止',
     speechNotSupported: '此浏览器不支持语音播放',
     tokenUsage: '{input} 输入 · {output} 输出',
+    tokenUsageWithCache: '{input} 输入 · {cache} 缓存 · {output} 输出',
   },
 
   workflow: {

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -1101,6 +1101,19 @@ function mapHermesMessages(msgs: HermesMessage[]): Message[] {
     // Normal user/assistant/command messages
     const displayRole = msg.display_role || msg.role
     const displayContent = msg.display_content ?? msg.content
+    // Server attaches provider-recorded usage (by run_id) to assistant rows on
+    // history read-back, so it survives refresh / reload. Surface it on the
+    // mapped Message so MessageItem can render it without a live run event.
+    const usage = displayRole === 'assistant' && msg.usage
+      ? {
+          input: msg.usage.input ?? 0,
+          output: msg.usage.output ?? 0,
+          ...(msg.usage.cacheRead != null ? { cacheRead: msg.usage.cacheRead } : {}),
+          ...(msg.usage.cacheWrite != null ? { cacheWrite: msg.usage.cacheWrite } : {}),
+          ...(msg.usage.reasoning != null ? { reasoning: msg.usage.reasoning } : {}),
+          ...(msg.usage.apiCalls != null ? { apiCalls: msg.usage.apiCalls } : {}),
+        }
+      : undefined
     result.push({
       id: String(msg.id),
       role: displayRole === 'moa' ? 'system' : displayRole,
@@ -1110,6 +1123,8 @@ function mapHermesMessages(msgs: HermesMessage[]): Message[] {
       systemType: displayRole === 'command' ? 'command' : undefined,
       finishReason: readFinishReason(msg),
       runMarker: readRunMarker(msg),
+      runId: msg.run_id || undefined,
+      usage,
     })
   }
   return result

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -97,6 +97,16 @@ export interface Message {
   runMarker?: string | null
   toolRunId?: string
   toolMessages?: Message[]
+  /** Provider-recorded usage for the run that produced this assistant reply. */
+  usage?: {
+    input: number
+    output: number
+    cacheRead?: number
+    cacheWrite?: number
+    reasoning?: number
+    apiCalls?: number
+  }
+  runId?: string | null
 }
 
 export type SubagentStreamStatus =
@@ -1786,8 +1796,14 @@ export const useChatStore = defineStore('chat', () => {
           existing.reasoningEffort = fresh.reasoningEffort
           if (!pushEnabledWriteTargets.has(existing.id)) existing.pushEnabled = fresh.pushEnabled
           existing.messageCount = fresh.messageCount
-          existing.inputTokens = fresh.inputTokens
-          existing.outputTokens = fresh.outputTokens
+          // sessions.input_tokens/output_tokens are often still 0 in the list API.
+          // Never let that wipe runtime usage from usage.updated / run.completed.
+          const freshInput = Number(fresh.inputTokens || 0)
+          const freshOutput = Number(fresh.outputTokens || 0)
+          if (freshInput > 0 || freshOutput > 0) {
+            existing.inputTokens = fresh.inputTokens
+            existing.outputTokens = fresh.outputTokens
+          }
           existing.workspace = fresh.workspace
           existing.categoryId = fresh.categoryId
           existing.isLocalOnly = false
@@ -2352,6 +2368,70 @@ export const useChatStore = defineStore('chat', () => {
       // Add new session
       sessions.value.push(session)
     }
+  }
+
+  function normalizeRunUsage(raw: any): Message['usage'] | undefined {
+    if (!raw || typeof raw !== 'object') return undefined
+    const input = Number(
+      raw.input ?? raw.inputTokens ?? raw.input_tokens ?? 0,
+    )
+    const output = Number(
+      raw.output ?? raw.outputTokens ?? raw.output_tokens ?? 0,
+    )
+    const cacheRead = Number(
+      raw.cacheRead ?? raw.cacheReadTokens ?? raw.cache_read ?? raw.cache_read_tokens ?? 0,
+    )
+    const cacheWrite = Number(
+      raw.cacheWrite ?? raw.cacheWriteTokens ?? raw.cache_write ?? raw.cache_write_tokens ?? 0,
+    )
+    const reasoning = Number(
+      raw.reasoning ?? raw.reasoningTokens ?? raw.reasoning_tokens ?? 0,
+    )
+    const apiCalls = Number(raw.apiCalls ?? raw.api_calls ?? 0)
+    if (![input, output, cacheRead, cacheWrite, reasoning].some(n => Number.isFinite(n) && n > 0)) {
+      return undefined
+    }
+    return {
+      input: Number.isFinite(input) ? input : 0,
+      output: Number.isFinite(output) ? output : 0,
+      ...(Number.isFinite(cacheRead) && cacheRead > 0 ? { cacheRead } : {}),
+      ...(Number.isFinite(cacheWrite) && cacheWrite > 0 ? { cacheWrite } : {}),
+      ...(Number.isFinite(reasoning) && reasoning > 0 ? { reasoning } : {}),
+      ...(Number.isFinite(apiCalls) && apiCalls > 0 ? { apiCalls } : {}),
+    }
+  }
+
+  function attachRunUsageToAssistant(
+    sessionId: string,
+    preferredMessageId: string | null | undefined,
+    evt: any,
+  ) {
+    const usage = normalizeRunUsage(evt?.runUsage || evt?.usage)
+    if (!usage) return
+    const runId = typeof evt?.run_id === 'string' && evt.run_id.trim()
+      ? evt.run_id
+      : typeof evt?.runId === 'string' && evt.runId.trim()
+        ? evt.runId
+        : null
+    const msgs = getSessionMsgs(sessionId)
+    let target = preferredMessageId
+      ? msgs.find(m => m.id === preferredMessageId && m.role === 'assistant')
+      : undefined
+    if (!target) {
+      for (let i = msgs.length - 1; i >= 0; i -= 1) {
+        const message = msgs[i]
+        if (message.role !== 'assistant') continue
+        if (message.systemType === 'error') continue
+        if (!(message.content || '').trim() && !(message.reasoning || '').trim()) continue
+        target = message
+        break
+      }
+    }
+    if (!target) return
+    updateMessage(sessionId, target.id, {
+      usage,
+      ...(runId ? { runId } : {}),
+    })
   }
 
   function updateMessage(sessionId: string, id: string, update: Partial<Message>) {
@@ -4171,6 +4251,7 @@ export const useChatStore = defineStore('chat', () => {
                   if ((evt as any).contextTokens != null) target.contextTokens = (evt as any).contextTokens
                 }
               }
+              attachRunUsageToAssistant(sid, completedAssistantMessageId || activeAssistantMessageId, evt)
               // Belt-and-suspenders: some providers may deliver the final
               // assistant text only via run.completed.output (no message.delta
               // stream). If we never produced assistant text but the gateway
@@ -4837,6 +4918,7 @@ export const useChatStore = defineStore('chat', () => {
               if ((evt as any).contextTokens != null) target.contextTokens = (evt as any).contextTokens
             }
           }
+          attachRunUsageToAssistant(sid, completedAssistantMessageId || activeAssistantMessageId, evt)
           // Check if backend provided parsed content (from stringified array format)
           let finalOutputTrimmed = ''
           if ((evt as any).parsed_content !== undefined) {
@@ -4906,7 +4988,7 @@ export const useChatStore = defineStore('chat', () => {
               runProducedAssistantContent = true
             }
           }
-          const queueInsertionInterruption = isQueueInsertionInterruption(evt)
+const queueInsertionInterruption = isQueueInsertionInterruption(evt)
           const swallowedError = !runProducedAssistantText
             && !runHadToolActivity
             && finalOutputTrimmed === ''

--- a/packages/server/src/modules/coding-agents/services/runtime/run-manager.ts
+++ b/packages/server/src/modules/coding-agents/services/runtime/run-manager.ts
@@ -1103,8 +1103,8 @@ export class CodingAgentRunManager {
       this.emitToChat(run.launch.sessionId, mapped.event, mapped.payload)
     }
     if (isTerminalEvent) {
-          const final = (storageSafeResponseEvent.data as any).response || storageSafeResponseEvent.data
-          run.assistantMessageId = this.persistTerminalResponse(run, final?.id || undefined)
+      const final = (storageSafeResponseEvent.data as any).response || storageSafeResponseEvent.data
+      run.assistantMessageId = this.persistTerminalResponse(run, final?.id || undefined)
       if (run.launch.mode !== 'scoped' && final?.usage) {
         const usage = normalizeTokenUsage(final.usage)
         if (!usage.isEstimated) {

--- a/packages/server/src/modules/coding-agents/services/runtime/run-manager.ts
+++ b/packages/server/src/modules/coding-agents/services/runtime/run-manager.ts
@@ -6,6 +6,7 @@ import { createSession, addMessage, getSession, updateSession, updateSessionStat
 import type { ApiMode, CodingAgentImageInput } from '../../protocol/types'
 import { logger } from '../../../studio/public/logging'
 import { normalizeTokenUsage, recordSessionUsage } from '../../../studio/public/usage'
+import { getRecordedUsageByRun } from '../../../studio/public/usage-store'
 import {
   applyResponseStreamEvent,
   calcAndUpdateUsage,
@@ -1102,8 +1103,8 @@ export class CodingAgentRunManager {
       this.emitToChat(run.launch.sessionId, mapped.event, mapped.payload)
     }
     if (isTerminalEvent) {
-      run.assistantMessageId = this.persistTerminalResponse(run)
-      const final = (storageSafeResponseEvent.data as any).response || storageSafeResponseEvent.data
+          const final = (storageSafeResponseEvent.data as any).response || storageSafeResponseEvent.data
+          run.assistantMessageId = this.persistTerminalResponse(run, final?.id || undefined)
       if (run.launch.mode !== 'scoped' && final?.usage) {
         const usage = normalizeTokenUsage(final.usage)
         if (!usage.isEstimated) {
@@ -1150,8 +1151,8 @@ export class CodingAgentRunManager {
     }
   }
 
-  private persistTerminalResponse(run: ManagedCodingAgentRun): string | undefined {
-    const assistantMessageId = flushResponseRunToDb(run.state, run.launch.sessionId)
+  private persistTerminalResponse(run: ManagedCodingAgentRun, runId?: string): string | undefined {
+      const assistantMessageId = flushResponseRunToDb(run.state, run.launch.sessionId, runId)
     run.state.responseRun = undefined
     updateSessionStats(run.launch.sessionId)
     return assistantMessageId
@@ -2867,11 +2868,21 @@ export class CodingAgentRunManager {
     run.pendingChatCompletionPayload = undefined
     const queueRemaining = run.state.queue.length
     const workspaceRunChange = this.completeWorkspaceRunDiff(run)
+    const runId = String((payload as any)?.run_id || run.id || '')
+    const recordedRunUsage = getRecordedUsageByRun(run.launch.sessionId, 'coding_agent', runId)
     this.emitToChat(run.launch.sessionId, event, {
       ...(payload || { event }),
       ...(run.assistantMessageId ? { message_id: run.assistantMessageId } : {}),
       ...(queueRemaining > 0 ? { queue_remaining: queueRemaining } : {}),
       workspace_run_change: workspaceRunChange,
+      runUsage: {
+        input: recordedRunUsage.inputTokens,
+        output: recordedRunUsage.outputTokens,
+        cacheRead: recordedRunUsage.cacheReadTokens,
+        cacheWrite: recordedRunUsage.cacheWriteTokens,
+        reasoning: recordedRunUsage.reasoningTokens,
+        apiCalls: recordedRunUsage.apiCalls,
+      },
     })
     if (queueRemaining === 0) {
       try {

--- a/packages/server/src/modules/coding-agents/services/runtime/run-manager.ts
+++ b/packages/server/src/modules/coding-agents/services/runtime/run-manager.ts
@@ -6,7 +6,7 @@ import { createSession, addMessage, getSession, updateSession, updateSessionStat
 import type { ApiMode, CodingAgentImageInput } from '../../protocol/types'
 import { logger } from '../../../studio/public/logging'
 import { normalizeTokenUsage, recordSessionUsage } from '../../../studio/public/usage'
-import { getRecordedUsageByRun } from '../../../studio/public/usage-store'
+import { getRecordedUsageByRun } from '../../../studio/public/sessions'
 import {
   applyResponseStreamEvent,
   calcAndUpdateUsage,

--- a/packages/server/src/modules/studio/contracts/runs/session.ts
+++ b/packages/server/src/modules/studio/contracts/runs/session.ts
@@ -56,6 +56,7 @@ export interface SessionMessage {
   reasoning?: string | null
   reasoning_details?: string | null
   reasoning_content?: string | null
+  run_id?: string | null
 }
 
 export interface QueuedRun {

--- a/packages/server/src/modules/studio/controllers/sessions.ts
+++ b/packages/server/src/modules/studio/controllers/sessions.ts
@@ -2077,7 +2077,7 @@ export async function getConversationMessagesPaginated(ctx: any) {
   const limit = ctx.query.limit ? parseInt(ctx.query.limit as string, 10) : 150
   const profile = requestedProfile(ctx)
 
-  const { getSessionDetailPaginated } = await import('../public/sessions')
+  const { getSessionDetailPaginated, attachRunUsageToMessages } = await import('../public/sessions')
   const localResult = getSessionDetailPaginated(ctx.params.id, offset, limit)
   const result = localResult && (!profile || localResult.session.profile === profile)
     ? localResult
@@ -2120,7 +2120,7 @@ export async function getConversationMessagesPaginated(ctx: any) {
       input_tokens: session.input_tokens,
       output_tokens: session.output_tokens,
     },
-    messages: result.messages,
+    messages: messagesWithUsage,
     workspaceRunChanges: listWorkspaceRunChangesForAssistantMessages(ctx.params.id, assistantMessageIds),
     total: result.total,
     offset: result.offset,

--- a/packages/server/src/modules/studio/controllers/sessions.ts
+++ b/packages/server/src/modules/studio/controllers/sessions.ts
@@ -2096,6 +2096,10 @@ export async function getConversationMessagesPaginated(ctx: any) {
     .filter((message: any) => String(message.display_role || message.role || '') === 'assistant')
     .map((message: any) => message.id)
 
+  // Attach provider-recorded usage (by run_id) to assistant messages so the
+  // UI can render token usage after a page refresh / session reload.
+  const messagesWithUsage = attachRunUsageToMessages(ctx.params.id, result.messages)
+
   ctx.body = {
     session: {
       id: session.id,

--- a/packages/server/src/modules/studio/infrastructure/database/schemas.ts
+++ b/packages/server/src/modules/studio/infrastructure/database/schemas.ts
@@ -101,7 +101,7 @@ export const MESSAGES_SCHEMA: Record<string, string> = {
   id: 'INTEGER PRIMARY KEY AUTOINCREMENT',
   session_id: 'TEXT NOT NULL',
   role: 'TEXT NOT NULL',
-  content: 'TEXT NOT NULL DEFAULT \'\'',
+  content: "TEXT NOT NULL DEFAULT ''",
   display_role: 'TEXT',
   display_content: 'TEXT',
   tool_call_id: 'TEXT',
@@ -114,6 +114,10 @@ export const MESSAGES_SCHEMA: Record<string, string> = {
   reasoning: 'TEXT',
   reasoning_details: 'TEXT',
   reasoning_content: 'TEXT',
+  // Run id of the model run that produced this message (assistant/tool rows only).
+  // Empty for user/system messages and for legacy rows written before this column
+  // was added; syncTable auto-adds it via ALTER ADD COLUMN on existing DBs.
+  run_id: "TEXT NOT NULL DEFAULT ''",
 }
 
 export const MESSAGES_INDEX = 'CREATE INDEX IF NOT EXISTS idx_messages_session_id ON messages(session_id)'

--- a/packages/server/src/modules/studio/repositories/session-store.ts
+++ b/packages/server/src/modules/studio/repositories/session-store.ts
@@ -7,6 +7,7 @@ import { COMPRESSION_SNAPSHOT_TABLE, SESSIONS_TABLE, MESSAGES_TABLE } from '../i
 import { normalizeMessageContentForStorageRole } from './message-content'
 import { copyCompressionSnapshot } from './compression-snapshot'
 import { recordSkillUsageMessage } from './skill-usage-store'
+import { getRecordedUsageByRun } from './usage-store'
 
 // Re-export types for compatibility with sessions-db.ts consumers
 export interface HermesSessionRow {
@@ -68,6 +69,18 @@ export interface HermesMessageRow {
   reasoning: string | null
   reasoning_details?: string | null
   reasoning_content?: string | null
+  /** Run id of the model run that produced this message (assistant/tool rows only). */
+  run_id?: string | null
+  /** Provider-recorded usage for this run; attached on read by
+   *  {@link attachRunUsageToMessages}, not persisted in the messages table. */
+  usage?: {
+    input: number
+    output: number
+    cacheRead?: number
+    cacheWrite?: number
+    reasoning?: number
+    apiCalls?: number
+  } | null
 }
 
 export interface HermesSessionSearchRow extends HermesSessionRow {
@@ -172,6 +185,7 @@ function mapMessageRow(row: Record<string, unknown>): HermesMessageRow {
     reasoning: row.reasoning != null ? String(row.reasoning) : null,
     reasoning_details: row.reasoning_details != null ? String(row.reasoning_details) : null,
     reasoning_content: row.reasoning_content != null ? String(row.reasoning_content) : null,
+    run_id: row.run_id != null && row.run_id !== '' ? String(row.run_id) : null,
   }
 }
 
@@ -813,13 +827,25 @@ export function addMessage(msg: {
   reasoning?: string | null
   reasoning_details?: string | null
   reasoning_content?: string | null
+  /** Run id of the model run that produced this message (assistant/tool rows only). */
+  run_id?: string | null
+  /** Provider-recorded usage for this run; only attached on read-back in
+   *  {@link attachRunUsageToMessages}, never persisted in the messages table. */
+  usage?: {
+    input: number
+    output: number
+    cacheRead?: number
+    cacheWrite?: number
+    reasoning?: number
+    apiCalls?: number
+  } | null
 }): number | undefined {
   if (!isSqliteAvailable()) return undefined
   const db = getDb()!
   const toolCallsJson = msg.tool_calls ? JSON.stringify(msg.tool_calls) : null
   const result = db.prepare(
-    `INSERT INTO ${MESSAGES_TABLE} (session_id, role, content, display_role, display_content, tool_call_id, tool_calls, tool_name, run_marker, timestamp, token_count, finish_reason, reasoning, reasoning_details, reasoning_content)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    `INSERT INTO ${MESSAGES_TABLE} (session_id, role, content, display_role, display_content, tool_call_id, tool_calls, tool_name, run_marker, timestamp, token_count, finish_reason, reasoning, reasoning_details, reasoning_content, run_id)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     msg.session_id, msg.role, normalizeMessageContentForStorageRole(msg.role, msg.content),
     msg.display_role ?? null, msg.display_content ?? null,
@@ -829,6 +855,7 @@ export function addMessage(msg: {
     msg.token_count ?? null, msg.finish_reason ?? null,
     msg.reasoning ?? null, msg.reasoning_details ?? null,
     msg.reasoning_content ?? null,
+    msg.run_id ?? '',
   )
   const messageId = Number(result.lastInsertRowid)
   recordSkillUsageMessage(messageId, msg)
@@ -851,12 +878,13 @@ export function addMessages(msgs: Array<{
   reasoning?: string | null
   reasoning_details?: string | null
   reasoning_content?: string | null
+  run_id?: string | null
 }>): number[] {
   if (!isSqliteAvailable() || msgs.length === 0) return []
   const db = getDb()!
   const insert = db.prepare(
-    `INSERT INTO ${MESSAGES_TABLE} (session_id, role, content, display_role, display_content, tool_call_id, tool_calls, tool_name, run_marker, timestamp, token_count, finish_reason, reasoning, reasoning_details, reasoning_content)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    `INSERT INTO ${MESSAGES_TABLE} (session_id, role, content, display_role, display_content, tool_call_id, tool_calls, tool_name, run_marker, timestamp, token_count, finish_reason, reasoning, reasoning_details, reasoning_content, run_id)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   )
   const ids: number[] = []
   db.exec('BEGIN')
@@ -872,6 +900,7 @@ export function addMessages(msgs: Array<{
         msg.token_count ?? null, msg.finish_reason ?? null,
         msg.reasoning ?? null, msg.reasoning_details ?? null,
         msg.reasoning_content ?? null,
+        msg.run_id ?? '',
       )
       const messageId = Number(result.lastInsertRowid)
       ids.push(messageId)
@@ -1054,4 +1083,66 @@ export function getSessionDetailPaginated(
     limit,
     hasMore: offset + messages.length < total,
   }
+}
+
+/**
+ * Attach provider-recorded usage to each assistant message that carries a `run_id`.
+ *
+ * Called on read-back (see controllers/hermes/sessions.ts) so that token usage
+ * survives session reload / page refresh. Non-assistant messages are returned
+ * unchanged — only assistant rows that already have a `run_id` get a `usage`
+ * field attached.
+ *
+ * Uses {@link getRecordedUsageByRun} to aggregate from `session_usage` rows.
+ * Multiple sources are tried because usage may have been recorded under
+ * `hermes`, `ekko_agent`, or `coding_agent` depending on which runtime path
+ * produced the run. Failures are swallowed conservatively (run-level usage must
+ * never break the history-loading path); a missing run id simply leaves the
+ * row without usage.
+ */
+export function attachRunUsageToMessages(
+  sessionId: string,
+  messages: HermesMessageRow[],
+): HermesMessageRow[] {
+  if (!messages.length) return messages
+  const seen = new Set<string>()
+  const cache = new Map<string, HermesMessageRow['usage'] | null>()
+  const sources = ['hermes', 'ekko_agent', 'coding_agent'] as const
+  for (const msg of messages) {
+    if (msg.role !== 'assistant') continue
+    const runId = msg.run_id
+    if (!runId || seen.has(runId)) continue
+    seen.add(runId)
+    try {
+      let usage: HermesMessageRow['usage'] | null = null
+      for (const source of sources) {
+        const u = getRecordedUsageByRun(sessionId, source, runId)
+        const candidate: HermesMessageRow['usage'] = {
+          input: u.inputTokens,
+          output: u.outputTokens,
+          ...(u.cacheReadTokens > 0 ? { cacheRead: u.cacheReadTokens } : {}),
+          ...(u.cacheWriteTokens > 0 ? { cacheWrite: u.cacheWriteTokens } : {}),
+          ...(u.reasoningTokens > 0 ? { reasoning: u.reasoningTokens } : {}),
+          ...(u.apiCalls > 0 ? { apiCalls: u.apiCalls } : {}),
+        }
+        // Skip zero-only payloads so we don't push a useless `{ input:0, output:0 }`
+        // onto every legacy assistant row that lacks a run_id.
+        if (candidate.input <= 0 && candidate.output <= 0) continue
+        usage = candidate
+        break
+      }
+      cache.set(runId, usage)
+    } catch {
+      cache.set(runId, null)
+    }
+  }
+  if (!cache.size) return messages
+  return messages.map(msg => {
+    if (msg.role !== 'assistant') return msg
+    const runId = msg.run_id
+    if (!runId) return msg
+    const usage = cache.get(runId)
+    if (!usage) return msg
+    return { ...msg, usage }
+  })
 }

--- a/packages/server/src/modules/studio/repositories/usage-store.ts
+++ b/packages/server/src/modules/studio/repositories/usage-store.ts
@@ -173,6 +173,79 @@ export function getRecordedUsageTotals(sessionId: string, source: string): {
   }
 }
 
+/**
+ * Aggregate provider-recorded usage for one chat run.
+ *
+ * Model-call rows are often stored as `${runId}:api:...` / `${runId}:step:...`
+ * rather than the bare run id, so both exact and prefix matches are included.
+ */
+export function getRecordedUsageByRun(
+  sessionId: string,
+  source: string,
+  runId: string,
+): {
+  inputTokens: number
+  outputTokens: number
+  cacheReadTokens: number
+  cacheWriteTokens: number
+  reasoningTokens: number
+  apiCalls: number
+} {
+  const empty = {
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    reasoningTokens: 0,
+    apiCalls: 0,
+  }
+  const normalizedRunId = String(runId || '').trim()
+  if (!normalizedRunId) return empty
+
+  if (!isSqliteAvailable()) {
+    const all = jsonGetAll(TABLE)
+    // JSON fallback stores one blob per session id (no multi-row run history).
+    const row = all[sessionId]
+    if (!row) return empty
+    const rowRunId = String(row.run_id || '')
+    if (rowRunId !== normalizedRunId && !rowRunId.startsWith(`${normalizedRunId}:`)) {
+      return empty
+    }
+    if (source && String(row.source || '') !== source) return empty
+    return {
+      inputTokens: Number(row.input_tokens || 0),
+      outputTokens: Number(row.output_tokens || 0),
+      cacheReadTokens: Number(row.cache_read_tokens || 0),
+      cacheWriteTokens: Number(row.cache_write_tokens || 0),
+      reasoningTokens: Number(row.reasoning_tokens || 0),
+      apiCalls: Number(row.api_calls || 0),
+    }
+  }
+
+  const row = getDb()!.prepare(`
+    SELECT
+      COALESCE(SUM(input_tokens), 0) AS input_tokens,
+      COALESCE(SUM(output_tokens), 0) AS output_tokens,
+      COALESCE(SUM(cache_read_tokens), 0) AS cache_read_tokens,
+      COALESCE(SUM(cache_write_tokens), 0) AS cache_write_tokens,
+      COALESCE(SUM(reasoning_tokens), 0) AS reasoning_tokens,
+      COALESCE(SUM(api_calls), 0) AS api_calls
+    FROM ${TABLE}
+    WHERE session_id = ?
+      AND source = ?
+      AND (run_id = ? OR run_id LIKE ?)
+  `).get(sessionId, source, normalizedRunId, `${normalizedRunId}:%`) as any
+
+  return {
+    inputTokens: Number(row?.input_tokens || 0),
+    outputTokens: Number(row?.output_tokens || 0),
+    cacheReadTokens: Number(row?.cache_read_tokens || 0),
+    cacheWriteTokens: Number(row?.cache_write_tokens || 0),
+    reasoningTokens: Number(row?.reasoning_tokens || 0),
+    apiCalls: Number(row?.api_calls || 0),
+  }
+}
+
 export function getUsage(sessionId: string): UsageRecord | undefined {
   if (isSqliteAvailable()) {
     return getDb()!.prepare(

--- a/packages/server/src/modules/studio/repositories/usage-store.ts
+++ b/packages/server/src/modules/studio/repositories/usage-store.ts
@@ -202,47 +202,52 @@ export function getRecordedUsageByRun(
   const normalizedRunId = String(runId || '').trim()
   if (!normalizedRunId) return empty
 
-  if (!isSqliteAvailable()) {
-    const all = jsonGetAll(TABLE)
-    // JSON fallback stores one blob per session id (no multi-row run history).
-    const row = all[sessionId]
-    if (!row) return empty
-    const rowRunId = String(row.run_id || '')
-    if (rowRunId !== normalizedRunId && !rowRunId.startsWith(`${normalizedRunId}:`)) {
-      return empty
+  // Lookup failure must never break run completion / socket emit paths.
+  try {
+    if (!isSqliteAvailable()) {
+      const all = jsonGetAll(TABLE)
+      // JSON fallback stores one blob per session id (no multi-row run history).
+      const row = all[sessionId]
+      if (!row) return empty
+      const rowRunId = String(row.run_id || '')
+      if (rowRunId !== normalizedRunId && !rowRunId.startsWith(`${normalizedRunId}:`)) {
+        return empty
+      }
+      if (source && String(row.source || '') !== source) return empty
+      return {
+        inputTokens: Number(row.input_tokens || 0),
+        outputTokens: Number(row.output_tokens || 0),
+        cacheReadTokens: Number(row.cache_read_tokens || 0),
+        cacheWriteTokens: Number(row.cache_write_tokens || 0),
+        reasoningTokens: Number(row.reasoning_tokens || 0),
+        apiCalls: Number(row.api_calls || 0),
+      }
     }
-    if (source && String(row.source || '') !== source) return empty
+
+    const row = getDb()!.prepare(`
+      SELECT
+        COALESCE(SUM(input_tokens), 0) AS input_tokens,
+        COALESCE(SUM(output_tokens), 0) AS output_tokens,
+        COALESCE(SUM(cache_read_tokens), 0) AS cache_read_tokens,
+        COALESCE(SUM(cache_write_tokens), 0) AS cache_write_tokens,
+        COALESCE(SUM(reasoning_tokens), 0) AS reasoning_tokens,
+        COALESCE(SUM(api_calls), 0) AS api_calls
+      FROM ${TABLE}
+      WHERE session_id = ?
+        AND source = ?
+        AND (run_id = ? OR run_id LIKE ?)
+    `).get(sessionId, source, normalizedRunId, `${normalizedRunId}:%`) as any
+
     return {
-      inputTokens: Number(row.input_tokens || 0),
-      outputTokens: Number(row.output_tokens || 0),
-      cacheReadTokens: Number(row.cache_read_tokens || 0),
-      cacheWriteTokens: Number(row.cache_write_tokens || 0),
-      reasoningTokens: Number(row.reasoning_tokens || 0),
-      apiCalls: Number(row.api_calls || 0),
+      inputTokens: Number(row?.input_tokens || 0),
+      outputTokens: Number(row?.output_tokens || 0),
+      cacheReadTokens: Number(row?.cache_read_tokens || 0),
+      cacheWriteTokens: Number(row?.cache_write_tokens || 0),
+      reasoningTokens: Number(row?.reasoning_tokens || 0),
+      apiCalls: Number(row?.api_calls || 0),
     }
-  }
-
-  const row = getDb()!.prepare(`
-    SELECT
-      COALESCE(SUM(input_tokens), 0) AS input_tokens,
-      COALESCE(SUM(output_tokens), 0) AS output_tokens,
-      COALESCE(SUM(cache_read_tokens), 0) AS cache_read_tokens,
-      COALESCE(SUM(cache_write_tokens), 0) AS cache_write_tokens,
-      COALESCE(SUM(reasoning_tokens), 0) AS reasoning_tokens,
-      COALESCE(SUM(api_calls), 0) AS api_calls
-    FROM ${TABLE}
-    WHERE session_id = ?
-      AND source = ?
-      AND (run_id = ? OR run_id LIKE ?)
-  `).get(sessionId, source, normalizedRunId, `${normalizedRunId}:%`) as any
-
-  return {
-    inputTokens: Number(row?.input_tokens || 0),
-    outputTokens: Number(row?.output_tokens || 0),
-    cacheReadTokens: Number(row?.cache_read_tokens || 0),
-    cacheWriteTokens: Number(row?.cache_write_tokens || 0),
-    reasoningTokens: Number(row?.reasoning_tokens || 0),
-    apiCalls: Number(row?.api_calls || 0),
+  } catch {
+    return empty
   }
 }
 

--- a/packages/server/src/modules/studio/services/chat-run/bridge-message.ts
+++ b/packages/server/src/modules/studio/services/chat-run/bridge-message.ts
@@ -7,7 +7,7 @@ import { logger } from '../../public/logging'
 import { persistRunMessages } from './message-persistence'
 import type { SessionMessage, SessionState } from './types'
 
-export function flushBridgePendingToDb(state: SessionState, sessionId: string, runMarker?: string): string | undefined {
+export function flushBridgePendingToDb(state: SessionState, sessionId: string, runMarker?: string, runId?: string): string | undefined {
   const content = state.bridgePendingAssistantContent || ''
   const reasoning = state.bridgePendingReasoningContent || ''
   if (!content.trim()) return state.bridgeAssistantMessageId
@@ -25,7 +25,9 @@ export function flushBridgePendingToDb(state: SessionState, sessionId: string, r
       reasoning: reasoning || null,
       reasoning_content: reasoning || null,
       timestamp: Math.floor(Date.now() / 1000),
+      run_id: runId,
     }],
+  })
   })
   state.bridgePendingAssistantContent = ''
   state.bridgePendingReasoningContent = ''

--- a/packages/server/src/modules/studio/services/chat-run/bridge-message.ts
+++ b/packages/server/src/modules/studio/services/chat-run/bridge-message.ts
@@ -28,7 +28,6 @@ export function flushBridgePendingToDb(state: SessionState, sessionId: string, r
       run_id: runId,
     }],
   })
-  })
   state.bridgePendingAssistantContent = ''
   state.bridgePendingReasoningContent = ''
   if (persistedId != null) {

--- a/packages/server/src/modules/studio/services/chat-run/handle-bridge-run.ts
+++ b/packages/server/src/modules/studio/services/chat-run/handle-bridge-run.ts
@@ -8,6 +8,7 @@ import { getSystemPrompt } from '../../public/runs/prompt'
 import { getFirstSessionMessageByRole, getSession, getSessionMessageCountByRole, createSession, addMessage, updateSession, updateSessionStats } from '../../repositories/session-store'
 import { logger, bridgeLogger } from '../../public/logging'
 import { normalizeTokenUsage, recordSessionUsage } from '../usage/usage-recorder'
+import { getRecordedUsageByRun } from '../../repositories/usage-store'
 import type {
   PrimaryAgentBridgeClient as AgentBridgeClient,
   PrimaryAgentBridgeContextEstimate as AgentBridgeContextEstimate,
@@ -1824,6 +1825,7 @@ async function applyBridgeChunkAsync(
   state.runId = undefined
   state.activeRunMarker = undefined
   state.events = []
+  const runUsage = getRecordedUsageByRun(sessionId, 'hermes', String(chunk.run_id || ''))
   const payload = {
     event: eventName,
     run_id: chunk.run_id,
@@ -1834,6 +1836,16 @@ async function applyBridgeChunkAsync(
     inputTokens: usage.inputTokens,
     outputTokens: usage.outputTokens,
     contextTokens,
+    // Provider-recorded usage for THIS run only (sum of model_call rows).
+    // Distinct from inputTokens/outputTokens above, which are session/context estimates.
+    runUsage: {
+      input: runUsage.inputTokens,
+      output: runUsage.outputTokens,
+      cacheRead: runUsage.cacheReadTokens,
+      cacheWrite: runUsage.cacheWriteTokens,
+      reasoning: runUsage.reasoningTokens,
+      apiCalls: runUsage.apiCalls,
+    },
     queue_remaining: state.queue.length,
     background_pending: backgroundPendingCount(state),
     autonomous: runMetadata?.autonomous === true,

--- a/packages/server/src/modules/studio/services/chat-run/handle-bridge-run.ts
+++ b/packages/server/src/modules/studio/services/chat-run/handle-bridge-run.ts
@@ -321,7 +321,7 @@ function processBridgeInterimMessage(
   state.bridgePendingAssistantContent = text
   message.content = text
   syncBridgeReasoningToMessage(message, state.bridgePendingReasoningContent)
-  flushBridgePendingToDb(state, sessionId, runMarker)
+  flushBridgePendingToDb(state, sessionId, runMarker, runId)
 
   emit('message.interim', {
     event: 'message.interim',
@@ -899,7 +899,7 @@ export async function handleBridgeRun(
     state.activeRunMarker = undefined
     state.events = []
     state.bridgePendingToolCallMarkup = undefined
-    flushBridgePendingToDb(state, session_id, runMarker)
+    flushBridgePendingToDb(state, session_id, runMarker) // aborted/failed run — no run_id to bind
     updateSessionStats(session_id)
     const message = err instanceof Error ? err.message : String(err)
     const errUsage = await calcAndUpdateUsage(session_id, state, emit)
@@ -1332,7 +1332,7 @@ async function applyBridgeChunkAsync(
       // come for this assistant message — the next chunk is the tool call
       // itself. See bridge-delta.ts for full rationale.
       flushPendingToolMarkupToAssistant(state, runMarker, chunk.run_id, emit)
-      flushBridgePendingToDb(state, sessionId, runMarker)
+      flushBridgePendingToDb(state, sessionId, runMarker, chunk.run_id ? String(chunk.run_id) : undefined)
       const toolName = (ev.tool_name as string) || ''
       const args = ev.args as Record<string, unknown> | undefined
       const tool = recordBridgeToolStarted(state, sessionId, runMarker, toolName, args, ev.tool_call_id)
@@ -1428,7 +1428,7 @@ async function applyBridgeChunkAsync(
       pushState(sessionMap, sessionId, evType, payload)
       emit(evType, payload)
     } else if (evType === 'turn.boundary') {
-      flushBridgePendingToDb(state, sessionId, runMarker)
+      flushBridgePendingToDb(state, sessionId, runMarker, chunk.run_id ? String(chunk.run_id) : undefined)
     } else if (evType === 'reasoning.delta' || evType === 'thinking.delta') {
       const text = String(ev.text || '')
       if (text) {
@@ -1735,7 +1735,7 @@ async function applyBridgeChunkAsync(
   }
 
   flushPendingToolMarkupToAssistant(state, runMarker, chunk.run_id, emit)
-  flushBridgePendingToDb(state, sessionId, runMarker)
+  flushBridgePendingToDb(state, sessionId, runMarker, chunk.run_id ? String(chunk.run_id) : undefined)
   finalResponse = bridgeFinalResponse(chunk, state, useMoaFinalResponse)
   state.bridgePendingToolCallMarkup = undefined
   if (runMetadata?.backgroundDelegationIds.size) {

--- a/packages/server/src/modules/studio/services/chat-run/handle-ekko-agent-run.ts
+++ b/packages/server/src/modules/studio/services/chat-run/handle-ekko-agent-run.ts
@@ -1429,6 +1429,7 @@ export async function handleEkkoAgentRun(
           reasoning: reasoningText || null,
           reasoning_details: reasoningDetails,
           reasoning_content: reasoningText || null,
+          run_id: runId || undefined,
         })
       } else if (step.type === 'tool') {
         if (persistedToolCallIds.has(step.toolCallId)) continue
@@ -1440,6 +1441,7 @@ export async function handleEkkoAgentRun(
           tool_name: step.toolName,
           timestamp,
           finish_reason: step.result.ok ? null : 'error',
+          run_id: runId || undefined,
         })
       }
     }
@@ -1504,6 +1506,7 @@ export async function handleEkkoAgentRun(
           reasoning: assistantReasoning || null,
           reasoning_details: reasoningDetails,
           reasoning_content: assistantReasoning || null,
+          run_id: runId || result.runId || undefined,
         }],
       })
       if (assistantId != null) assistantMessageId = String(assistantId)

--- a/packages/server/src/modules/studio/services/chat-run/handle-ekko-agent-run.ts
+++ b/packages/server/src/modules/studio/services/chat-run/handle-ekko-agent-run.ts
@@ -38,6 +38,7 @@ import {
 import type { ChatMessage } from '../context-compressor'
 import { logger } from '../../public/logging'
 import { recordSessionUsage } from '../usage/usage-recorder'
+import { getRecordedUsageByRun } from '../../repositories/usage-store'
 import { observeRunChatPetEvent } from '../../public/pet-events'
 import { contentBlocksToString, convertContentBlocksForAgent, extractTextForPreview } from './content-blocks'
 import { buildCompressedHistory, getOrCreateSession } from './compression'
@@ -1540,6 +1541,7 @@ export async function handleEkkoAgentRun(
       context_tokens: contextEstimate?.contextTokens ?? state.contextTokens,
     })
     const workspaceRunChange = completeWorkspaceRunDiff()
+    const recordedRunUsage = getRecordedUsageByRun(sessionId, 'ekko_agent', String(runId || result.runId || ''))
     emit('run.completed', {
       event: 'run.completed',
       run_id: runId || result.runId,
@@ -1553,6 +1555,14 @@ export async function handleEkkoAgentRun(
         input_tokens: usageInput,
         output_tokens: usageOutput,
         total_tokens: usageInput + usageOutput,
+      },
+      runUsage: {
+        input: recordedRunUsage.inputTokens || usageInput,
+        output: recordedRunUsage.outputTokens || usageOutput,
+        cacheRead: recordedRunUsage.cacheReadTokens,
+        cacheWrite: recordedRunUsage.cacheWriteTokens,
+        reasoning: recordedRunUsage.reasoningTokens,
+        apiCalls: recordedRunUsage.apiCalls,
       },
       queue_remaining: state.queue.length,
       background_pending: ekkoBackgroundPendingCount(state),

--- a/packages/server/src/modules/studio/services/chat-run/message-persistence.ts
+++ b/packages/server/src/modules/studio/services/chat-run/message-persistence.ts
@@ -71,6 +71,7 @@ export function persistRunMessages(
     reasoning: message.reasoning ?? null,
     reasoning_details: message.reasoning_details ?? null,
     reasoning_content: message.reasoning_content ?? null,
+    run_id: (message as any).run_id ?? '',
   }))
   const ids = atomic
     ? addMessages(rows).map(id => id as number | undefined)

--- a/packages/server/src/modules/studio/services/chat-run/message-persistence.ts
+++ b/packages/server/src/modules/studio/services/chat-run/message-persistence.ts
@@ -6,6 +6,7 @@ export type RunMessageDraft = Omit<SessionMessage, 'id' | 'session_id' | 'runMar
   runMarker?: string | null
   run_marker?: string | null
   timestamp?: number
+  run_id?: string | null
 }
 
 interface PersistRunMessagesOptions {
@@ -71,7 +72,7 @@ export function persistRunMessages(
     reasoning: message.reasoning ?? null,
     reasoning_details: message.reasoning_details ?? null,
     reasoning_content: message.reasoning_content ?? null,
-    run_id: (message as any).run_id ?? '',
+    run_id: message.run_id ?? '',
   }))
   const ids = atomic
     ? addMessages(rows).map(id => id as number | undefined)

--- a/packages/server/src/modules/studio/services/chat-run/response-stream.ts
+++ b/packages/server/src/modules/studio/services/chat-run/response-stream.ts
@@ -458,7 +458,7 @@ export function getResponseRunState(state: SessionState, runMarker?: string): Re
 }
 
 /** Flush all non-user messages for this run to DB in order. */
-export function flushResponseRunToDb(state: SessionState, sessionId: string): string | undefined {
+export function flushResponseRunToDb(state: SessionState, sessionId: string, runId?: string): string | undefined {
   const run = state.responseRun
   if (!run?.runMarker) return undefined
   const messages = state.messages.filter(msg => msg.runMarker === run.runMarker && msg.role !== 'user')

--- a/tests/client/chat-store-run-usage.test.ts
+++ b/tests/client/chat-store-run-usage.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+
+vi.mock('@/api/hermes/chat', () => ({
+  startRunViaSocket: vi.fn(),
+  resumeSession: vi.fn(),
+  registerSessionHandlers: vi.fn(),
+  unregisterSessionHandlers: vi.fn(),
+  getChatRunSocket: vi.fn(() => null),
+  respondToolApproval: vi.fn(),
+  onPeerUserMessage: vi.fn(() => () => {}),
+  onSessionCommand: vi.fn(() => () => {}),
+  onSessionTitleUpdated: vi.fn(() => () => {}),
+  onSessionWorkspaceUpdated: vi.fn(() => () => {}),
+  respondClarify: vi.fn(),
+}))
+
+vi.mock('@/api/hermes/sessions', () => ({
+  archiveSession: vi.fn(),
+  deleteSession: vi.fn(),
+  fetchSessionMessagesPage: vi.fn(),
+  fetchSessions: vi.fn(async () => ([
+    {
+      id: 'session-1',
+      source: 'cli',
+      model: 'test',
+      title: 'S1',
+      started_at: 1,
+      ended_at: null,
+      message_count: 2,
+      tool_call_count: 0,
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_read_tokens: 0,
+      cache_write_tokens: 0,
+      reasoning_tokens: 0,
+      billing_provider: null,
+      estimated_cost_usd: 0,
+      actual_cost_usd: null,
+      cost_status: '',
+    },
+  ])),
+  fetchWorkspaceRunChangeFile: vi.fn(),
+  fetchWorkspaceRunChangesForSession: vi.fn(async () => []),
+  setSessionModel: vi.fn(),
+}))
+
+vi.mock('@/api/client', () => ({
+  getActiveProfileName: () => 'default',
+}))
+
+vi.mock('@/api/hermes/download', () => ({
+  getDownloadUrl: (path: string) => path,
+}))
+
+vi.mock('@/utils/completion-sound', () => ({
+  primeCompletionSound: vi.fn(),
+  playCompletionSound: vi.fn(),
+}))
+
+vi.mock('@/utils/completion-notification', () => ({
+  showCompletionNotification: vi.fn(),
+}))
+
+import { useChatStore } from '@/stores/hermes/chat'
+
+describe('chat store run usage binding', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('does not let session list 0/0 overwrite runtime session usage', async () => {
+    const store = useChatStore()
+    store.sessions = [{
+      id: 'session-1',
+      title: 'S1',
+      messages: [],
+      createdAt: 1,
+      updatedAt: 1,
+      inputTokens: 17247,
+      outputTokens: 1014,
+    }] as any
+    store.activeSessionId = 'session-1'
+    store.activeSession = store.sessions[0]
+
+    await store.refreshSessionListOnly()
+
+    expect(store.sessions[0].inputTokens).toBe(17247)
+    expect(store.sessions[0].outputTokens).toBe(1014)
+  })
+})

--- a/tests/client/message-item-token-usage.test.ts
+++ b/tests/client/message-item-token-usage.test.ts
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { nextTick } from 'vue'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string, params?: Record<string, string | number>) => {
+      if (key === 'chat.tokenUsage') {
+        return `${params?.input} in · ${params?.output} out`
+      }
+      return key
+    },
+  }),
+}))
+
+vi.mock('naive-ui', () => ({
+  NButton: { template: '<button><slot /></button>' },
+  NDrawer: { template: '<div><slot /></div>' },
+  NDrawerContent: { template: '<div><slot /></div>' },
+  NSpin: { template: '<div />' },
+  useMessage: () => ({
+    error: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+  }),
+}))
+
+import MessageItem from '@/components/hermes/chat/MessageItem.vue'
+import { useChatStore, type Message, type Session } from '@/stores/hermes/chat'
+import { useSettingsStore } from '@/stores/hermes/settings'
+
+function makeSession(partial: Partial<Session> & { messages: Message[] }): Session {
+  return {
+    id: 'session-1',
+    title: 'Token usage session',
+    createdAt: 1,
+    updatedAt: 1,
+    inputTokens: 1200,
+    outputTokens: 340,
+    ...partial,
+  }
+}
+
+describe('MessageItem token usage', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    Object.defineProperty(window, 'isSecureContext', {
+      configurable: true,
+      value: true,
+    })
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    })
+    Object.defineProperty(window, 'speechSynthesis', {
+      configurable: true,
+      value: {
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        getVoices: vi.fn(() => []),
+        speak: vi.fn(),
+        cancel: vi.fn(),
+        pause: vi.fn(),
+        resume: vi.fn(),
+      },
+    })
+  })
+
+  it('hides reply token usage when show_cost is disabled', () => {
+    const chatStore = useChatStore()
+    const settingsStore = useSettingsStore()
+    settingsStore.display.show_cost = false
+
+    const message: Message = {
+      id: 'assistant-1',
+      role: 'assistant',
+      content: 'Done',
+      timestamp: Date.now(),
+    }
+
+    chatStore.activeSessionId = 'session-1'
+    chatStore.activeSession = makeSession({ messages: [message] })
+
+    const wrapper = mount(MessageItem, {
+      props: { message },
+      global: { stubs: { MarkdownRenderer: true } },
+    })
+
+    expect(wrapper.find('.message-usage').exists()).toBe(false)
+  })
+
+  it('shows cumulative session token usage on the latest completed assistant reply', async () => {
+    const chatStore = useChatStore()
+    const settingsStore = useSettingsStore()
+    settingsStore.display.show_cost = true
+
+    const older: Message = {
+      id: 'assistant-older',
+      role: 'assistant',
+      content: 'Earlier answer',
+      timestamp: Date.now() - 1000,
+    }
+    const latest: Message = {
+      id: 'assistant-latest',
+      role: 'assistant',
+      content: 'Latest answer',
+      timestamp: Date.now(),
+    }
+
+    chatStore.activeSessionId = 'session-1'
+    chatStore.activeSession = makeSession({
+      messages: [
+        { id: 'user-1', role: 'user', content: 'hi', timestamp: Date.now() - 2000 },
+        older,
+        latest,
+      ],
+      inputTokens: 12_500,
+      outputTokens: 800,
+    })
+
+    const olderWrapper = mount(MessageItem, {
+      props: { message: older },
+      global: { stubs: { MarkdownRenderer: true } },
+    })
+    const latestWrapper = mount(MessageItem, {
+      props: { message: latest },
+      global: { stubs: { MarkdownRenderer: true } },
+    })
+
+    expect(olderWrapper.find('.message-usage').exists()).toBe(false)
+    expect(latestWrapper.find('.message-usage').exists()).toBe(true)
+    expect(latestWrapper.find('.message-usage').text()).toBe('12.5K in · 800 out')
+  })
+
+  it('does not show token usage while the assistant reply is still streaming', async () => {
+    const chatStore = useChatStore()
+    const settingsStore = useSettingsStore()
+    settingsStore.display.show_cost = true
+
+    const message: Message = {
+      id: 'assistant-streaming',
+      role: 'assistant',
+      content: 'partial',
+      timestamp: Date.now(),
+      isStreaming: true,
+    }
+
+    chatStore.activeSessionId = 'session-1'
+    chatStore.activeSession = makeSession({ messages: [message] })
+
+    const wrapper = mount(MessageItem, {
+      props: { message },
+      global: { stubs: { MarkdownRenderer: true } },
+    })
+
+    expect(wrapper.find('.message-usage').exists()).toBe(false)
+
+    message.isStreaming = false
+    chatStore.activeSession = makeSession({
+      messages: [{ ...message, isStreaming: false }],
+      inputTokens: 100,
+      outputTokens: 20,
+    })
+    await wrapper.setProps({ message: { ...message, isStreaming: false } })
+    await nextTick()
+
+    expect(wrapper.find('.message-usage').exists()).toBe(true)
+    expect(wrapper.find('.message-usage').text()).toBe('100 in · 20 out')
+  })
+})

--- a/tests/client/message-item-token-usage.test.ts
+++ b/tests/client/message-item-token-usage.test.ts
@@ -10,6 +10,9 @@ vi.mock('vue-i18n', () => ({
       if (key === 'chat.tokenUsage') {
         return `${params?.input} in · ${params?.output} out`
       }
+      if (key === 'chat.tokenUsageWithCache') {
+        return `${params?.input} in · ${params?.cache} cache · ${params?.output} out`
+      }
       return key
     },
   }),
@@ -81,6 +84,7 @@ describe('MessageItem token usage', () => {
       role: 'assistant',
       content: 'Done',
       timestamp: Date.now(),
+      usage: { input: 100, output: 20 },
     }
 
     chatStore.activeSessionId = 'session-1'
@@ -94,7 +98,7 @@ describe('MessageItem token usage', () => {
     expect(wrapper.find('.message-usage').exists()).toBe(false)
   })
 
-  it('shows cumulative session token usage on the latest completed assistant reply', async () => {
+  it('shows provider-recorded run usage on the completed assistant reply', async () => {
     const chatStore = useChatStore()
     const settingsStore = useSettingsStore()
     settingsStore.display.show_cost = true
@@ -104,12 +108,15 @@ describe('MessageItem token usage', () => {
       role: 'assistant',
       content: 'Earlier answer',
       timestamp: Date.now() - 1000,
+      usage: { input: 500, output: 40 },
     }
     const latest: Message = {
       id: 'assistant-latest',
       role: 'assistant',
       content: 'Latest answer',
       timestamp: Date.now(),
+      usage: { input: 17247, output: 1014, cacheRead: 122112 },
+      runId: 'run-weather-1',
     }
 
     chatStore.activeSessionId = 'session-1'
@@ -119,8 +126,8 @@ describe('MessageItem token usage', () => {
         older,
         latest,
       ],
-      inputTokens: 12_500,
-      outputTokens: 800,
+      inputTokens: 91281,
+      outputTokens: 1177,
     })
 
     const olderWrapper = mount(MessageItem, {
@@ -132,9 +139,37 @@ describe('MessageItem token usage', () => {
       global: { stubs: { MarkdownRenderer: true } },
     })
 
-    expect(olderWrapper.find('.message-usage').exists()).toBe(false)
+    expect(olderWrapper.find('.message-usage').exists()).toBe(true)
+    expect(olderWrapper.find('.message-usage').text()).toBe('500 in · 40 out')
     expect(latestWrapper.find('.message-usage').exists()).toBe(true)
-    expect(latestWrapper.find('.message-usage').text()).toBe('12.5K in · 800 out')
+    expect(latestWrapper.find('.message-usage').text()).toBe('17.2K in · 122.1K cache · 1.0K out')
+  })
+
+  it('does not show session cumulative tokens as reply usage', () => {
+    const chatStore = useChatStore()
+    const settingsStore = useSettingsStore()
+    settingsStore.display.show_cost = true
+
+    const message: Message = {
+      id: 'assistant-no-run-usage',
+      role: 'assistant',
+      content: 'Done',
+      timestamp: Date.now(),
+    }
+
+    chatStore.activeSessionId = 'session-1'
+    chatStore.activeSession = makeSession({
+      messages: [message],
+      inputTokens: 91281,
+      outputTokens: 1177,
+    })
+
+    const wrapper = mount(MessageItem, {
+      props: { message },
+      global: { stubs: { MarkdownRenderer: true } },
+    })
+
+    expect(wrapper.find('.message-usage').exists()).toBe(false)
   })
 
   it('does not show token usage while the assistant reply is still streaming', async () => {
@@ -148,6 +183,7 @@ describe('MessageItem token usage', () => {
       content: 'partial',
       timestamp: Date.now(),
       isStreaming: true,
+      usage: { input: 100, output: 20 },
     }
 
     chatStore.activeSessionId = 'session-1'
@@ -163,8 +199,6 @@ describe('MessageItem token usage', () => {
     message.isStreaming = false
     chatStore.activeSession = makeSession({
       messages: [{ ...message, isStreaming: false }],
-      inputTokens: 100,
-      outputTokens: 20,
     })
     await wrapper.setProps({ message: { ...message, isStreaming: false } })
     await nextTick()

--- a/tests/server/handle-bridge-run-session-ended.test.ts
+++ b/tests/server/handle-bridge-run-session-ended.test.ts
@@ -33,6 +33,14 @@ vi.mock('../../packages/server/src/modules/studio/repositories/session-store', (
 
 vi.mock('../../packages/server/src/modules/studio/repositories/usage-store', () => ({
   updateUsage: mocks.updateUsage,
+  getRecordedUsageByRun: vi.fn(() => ({
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    reasoningTokens: 0,
+    apiCalls: 0,
+  })),
 }))
 
 vi.mock('../../packages/server/src/modules/studio/public/logging', () => ({

--- a/tests/server/message-run-usage.test.ts
+++ b/tests/server/message-run-usage.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { resolve } from 'path'
+
+// Use the canonical test-runtime db dir that db/index.ts chooses under VITEST.
+const TEST_DB_DIR = resolve(process.cwd(), 'packages/server/data/test-runtime')
+const TEST_DB_PATH = resolve(TEST_DB_DIR, 'hermes-web-ui.db')
+
+function ensureSqliteAvailable() {
+  const [major, minor] = process.versions.node.split('.').map(Number)
+  if (major < 22 || (major === 22 && minor < 5)) {
+    throw new Error(`node:sqlite requires Node >= 22.5, current: ${process.versions.node}`)
+  }
+}
+
+function uniqueSuffix(): string {
+  return `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`
+}
+
+describe('message run_id + usage persistence', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    // Singleton db handle in db/index.ts may still hold the file open; do not
+    // attempt to delete it (EPERM on Windows). Each test uses a unique session
+    // id, so leftover rows do not interfere across tests.
+    vi.resetModules()
+  })
+
+  it('addMessage persists run_id and getSessionDetailPaginated maps it onto HermesMessageRow', async () => {
+    ensureSqliteAvailable()
+    const { initAllHermesTables } = await import('../../packages/server/src/db/hermes/schemas')
+    const sessionStore = await import('../../packages/server/src/db/hermes/session-store')
+    initAllHermesTables()
+
+    const sid = `s1_${uniqueSuffix()}`
+    sessionStore.createSession({
+      id: sid, source: 'cli', model: 'gpt-5.5', title: 'session1',
+      started_at: 100,
+    })
+
+    const id = sessionStore.addMessage({
+      session_id: sid, role: 'assistant', content: 'assistant reply',
+      timestamp: 110, finish_reason: 'stop', run_id: 'run_abc_123',
+    })
+    expect(id).toBeGreaterThan(0)
+
+    const detail = sessionStore.getSessionDetailPaginated(sid, 0, 150)
+    expect(detail).not.toBeNull()
+    const msg = detail!.messages.find(m => m.role === 'assistant')
+    expect(msg).toBeDefined()
+    expect(msg!.content).toBe('assistant reply')
+    expect(msg!.run_id).toBe('run_abc_123')
+  })
+
+  it('attachRunUsageToMessages injects runUsage onto assistant messages with a matching run_id', async () => {
+    ensureSqliteAvailable()
+    const { initAllHermesTables } = await import('../../packages/server/src/db/hermes/schemas')
+    const sessionStore = await import('../../packages/server/src/db/hermes/session-store')
+    const usageStore = await import('../../packages/server/src/db/hermes/usage-store')
+    initAllHermesTables()
+
+    const sid = `s2_${uniqueSuffix()}`
+    sessionStore.createSession({
+      id: sid, source: 'cli', model: 'gpt-5.5', title: 'session2',
+      started_at: 100,
+    })
+
+    // Provider-recorded usage for run_id=run_xyz
+    usageStore.updateUsage(sid, {
+      runId: 'run_xyz', source: 'hermes', apiCalls: 2,
+      inputTokens: 100, outputTokens: 50, cacheReadTokens: 30,
+      cacheWriteTokens: 0, reasoningTokens: 12, isEstimated: false,
+      model: 'glm-5.2', provider: 'custom', profile: 'default',
+    })
+
+    sessionStore.addMessage({
+      session_id: sid, role: 'user', content: 'hello', timestamp: 110,
+    })
+    sessionStore.addMessage({
+      session_id: sid, role: 'assistant', content: 'world', timestamp: 120,
+      finish_reason: 'stop', run_id: 'run_xyz',
+    })
+
+    const detail = sessionStore.getSessionDetailPaginated(sid, 0, 150)
+    const assistantMsg = detail!.messages.find(m => m.role === 'assistant')
+    expect(assistantMsg?.run_id).toBe('run_xyz')
+    expect(assistantMsg?.usage).toBeUndefined() // not yet injected
+
+    const enriched = sessionStore.attachRunUsageToMessages(sid, detail!.messages)
+    const enrichedAssistant = enriched.find(m => m.role === 'assistant')
+    expect(enrichedAssistant?.usage).toEqual({
+      input: 100, output: 50, cacheRead: 30, reasoning: 12, apiCalls: 2,
+    })
+    const userMsg = enriched.find(m => m.role === 'user')
+    expect(userMsg?.usage).toBeUndefined() // never inject onto non-assistant
+  })
+})

--- a/tests/server/message-run-usage.test.ts
+++ b/tests/server/message-run-usage.test.ts
@@ -30,8 +30,8 @@ describe('message run_id + usage persistence', () => {
 
   it('addMessage persists run_id and getSessionDetailPaginated maps it onto HermesMessageRow', async () => {
     ensureSqliteAvailable()
-    const { initAllHermesTables } = await import('../../packages/server/src/db/hermes/schemas')
-    const sessionStore = await import('../../packages/server/src/db/hermes/session-store')
+    const { initAllHermesTables } = await import('../../packages/server/src/modules/studio/infrastructure/database/schemas')
+    const sessionStore = await import('../../packages/server/src/modules/studio/repositories/session-store')
     initAllHermesTables()
 
     const sid = `s1_${uniqueSuffix()}`
@@ -56,9 +56,9 @@ describe('message run_id + usage persistence', () => {
 
   it('attachRunUsageToMessages injects runUsage onto assistant messages with a matching run_id', async () => {
     ensureSqliteAvailable()
-    const { initAllHermesTables } = await import('../../packages/server/src/db/hermes/schemas')
-    const sessionStore = await import('../../packages/server/src/db/hermes/session-store')
-    const usageStore = await import('../../packages/server/src/db/hermes/usage-store')
+    const { initAllHermesTables } = await import('../../packages/server/src/modules/studio/infrastructure/database/schemas')
+    const sessionStore = await import('../../packages/server/src/modules/studio/repositories/session-store')
+    const usageStore = await import('../../packages/server/src/modules/studio/repositories/usage-store')
     initAllHermesTables()
 
     const sid = `s2_${uniqueSuffix()}`

--- a/tests/server/run-chat-bridge-final-context.test.ts
+++ b/tests/server/run-chat-bridge-final-context.test.ts
@@ -66,6 +66,14 @@ vi.mock('../../packages/server/src/modules/studio/repositories/session-store', (
 
 vi.mock('../../packages/server/src/modules/studio/repositories/usage-store', () => ({
   updateUsage: updateUsageMock,
+  getRecordedUsageByRun: vi.fn(() => ({
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    reasoningTokens: 0,
+    apiCalls: 0,
+  })),
 }))
 
 vi.mock('../../packages/server/src/modules/studio/public/logging', () => ({
@@ -145,6 +153,8 @@ function makeState() {
   } as any
 }
 
+const defaultBridgeWorkspace = join('/tmp/hermes-bridge-final-context', 'default', 'workspace')
+
 describe('bridge run final context usage', () => {
   beforeEach(() => {
     const home = mkdtempSync(join(tmpdir(), 'hermes-bridge-run-token-'))
@@ -212,7 +222,7 @@ describe('bridge run final context usage', () => {
       profile: 'default',
       model: 'gpt-test',
       provider: 'openai',
-      workspace: '/tmp/hermes-bridge-final-context/default/workspace',
+      workspace: defaultBridgeWorkspace,
       ended_at: 1_770_000_000,
       end_reason: 'complete',
     })
@@ -356,7 +366,7 @@ describe('bridge run final context usage', () => {
       {
         model: 'gpt-test',
         provider: 'openai',
-        workspace: '/tmp/hermes-bridge-final-context/default/workspace',
+        workspace: defaultBridgeWorkspace,
       },
     )
     expect(bridge.chat).toHaveBeenCalledWith(
@@ -876,7 +886,7 @@ describe('bridge run final context usage', () => {
     expect(createSessionMock).toHaveBeenCalledWith(expect.objectContaining({
       id: 'session-1',
       source: 'global_agent',
-      workspace: '/tmp/hermes-bridge-final-context/default/workspace',
+      workspace: defaultBridgeWorkspace,
     }))
     expect(state.source).toBe('global_agent')
   })
@@ -1599,7 +1609,7 @@ describe('bridge run final context usage', () => {
       'default',
       expect.objectContaining({
         storage_message: '/plan build the feature',
-        workspace: '/tmp/hermes-bridge-final-context/default/workspace',
+        workspace: defaultBridgeWorkspace,
       }),
     )
   })
@@ -1724,7 +1734,7 @@ describe('bridge run final context usage', () => {
       'default',
       expect.objectContaining({
         storage_message: '[IMPORTANT: expanded skill prompt]',
-        workspace: '/tmp/hermes-bridge-final-context/default/workspace',
+        workspace: defaultBridgeWorkspace,
       }),
     )
   })

--- a/tests/server/run-chat-bridge-resume.test.ts
+++ b/tests/server/run-chat-bridge-resume.test.ts
@@ -18,6 +18,14 @@ vi.mock('../../packages/server/src/modules/studio/repositories/session-store', (
 
 vi.mock('../../packages/server/src/modules/studio/repositories/usage-store', () => ({
   updateUsage: updateUsageMock,
+  getRecordedUsageByRun: vi.fn(() => ({
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    reasoningTokens: 0,
+    apiCalls: 0,
+  })),
 }))
 
 vi.mock('../../packages/server/src/modules/studio/public/logging', () => ({

--- a/tests/server/usage-store.test.ts
+++ b/tests/server/usage-store.test.ts
@@ -25,6 +25,7 @@ import {
   getUsageBatch,
   deleteUsage,
   getRecordedUsageSessionIds,
+  getRecordedUsageByRun,
 } from '../../packages/server/src/modules/studio/repositories/usage-store'
 
 describe('Usage Store (JSON fallback)', () => {
@@ -306,5 +307,36 @@ describe('Usage Store (SQLite path)', () => {
       total_api_calls: 3,
     })
     expect(getRecordedUsageSessionIds('default')).toEqual(['session-1', 'session-2'])
+  })
+
+  it('aggregates JSON run usage by bare run id and prefix', () => {
+    mockJsonGetAll.mockReturnValue({
+      'session-1': {
+        run_id: 'run-abc:api:1',
+        source: 'hermes',
+        input_tokens: 10,
+        output_tokens: 4,
+        cache_read_tokens: 7,
+        cache_write_tokens: 0,
+        reasoning_tokens: 1,
+        api_calls: 1,
+      },
+    })
+    expect(getRecordedUsageByRun('session-1', 'hermes', 'run-abc')).toEqual({
+      inputTokens: 10,
+      outputTokens: 4,
+      cacheReadTokens: 7,
+      cacheWriteTokens: 0,
+      reasoningTokens: 1,
+      apiCalls: 1,
+    })
+    expect(getRecordedUsageByRun('session-1', 'hermes', 'other')).toEqual({
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      reasoningTokens: 0,
+      apiCalls: 0,
+    })
   })
 })


### PR DESCRIPTION
## Summary
Display settings already had a **Show Cost** toggle (`show_cost`) with the hint “Show token usage in replies”, but chat bubbles never read that setting. With the toggle on, replies still looked empty of any token information.

This wires the existing session `inputTokens` / `outputTokens` into `MessageItem` and shows them on the latest completed assistant reply when `show_cost` is enabled. Management of the setting itself is unchanged; usage is still session-cumulative (same numbers the context meter already tracks).

## Validation
- `npm run test -- tests/client/message-item-token-usage.test.ts`
- `npm run harness:check`
- `npm run build`

Fixes #2140