### PR TITLE
feat(desktop): Windows 桌面版 Ctrl+加号/减号 缩放(重启保留) — AI 辅助实现, 欢迎优化

### DIFF
--- a/packages/desktop/src/main/browser/browser-manager.ts
+++ b/packages/desktop/src/main/browser/browser-manager.ts
@@ -127,6 +127,9 @@ export class BrowserManager {
   private activeTabId: string | undefined
   private visible = false
   private bounds: BrowserBounds = { x: 0, y: 0, width: 800, height: 600 }
+  // 网页端上报的浏览器占位区域(CSS 布局坐标, 与主窗口 zoom 无关)。this.bounds
+  // 是它乘以当前 zoom 因子后的实际覆盖区, 用于 contentView 定位与 offscreen 避让。
+  private rawViewport: BrowserBounds = { x: 0, y: 0, width: 800, height: 600 }
 
   constructor(private readonly window: BrowserWindow, stateRoot: string, private readonly options?: BrowserManagerOptions) {
     this.profileStore = new BrowserProfileStore(stateRoot)
@@ -160,7 +163,7 @@ export class BrowserManager {
   }
 
   setViewport(bounds: BrowserBounds, visible: boolean): DesktopBrowserState {
-    this.bounds = {
+    this.rawViewport = {
       x: Math.max(0, Math.round(bounds.x)),
       y: Math.max(0, Math.round(bounds.y)),
       width: Math.max(1, Math.round(bounds.width)),
@@ -170,6 +173,23 @@ export class BrowserManager {
     this.syncViews()
     this.emitState()
     return this.state()
+  }
+
+  // 主窗口 zoom 变化时由主进程调用, 重算浏览器 view 的覆盖区与内容缩放, 消除
+  // 与放大后主 UI 的错位(zoom 不影响布局坐标, 网页端不会自动重报 viewport)。
+  applyDesktopZoom(): void {
+    this.syncViews()
+  }
+
+  private effectiveBounds(): BrowserBounds {
+    const factor = this.window.webContents.getZoomFactor()
+    const viewport = this.rawViewport
+    return {
+      x: Math.round(viewport.x * factor),
+      y: Math.round(viewport.y * factor),
+      width: Math.max(1, Math.round(viewport.width * factor)),
+      height: Math.max(1, Math.round(viewport.height * factor)),
+    }
   }
 
   async createTab(url = 'about:blank', activate = true): Promise<DesktopBrowserTab> {
@@ -948,7 +968,12 @@ export class BrowserManager {
   }
 
   private syncViews(): void {
+    this.bounds = this.effectiveBounds()
+    const browserZoomFactor = this.window.webContents.getZoomFactor()
     for (const [id, record] of this.records) {
+      if (record.view.webContents.getZoomFactor() !== browserZoomFactor) {
+        record.view.webContents.setZoomFactor(browserZoomFactor)
+      }
       const userVisible = this.visible && id === this.activeTabId
       if (userVisible) {
         record.view.setBounds(this.bounds)

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -15,7 +15,7 @@ import {
   type OpenDialogOptions,
   type IpcMainInvokeEvent,
 } from 'electron'
-import { existsSync } from 'node:fs'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { startWebUiServer, stopWebUiServer, getToken } from './webui-server'
 import { bundledNode, desktopIcon, desktopMacTrayIcon, desktopRuntimeVersion, desktopWindowsTrayIcon, hermesBinExists, hermesBin, runtimeStorageRoot, webuiDir, webUiHome } from './paths'
@@ -463,6 +463,70 @@ function createTray() {
   updateTrayMenu()
 }
 
+// ── [zoom patch] Windows 桌面端字体缩放 ──────────────────────────────
+// 上游把 Windows/Linux 的原生菜单整体移除了（Menu.setApplicationMenu(null)），
+// 导致 Electron 默认的缩放快捷键 Ctrl+= / Ctrl+- / Ctrl+0 一并失效。
+// 这里在主进程用 before-input-event 重新注册 Ctrl+加号 / Ctrl+减号 / Ctrl+0，
+// 通过 webContents.setZoomLevel() 缩放整个界面字体/UI，并持久化级别。
+// 只对 Windows 生效；macOS 保留系统默认菜单的缩放。
+const ZOOM_STEP = 0.5
+const ZOOM_MIN = -3
+const ZOOM_MAX = 4
+function desktopZoomStatePath(): string {
+  return join(app.getPath('userData'), 'desktop-zoom.json')
+}
+function loadDesktopZoomLevel(): number {
+  try {
+    const parsed = JSON.parse(readFileSync(desktopZoomStatePath(), 'utf8')) as { level?: unknown }
+    const level = Number(parsed?.level)
+    return Number.isFinite(level) ? Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, level)) : 0
+  } catch {
+    return 0
+  }
+}
+function saveDesktopZoomLevel(level: number): void {
+  try {
+    writeFileSync(desktopZoomStatePath(), JSON.stringify({ level }), 'utf8')
+  } catch (err) {
+    console.warn('[desktop-zoom] failed to persist zoom level:', err)
+  }
+}
+function installDesktopZoomShortcuts(target: BrowserWindow): void {
+  if (process.platform !== 'win32') return
+  const applyZoom = (delta: number): void => {
+    if (target.isDestroyed()) return
+    const next = Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, target.webContents.getZoomLevel() + delta))
+    target.webContents.setZoomLevel(next)
+    saveDesktopZoomLevel(next)
+    if (target === mainWindow) browserManager?.applyDesktopZoom()
+  }
+  const resetZoom = (): void => {
+    if (target.isDestroyed()) return
+    target.webContents.setZoomLevel(0)
+    saveDesktopZoomLevel(0)
+    if (target === mainWindow) browserManager?.applyDesktopZoom()
+  }
+  target.webContents.on('before-input-event', (event, input) => {
+    if (input.type !== 'keyDown' || !input.control) return
+    const key = input.key
+    if (key === '+' || key === '=' || key === 'Add') {
+      event.preventDefault()
+      applyZoom(ZOOM_STEP)
+    } else if (key === '-' || key === 'Subtract') {
+      event.preventDefault()
+      applyZoom(-ZOOM_STEP)
+    } else if (key === '0') {
+      event.preventDefault()
+      resetZoom()
+    }
+  })
+  const saved = loadDesktopZoomLevel()
+  if (saved !== 0) {
+    target.webContents.setZoomLevel(saved)
+    if (target === mainWindow) browserManager?.applyDesktopZoom()
+  }
+}
+
 async function createWindow(): Promise<void> {
   mainWindow = new BrowserWindow({
     width: 1280,
@@ -511,6 +575,9 @@ async function createWindow(): Promise<void> {
   mainWindow.on('restore', () => notifyWindowStateChanged(mainWindow))
 
   installSelectionContextMenu(mainWindow)
+
+  // [zoom patch] 主窗口启用 Ctrl+加号/减号 缩放
+  installDesktopZoomShortcuts(mainWindow)
 
   // External links → system browser
   mainWindow.webContents.setWindowOpenHandler(({ url, frameName }) => {
@@ -600,6 +667,9 @@ async function openChatWindow(sessionIdInput: unknown, profileInput?: unknown): 
   chatWindow.on('closed', () => {
     if (chatWindows.get(windowKey) === chatWindow) chatWindows.delete(windowKey)
   })
+
+  // [zoom patch] 聊天窗口同样支持 Ctrl+加号/减号 缩放
+  installDesktopZoomShortcuts(chatWindow)
 
   installSelectionContextMenu(chatWindow)
   chatWindow.webContents.setWindowOpenHandler(({ url: targetUrl, frameName }) => {


### PR DESCRIPTION
## 概述

为 **Windows 桌面版** 恢复被上游移除的界面缩放能力。上游在 Win/Linux 上调用了 `Menu.setApplicationMenu(null)`，导致 Electron 内置的 `Ctrl+= / Ctrl+- / Ctrl+0` 缩放快捷键一并失效，用户无法调整桌面版字体/UI 大小。

本 PR 在主进程中通过 `before-input-event` 重新注册缩放快捷键，并让内置浏览器视图跟随主窗口一致缩放。

---

### 改动内容

| 文件 | 改动 |
|---|---|
| `packages/desktop/src/main/index.ts` | 新增 `installDesktopZoomShortcuts`：注册 `Ctrl+= / Ctrl+= 小键盘 / Ctrl+- / Ctrl+0`，调用 `setZoomLevel` 缩放，并把级别持久化到 `userData/desktop-zoom.json`（重启保留） |
| `packages/desktop/src/main/browser/browser-manager.ts` | view bounds 与内容 zoom 跟随主窗口 zoom factor 同步，消除放大后浏览器占位与主 UI 的错位 |

**效果：**
- `Ctrl+=` / `Ctrl+-` / `Ctrl+0` 调节缩放，步进 0.5
- 范围 `-3 ~ +4`（约 12.5% ~ 400%）
- 缩放级别重启后保留
- 主窗口与独立聊天窗口均生效
- **仅 Windows**；macOS 保留系统默认菜单缩放

---

### 说明(请作者协助优化)

> 这份改动主要是 **AI 辅助生成**的，我自己对 Electron 主进程细节不够熟练。虽然已在我的 Windows 11 环境（上游 v0.6.42 基线）上验证运行正常，但**实现方式、边界处理、以及是否与上游将来的菜单方案冲突**等方面，欢迎作者直接给出改进意见或重写：
> - 是否用更贴近官方的方式（而不是 `before-input-event`）更稳妥
> - 是否需要把缩放限制范围、步进改成可配置
> - 是否需要纳入 i18n 或设置面板
> - 代码命名/注释风格是否与项目规范一致
>
> 多谢！

---

### 兼容性

- 纯增量改动，未移除任何现有行为
- 只影响 Windows 桌面端
- 相关代码以 `[zoom patch]` / `[desktop-zoom]` 注释标记，便于识别
