### PR TITLE
feat: 消息队列(排队+插队放行) & Windows 桌面版字体缩放 (Ctrl+±)

### DIFF
--- a/packages/client/src/api/hermes/chat.ts
+++ b/packages/client/src/api/hermes/chat.ts
@@ -42,6 +42,9 @@ export interface StartRunRequest {
   /** Per-session reasoning effort override.
    * Empty/undefined = use config.yaml default. */
   reasoning_effort?: string
+  /** true = 用户主动放行(打断当前回复并插队到队首立即执行)。
+   * false/缺省 = 普通发送,仅入队尾排队等待。 */
+  preempt?: boolean
 }
 
 export interface StartRunResponse {

--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -1285,6 +1285,31 @@ function handleKeydown(e: KeyboardEvent) {
     }
   }
 
+  // 队列里有排队消息时,按一次 ESC 放行队首一条(打断当前回复立即执行)。
+  // 与 Claude Code 桌面版"ESC 中断"不同:这里 ESC 不打断当前回复,
+  // 只把排队中的下一条消息插入执行;队列为空时 ESC 无操作。
+  if (e.key === 'Escape') {
+    const sid = chatStore.activeSessionId
+    const queue = sid ? (chatStore.queuedUserMessages.get(sid) || []) : []
+    if (sid && queue.length > 0) {
+      e.preventDefault()
+      chatStore.promoteQueuedMessage(sid, queue[0].id)
+    }
+    return
+  }
+
+  // Ctrl+Enter: 与 ESC 相同，放行队首一条排队消息。
+  if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+    const sid = chatStore.activeSessionId
+    const queue = sid ? (chatStore.queuedUserMessages.get(sid) || []) : []
+    if (sid && queue.length > 0) {
+      e.preventDefault()
+      chatStore.promoteQueuedMessage(sid, queue[0].id)
+      return
+    }
+    // 队列为空时 Ctrl+Enter 不做特殊操作，允许后续 Enter 逻辑处理
+  }
+
   if (e.key !== 'Enter' || e.shiftKey) return
   if (isImeEnter(e)) return
 

--- a/packages/client/src/components/hermes/chat/MessageList.vue
+++ b/packages/client/src/components/hermes/chat/MessageList.vue
@@ -347,6 +347,12 @@ function removeQueuedMessage(messageId: string) {
   chatStore.removeQueuedMessage(sid, messageId);
 }
 
+function promoteQueuedMessage(messageId: string) {
+  const sid = chatStore.activeSessionId;
+  if (!sid) return;
+  chatStore.promoteQueuedMessage(sid, messageId);
+}
+
 function queuedPreview(content: string): string {
   const reference = parseMessageReference(content);
   const visibleContent = reference?.reply || reference?.content || content;
@@ -970,6 +976,16 @@ defineExpose({
               <span class="queue-text">{{ queuedPreview(message.content) }}</span>
               <button
                 type="button"
+                class="queue-promote"
+                @click="promoteQueuedMessage(message.id)"
+              >
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2">
+                  <line x1="12" y1="19" x2="12" y2="6" />
+                  <polyline points="5 11 12 4 19 11" />
+                </svg>
+              </button>
+              <button
+                type="button"
                 class="queue-remove"
                 :title="t('chat.removeQueuedMessage')"
                 @click="removeQueuedMessage(message.id)"
@@ -1270,6 +1286,26 @@ defineExpose({
   }
 }
 
+.queue-promote {
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  border: none;
+  border-radius: 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: $text-muted;
+  background: transparent;
+  cursor: pointer;
+  transition: all $transition-fast;
+
+  &:hover {
+    color: $success;
+    background: rgba($success, 0.1);
+  }
+}
+
 @media (max-width: 640px) {
   .message-float-stack {
     left: 8px;
@@ -1335,6 +1371,11 @@ defineExpose({
   }
 
   .queue-remove {
+    width: 22px;
+    height: 22px;
+  }
+
+  .queue-promote {
     width: 22px;
     height: 22px;
   }

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -2727,6 +2727,14 @@ export const useChatStore = defineStore('chat', () => {
     })
   }
 
+  function promoteQueuedMessage(sessionId: string, messageId: string) {
+    if (!(queuedUserMessages.value.get(sessionId) || []).some(message => message.id === messageId)) return
+    getChatRunSocket(runtimeTransport())?.emit('run.promote', {
+      session_id: sessionId,
+      queue_id: messageId,
+    })
+  }
+
   function normalizeQueuedUserMessages(rawMessages: unknown): Message[] {
     if (!Array.isArray(rawMessages)) return []
     return rawMessages.flatMap((raw) => {
@@ -3222,6 +3230,9 @@ export const useChatStore = defineStore('chat', () => {
           models: group.models,
         })),
         queue_id: userMsg.id,
+        // 普通发送默认排队不打断;只有用户通过"立即发送"/ESC 显式放行时
+        // (promoteQueuedMessage 走 run.promote)才打断当前回复。
+        preempt: false,
         workspace: activeSession.value?.workspace || undefined,
         category_id: activeSession.value?.categoryId ?? null,
         source: sessionSource,
@@ -5017,6 +5028,7 @@ export const useChatStore = defineStore('chat', () => {
     subagentStreams,
     getSubagentStream,
     removeQueuedMessage,
+    promoteQueuedMessage,
     setMessageReference,
     clearMessageReference,
     isLoadingSessions,

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -15,7 +15,7 @@ import {
   type OpenDialogOptions,
   type IpcMainInvokeEvent,
 } from 'electron'
-import { existsSync } from 'node:fs'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { startWebUiServer, stopWebUiServer, getToken } from './webui-server'
 import { bundledNode, desktopIcon, desktopMacTrayIcon, desktopRuntimeVersion, desktopWindowsTrayIcon, hermesBinExists, hermesBin, runtimeStorageRoot, webuiDir, webUiHome } from './paths'
@@ -463,6 +463,65 @@ function createTray() {
   updateTrayMenu()
 }
 
+// ── [zoom patch] Windows 桌面端字体缩放 ──────────────────────────────
+// 上游把 Windows/Linux 的原生菜单整体移除了（Menu.setApplicationMenu(null)），
+// 导致 Electron 默认的缩放快捷键 Ctrl+= / Ctrl+- / Ctrl+0 一并失效。
+// 这里在主进程用 before-input-event 重新注册 Ctrl+加号 / Ctrl+减号 / Ctrl+0，
+// 通过 webContents.setZoomLevel() 缩放整个界面字体/UI，并持久化级别。
+// 只对 Windows 生效；macOS 保留系统默认菜单的缩放。
+const ZOOM_STEP = 0.5
+const ZOOM_MIN = -3
+const ZOOM_MAX = 4
+function desktopZoomStatePath(): string {
+  return join(app.getPath('userData'), 'desktop-zoom.json')
+}
+function loadDesktopZoomLevel(): number {
+  try {
+    const parsed = JSON.parse(readFileSync(desktopZoomStatePath(), 'utf8')) as { level?: unknown }
+    const level = Number(parsed?.level)
+    return Number.isFinite(level) ? Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, level)) : 0
+  } catch {
+    return 0
+  }
+}
+function saveDesktopZoomLevel(level: number): void {
+  try {
+    writeFileSync(desktopZoomStatePath(), JSON.stringify({ level }), 'utf8')
+  } catch (err) {
+    console.warn('[desktop-zoom] failed to persist zoom level:', err)
+  }
+}
+function installDesktopZoomShortcuts(target: BrowserWindow): void {
+  if (process.platform !== 'win32') return
+  const applyZoom = (delta: number): void => {
+    if (target.isDestroyed()) return
+    const next = Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, target.webContents.getZoomLevel() + delta))
+    target.webContents.setZoomLevel(next)
+    saveDesktopZoomLevel(next)
+  }
+  const resetZoom = (): void => {
+    if (target.isDestroyed()) return
+    target.webContents.setZoomLevel(0)
+    saveDesktopZoomLevel(0)
+  }
+  target.webContents.on('before-input-event', (event, input) => {
+    if (input.type !== 'keyDown' || !input.control) return
+    const key = input.key
+    if (key === '+' || key === '=' || key === 'Add') {
+      event.preventDefault()
+      applyZoom(ZOOM_STEP)
+    } else if (key === '-' || key === 'Subtract') {
+      event.preventDefault()
+      applyZoom(-ZOOM_STEP)
+    } else if (key === '0') {
+      event.preventDefault()
+      resetZoom()
+    }
+  })
+  const saved = loadDesktopZoomLevel()
+  if (saved !== 0) target.webContents.setZoomLevel(saved)
+}
+
 async function createWindow(): Promise<void> {
   mainWindow = new BrowserWindow({
     width: 1280,
@@ -511,6 +570,9 @@ async function createWindow(): Promise<void> {
   mainWindow.on('restore', () => notifyWindowStateChanged(mainWindow))
 
   installSelectionContextMenu(mainWindow)
+
+  // [zoom patch] 主窗口启用 Ctrl+加号/减号 缩放
+  installDesktopZoomShortcuts(mainWindow)
 
   // External links → system browser
   mainWindow.webContents.setWindowOpenHandler(({ url, frameName }) => {
@@ -600,6 +662,9 @@ async function openChatWindow(sessionIdInput: unknown, profileInput?: unknown): 
   chatWindow.on('closed', () => {
     if (chatWindows.get(windowKey) === chatWindow) chatWindows.delete(windowKey)
   })
+
+  // [zoom patch] 聊天窗口同样支持 Ctrl+加号/减号 缩放
+  installDesktopZoomShortcuts(chatWindow)
 
   installSelectionContextMenu(chatWindow)
   chatWindow.webContents.setWindowOpenHandler(({ url: targetUrl, frameName }) => {

--- a/packages/server/src/services/hermes/run-chat/abort.ts
+++ b/packages/server/src/services/hermes/run-chat/abort.ts
@@ -87,6 +87,8 @@ export async function handleAbort(
 
   const runId = activeState.runId
   activeState.isAborting = true
+  // [preempt patch] 新一轮 abort 重置幂等标志,使本轮 markAbortCompleted 只生效一次
+  activeState.abortFinalized = false
   replaceState(sessionMap, sessionId, 'abort.started', {
     event: 'abort.started',
     run_id: runId,
@@ -197,6 +199,15 @@ export async function markAbortCompleted(
 ) {
   const state = sessionMap.get(sessionId)
   if (!state) return
+  // [preempt patch] 幂等保护:handleAbort 和 bridge terminal chunk 都会被触发
+  // markAbortCompleted。重复执行会清掉刚启动的下一条 run 的状态(activeRunMarker/
+  // runId),使 bridge 端 run 悬空,后续新消息撞 "already running"。标记为事务性:
+  // 在第一个 await 之前原子置位,并发第二次调用直接跳过。
+  if (state.abortFinalized) {
+    logger.info({ sessionId, runId }, '[chat-run-socket][abort] markAbortCompleted skipped, already finalized')
+    return
+  }
+  state.abortFinalized = true
 
   const profile = state.profile
   updateSessionStats(sessionId)
@@ -236,6 +247,7 @@ export async function markAbortCompleted(
     emitToSession(nsp, socket, sessionId, 'run.queued', {
       event: 'run.queued',
       queue_length: state.queue.length,
+      dequeued_queue_id: next.queue_id,
     })
     state.events = []
     runQueuedItem(socket, sessionId, next, profile || 'default')

--- a/packages/server/src/services/hermes/run-chat/abort.ts
+++ b/packages/server/src/services/hermes/run-chat/abort.ts
@@ -12,6 +12,7 @@ import {
 } from '../../ekko-agent/manager'
 import { flushBridgePendingToDb } from './bridge-message'
 import { flushResponseRunToDb } from './response-stream'
+import { contentBlocksToString } from './content-blocks'
 import { replaceState } from './compression'
 import { calcAndUpdateUsage } from './usage'
 import type { QueuedRun, SessionState } from './types'
@@ -248,6 +249,17 @@ export async function markAbortCompleted(
       event: 'run.queued',
       queue_length: state.queue.length,
       dequeued_queue_id: next.queue_id,
+      // [queue-fix patch] 与 dequeueNextQueuedRun 一致:携带剩余队列的完整序列化,
+      // 前端 replaceQueuedUserMessages 直接整表替换,不依赖本地 filter 猜删。
+      queued_messages: state.queue
+        .filter(item => item.displayInput !== null)
+        .map(item => ({
+          id: item.queue_id,
+          role: item.displayRole || (typeof item.displayInput === 'string' && item.displayInput.trim().startsWith('/') ? 'command' : 'user'),
+          content: contentBlocksToString(item.displayInput ?? item.input),
+          timestamp: Math.floor(Date.now() / 1000),
+          queued: true,
+        })),
     })
     state.events = []
     runQueuedItem(socket, sessionId, next, profile || 'default')

--- a/packages/server/src/services/hermes/run-chat/index.ts
+++ b/packages/server/src/services/hermes/run-chat/index.ts
@@ -533,23 +533,37 @@ export class ChatRunSocket {
     // [user-controlled patch] 立即发送:把指定排队消息提升到队首并打断当前 run,
     // 使其马上开始回复(markAbortCompleted 出队队首即该消息)。前端"立即发送"
     // 按钮与 ESC 放行都走这个事件。
-    socket.on('run.promote', async (data: { session_id?: string; queue_id?: string }) => {
+    // [queue-fix patch] 并发 promote 会同时触发 handleAbort,而 abortFinalized
+    // 幂等保护只放行第一个 markAbortCompleted,其余被吞 → 消息留在队列不执行,
+    // 前端队列残留。这里把同一 session 的 promote 串成链,前一个彻底结束
+    // (出队+启动下一 run)再处理下一个。
+    socket.on('run.promote', (data: { session_id?: string; queue_id?: string }) => {
       if (!data.session_id || !data.queue_id) return
       const state = this.sessionMap.get(data.session_id)
       if (!state || !state.queue.length) return
-      const targetIndex = state.queue.findIndex(item => item.queue_id === data.queue_id)
-      if (targetIndex === -1) {
-        logger.info('[chat-run-socket] promote miss %s for session %s (queue: %d)', data.queue_id, data.session_id, state.queue.length)
-        return
+      const runPromote = async () => {
+        const sid = data.session_id as string
+        const qid = data.queue_id as string
+        const current = this.sessionMap.get(sid)
+        if (!current || !current.queue.length) return
+        const targetIndex = current.queue.findIndex(item => item.queue_id === qid)
+        if (targetIndex === -1) {
+          logger.info('[chat-run-socket] promote miss %s for session %s (queue: %d)', qid, sid, current.queue.length)
+          return
+        }
+        const [target] = current.queue.splice(targetIndex, 1)
+        current.queue.unshift(target)
+        logger.info('[chat-run-socket] promote %s to head for session %s (queue: %d)', qid, sid, current.queue.length)
+        await handleAbort(this.nsp, socket, sid, this.sessionMap, this.bridge, this.runQueuedItem.bind(this))
+        const after = this.sessionMap.get(sid)
+        if (after && !after.isWorking && after.queue.length > 0) {
+          this.dequeueNextQueuedRun(socket, sid, target.profile || 'default')
+        }
       }
-      const [target] = state.queue.splice(targetIndex, 1)
-      state.queue.unshift(target)
-      logger.info('[chat-run-socket] promote %s to head for session %s (queue: %d)', data.queue_id, data.session_id, state.queue.length)
-      await handleAbort(this.nsp, socket, data.session_id, this.sessionMap, this.bridge, this.runQueuedItem.bind(this))
-      const after = this.sessionMap.get(data.session_id)
-      if (after && !after.isWorking && after.queue.length > 0) {
-        this.dequeueNextQueuedRun(socket, data.session_id, target.profile || 'default')
-      }
+      const previous = state.promoteChain || Promise.resolve()
+      state.promoteChain = previous.then(runPromote, runPromote).catch((err: unknown) => {
+        logger.warn(err, '[chat-run-socket] promote chain error for session %s', data.session_id)
+      })
     })
 
     socket.on('resume', async (data: { session_id?: string }) => {

--- a/packages/server/src/services/hermes/run-chat/index.ts
+++ b/packages/server/src/services/hermes/run-chat/index.ts
@@ -330,6 +330,9 @@ export class ChatRunSocket {
       allow_command_passthrough?: boolean
       // Local patch (reasoning-effort): per-session reasoning effort override.
       reasoning_effort?: string
+      // Local patch (user-controlled queue): true = 用户主动放行(打断当前、
+      // 插队到队首立即执行);缺省/false = 普通发送,仅入队尾排队等待。
+      preempt?: boolean
     }) => {
       let runProfile: string
       try {
@@ -380,8 +383,10 @@ export class ChatRunSocket {
           return
         }
         if (state.isWorking) {
+          logger.info('[chat-run-socket][preempt] new run during active session %s (isWorking=%s isAborting=%s runId=%s qlen=%d)',
+            data.session_id, state.isWorking, state.isAborting, state.runId, state.queue.length)
           const queueId = data.queue_id || `queue_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`
-          state.queue.push({
+          const queuedRun: QueuedRun = {
             queue_id: queueId,
             input: data.input,
             displayInput: data.display_input,
@@ -414,7 +419,35 @@ export class ChatRunSocket {
             commandPassthrough: data.allow_command_passthrough,
             reasoningEffort: data.reasoning_effort,
             originSocketId: socket.id,
-          })
+          }
+          // [user-controlled patch] 两种行为:
+          //  - data.preempt === true(用户通过"立即发送"按钮 / ESC 显式放行):
+          //    插队到队首并打断当前 run,让该消息立即开始回复。
+          //  - 缺省(普通发送):只 push 到队尾排队等待,不打断当前生成,
+          //    当前 run 完成后的 dequeueNextQueuedRun 会按序自动拾取。
+          if (data.preempt === true) {
+            state.queue.unshift(queuedRun)
+            if (state.isAborting) {
+              this.nsp.to(`session:${data.session_id}`).emit('run.queued', {
+                event: 'run.queued',
+                session_id: data.session_id,
+                queue_length: state.queue.length,
+                queued_messages: this.serializeQueuedMessages(state.queue),
+              })
+              logger.info('[chat-run-socket] preempt queued run while already aborting for session %s (queue: %d)', data.session_id, state.queue.length)
+              return
+            }
+            logger.info('[chat-run-socket] preempting running session %s with new run (queue: %d)', data.session_id, state.queue.length)
+            await handleAbort(this.nsp, socket, data.session_id, this.sessionMap, this.bridge, this.runQueuedItem.bind(this))
+            // 兜底:handleAbort 若因"无活动 run"被忽略,手动出队队首(新消息)
+            const preempted = this.sessionMap.get(data.session_id)
+            if (preempted && !preempted.isWorking && preempted.queue.length > 0) {
+              this.dequeueNextQueuedRun(socket, data.session_id, runProfile)
+            }
+            return
+          }
+          // 默认:排队等待,不打断当前回复
+          state.queue.push(queuedRun)
           const queuedPayload = {
             event: 'run.queued',
             session_id: data.session_id,
@@ -434,7 +467,7 @@ export class ChatRunSocket {
             workflowNodeId: data.workflow_node_id,
           })
           this.nsp.to(`session:${data.session_id}`).emit('run.queued', queuedPayload)
-          logger.info('[chat-run-socket] queued run for session %s (queue: %d)', data.session_id, state.queue.length)
+          logger.info('[chat-run-socket] queued run %s for busy session %s (queue: %d, preempt=off)', queueId, data.session_id, state.queue.length)
           return
         }
         state.events = []
@@ -495,6 +528,28 @@ export class ChatRunSocket {
       })
       logger.info('[chat-run-socket] cancelled queued run %s for session %s (queue: %d)',
         data.queue_id, data.session_id, state.queue.length)
+    })
+
+    // [user-controlled patch] 立即发送:把指定排队消息提升到队首并打断当前 run,
+    // 使其马上开始回复(markAbortCompleted 出队队首即该消息)。前端"立即发送"
+    // 按钮与 ESC 放行都走这个事件。
+    socket.on('run.promote', async (data: { session_id?: string; queue_id?: string }) => {
+      if (!data.session_id || !data.queue_id) return
+      const state = this.sessionMap.get(data.session_id)
+      if (!state || !state.queue.length) return
+      const targetIndex = state.queue.findIndex(item => item.queue_id === data.queue_id)
+      if (targetIndex === -1) {
+        logger.info('[chat-run-socket] promote miss %s for session %s (queue: %d)', data.queue_id, data.session_id, state.queue.length)
+        return
+      }
+      const [target] = state.queue.splice(targetIndex, 1)
+      state.queue.unshift(target)
+      logger.info('[chat-run-socket] promote %s to head for session %s (queue: %d)', data.queue_id, data.session_id, state.queue.length)
+      await handleAbort(this.nsp, socket, data.session_id, this.sessionMap, this.bridge, this.runQueuedItem.bind(this))
+      const after = this.sessionMap.get(data.session_id)
+      if (after && !after.isWorking && after.queue.length > 0) {
+        this.dequeueNextQueuedRun(socket, data.session_id, target.profile || 'default')
+      }
     })
 
     socket.on('resume', async (data: { session_id?: string }) => {

--- a/packages/server/src/services/hermes/run-chat/types.ts
+++ b/packages/server/src/services/hermes/run-chat/types.ts
@@ -94,6 +94,10 @@ export interface SessionState {
   contextTokens?: number
   bridgeContext?: BridgeContextState
   isAborting?: boolean
+  /** [preempt patch] 幂等保护:同一轮 abort 的 markAbortCompleted 只执行一次。
+   *  handleAbort 与 bridge terminal chunk 的 markAbortCompleted 会并发触发,
+   *  不加保护会把刚启动的下一条 run 的 activeRunMarker/runId 清掉。 */
+  abortFinalized?: boolean
   queue: QueuedRun[]
   responseRun?: ResponseRunState
   source?: ChatRunSource

--- a/packages/server/src/services/hermes/run-chat/types.ts
+++ b/packages/server/src/services/hermes/run-chat/types.ts
@@ -95,10 +95,14 @@ export interface SessionState {
   bridgeContext?: BridgeContextState
   isAborting?: boolean
   /** [preempt patch] 幂等保护:同一轮 abort 的 markAbortCompleted 只执行一次。
-   *  handleAbort 与 bridge terminal chunk 的 markAbortCompleted 会并发触发,
-   *  不加保护会把刚启动的下一条 run 的 activeRunMarker/runId 清掉。 */
-  abortFinalized?: boolean
-  queue: QueuedRun[]
+     *  handleAbort 与 bridge terminal chunk 的 markAbortCompleted 会并发触发,
+     *  不加保护会把刚启动的下一条 run 的 activeRunMarker/runId 清掉。 */
+    abortFinalized?: boolean
+    /** [queue-fix patch] run.promote 串行链:同一 session 的"立即发送"排队执行。
+     *  并发 promote 会同时触发 handleAbort,而 abortFinalized 幂等保护只放行
+     *  第一个 markAbortCompleted,其余被吞导致队列卡死、前端队列残留。 */
+    promoteChain?: Promise<void>
+    queue: QueuedRun[]
   responseRun?: ResponseRunState
   source?: ChatRunSource
   webhookAgent?: 'bridge' | 'ekko' | 'claude-code' | 'codex'


### PR DESCRIPTION
## 背景 / Background

这两个功能是我们 fork(`stevenwang288/hermes-studio`)里实际在用的改进,曾向作者多次提需求但未获采纳,遂自行实现。现整理成最小 diff,基于最新 `main` 提交,方便作者审阅合入正式版。

These two features have been running in our fork (`stevenwang288/hermes-studio`) in production. We requested them from the author multiple times without adoption, so we implemented them ourselves. This PR is a minimal, clean diff on top of the latest `main`, ready for review and merge.

---

## ① 消息队列:发新消息排队,可随时插队放行 (Message Queue)

**问题 / Problem**: 当会话正在生成回复时,再发新消息会直接打断当前回复,导致上下文混乱;想"排队等当前回复完再答"做不到。

**改动 / Changes** (7 files, +155/-3):
- run-chat/index.ts: 会话忙时新消息默认 push 到队尾排队,不打断当前 run;data.preempt === true 时插队到队首并打断当前 run 立即回复。
- 新增 run.promote socket 事件:将队首消息提升为 preempt(立即执行)。
- 前端 chat.ts store / ChatInput.vue / MessageList.vue: 队列项显示 ↑ 按钮,点击后提升该消息到队首并立即执行;ESC / Ctrl+Enter 快捷键放行队首消息。
- abort.ts: abortFinalized 增加幂等保护。

**行为 / Behavior**:
- 默认发送 → 排队等待,不打断当前回复,当前 run 完成后自动按序执行。
- 立即发送(ESC 或 ↑ 按钮)→ 打断当前回复,优先执行新消息。

## ② Windows 桌面版字体缩放 (Ctrl+加号/减号) (Desktop Font Zoom)

**问题 / Problem**: 上游移除原生菜单后,Windows 桌面版 Electron 的默认缩放快捷键(Ctrl+加号/减号/0)失效,窗口字体大小无法调整。

**改动 / Changes** (1 file, +66/-1, packages/desktop/src/main/index.ts):
- 通过 before-input-event 重新注册 Ctrl+= / Ctrl+- / Ctrl+0(含小键盘)。
- setZoomLevel 调整后持久化到 userData/desktop-zoom.json,重启后保留缩放级别。
- 仅 Windows 生效,主窗口与独立聊天窗口均挂载。

---

## 验证 / Verification

- 基于 main @ 7bcc39b3(0.6.41 changelog)构建,npm run build 通过(vue-tsc + vite + server tsc 全绿)。
- 两个功能在 fork 生产环境已稳定运行。

合并策略:两个 commit 完全独立,可单独 cherry-pick;若只想要其中一个,`git cherry-pick 052ad070`(消息队列)或 `git cherry-pick 52dd6dc2`(字体缩放)即可。
