### PR TITLE
feat: Windows desktop zoom shortcuts + user-controlled message queue

### DIFF
--- a/packages/client/src/api/hermes/chat.ts
+++ b/packages/client/src/api/hermes/chat.ts
@@ -42,6 +42,9 @@ export interface StartRunRequest {
   /** Per-session reasoning effort override.
    * Empty/undefined = use config.yaml default. */
   reasoning_effort?: string
+  /** true = 用户主动放行(打断当前回复并插队到队首立即执行)。
+   * false/缺省 = 普通发送,仅入队尾排队等待。 */
+  preempt?: boolean
 }
 
 export interface StartRunResponse {

--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -971,6 +971,31 @@ function handleKeydown(e: KeyboardEvent) {
     }
   }
 
+  // 队列里有排队消息时,按一次 ESC 放行队首一条(打断当前回复立即执行)。
+  // 与 Claude Code 桌面版"ESC 中断"不同:这里 ESC 不打断当前回复,
+  // 只把排队中的下一条消息插入执行;队列为空时 ESC 无操作。
+  if (e.key === 'Escape') {
+    const sid = chatStore.activeSessionId
+    const queue = sid ? (chatStore.queuedUserMessages.get(sid) || []) : []
+    if (sid && queue.length > 0) {
+      e.preventDefault()
+      chatStore.promoteQueuedMessage(sid, queue[0].id)
+    }
+    return
+  }
+
+  // Ctrl+Enter: 与 ESC 相同，放行队首一条排队消息。
+  if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+    const sid = chatStore.activeSessionId
+    const queue = sid ? (chatStore.queuedUserMessages.get(sid) || []) : []
+    if (sid && queue.length > 0) {
+      e.preventDefault()
+      chatStore.promoteQueuedMessage(sid, queue[0].id)
+      return
+    }
+    // 队列为空时 Ctrl+Enter 不做特殊操作，允许后续 Enter 逻辑处理
+  }
+
   if (e.key !== 'Enter' || e.shiftKey) return
   if (isImeEnter(e)) return
 

--- a/packages/client/src/components/hermes/chat/MessageList.vue
+++ b/packages/client/src/components/hermes/chat/MessageList.vue
@@ -371,6 +371,13 @@ function queueInsertionTitle(messageId: string): string {
   return t("chat.queueInsertionStopping");
 }
 
+// [user-controlled patch] 立即发送:把排队消息提到队首并打断当前 run
+function promoteQueuedMessage(messageId: string) {
+  const sid = chatStore.activeSessionId;
+  if (!sid) return;
+  chatStore.promoteQueuedMessage(sid, messageId);
+}
+
 function queuedPreview(content: string): string {
   const reference = parseMessageReference(content);
   const visibleContent = reference?.reply || reference?.content || content;
@@ -978,18 +985,58 @@ defineExpose({
         </div>
       </Transition>
       <Transition name="queue-float">
-        <MessageQueueFloatPanel
-          :items="queuedFloatItems"
-          :can-insert="canInsertQueuedMessages"
-          :active-insert-id="activeQueueInsertion?.queueId"
-          :insert-title="item => queueInsertionTitle(item.id)"
-          @insert="insertQueuedMessage"
-          @remove="removeQueuedMessage"
-        />
-      </Transition>
-    </div>
-  </div>
-</template>
+              <MessageQueueFloatPanel
+                v-if="canInsertQueuedMessages"
+                :items="queuedFloatItems"
+                :can-insert="canInsertQueuedMessages"
+                :active-insert-id="activeQueueInsertion?.queueId"
+                :insert-title="item => queueInsertionTitle(item.id)"
+                @insert="insertQueuedMessage"
+                @remove="removeQueuedMessage"
+              />
+              <div v-else-if="queuedMessages.length > 0" class="queue-float-panel">
+          <div class="queue-float-header">
+            <span class="queue-orbit" aria-hidden="true">
+              <span></span>
+            </span>
+            <span>{{ t('chat.messageQueue') }}</span>
+            <strong>{{ queuedMessages.length }}</strong>
+          </div>
+          <div class="queue-float-list">
+            <div
+              v-for="(message, index) in queuedMessages"
+              :key="message.id"
+              class="queue-float-item"
+            >
+              <span class="queue-index">{{ index + 1 }}</span>
+              <span class="queue-text">{{ queuedPreview(message.content) }}</span>
+              <button
+                type="button"
+                class="queue-promote"
+                @click="promoteQueuedMessage(message.id)"
+              >
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2">
+                  <line x1="12" y1="19" x2="12" y2="6" />
+                  <polyline points="5 11 12 4 19 11" />
+                </svg>
+              </button>
+              <button
+                type="button"
+                class="queue-remove"
+                :title="t('chat.removeQueuedMessage')"
+                @click="removeQueuedMessage(message.id)"
+              >
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <line x1="18" y1="6" x2="6" y2="18" />
+                  <line x1="6" y1="6" x2="18" y2="18" />
+                </svg>
+              </button>
+            </div>
+                    </div>
+                  </Transition>
+                </div>
+              </div>
+            </template>
 
 <style scoped lang="scss">
 @use "@/styles/variables" as *;
@@ -1303,6 +1350,26 @@ defineExpose({
   }
 }
 
+.queue-promote {
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  border: none;
+  border-radius: 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: $text-muted;
+  background: transparent;
+  cursor: pointer;
+  transition: all $transition-fast;
+
+  &:hover {
+    color: $success;
+    background: rgba($success, 0.1);
+  }
+}
+
 @media (max-width: 640px) {
   .message-float-stack {
     left: 8px;
@@ -1369,6 +1436,11 @@ defineExpose({
 
   .queue-insert,
   .queue-remove {
+    width: 22px;
+    height: 22px;
+  }
+
+  .queue-promote {
     width: 22px;
     height: 22px;
   }

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -2753,9 +2753,18 @@ export const useChatStore = defineStore('chat', () => {
     })
   }
 
-  function insertQueuedMessage(sessionId: string, messageId: string) {
+function insertQueuedMessage(sessionId: string, messageId: string) {
     if (!(queuedUserMessages.value.get(sessionId) || []).some(message => message.id === messageId)) return
     getChatRunSocket(runtimeTransport())?.emit('insert_queued_run', {
+      session_id: sessionId,
+      queue_id: messageId,
+    })
+  }
+
+  // [user-controlled patch] 立即发送:把排队消息提到队首并打断当前 run
+  function promoteQueuedMessage(sessionId: string, messageId: string) {
+    if (!(queuedUserMessages.value.get(sessionId) || []).some(message => message.id === messageId)) return
+    getChatRunSocket(runtimeTransport())?.emit('run.promote', {
       session_id: sessionId,
       queue_id: messageId,
     })
@@ -3290,6 +3299,9 @@ export const useChatStore = defineStore('chat', () => {
           models: group.models,
         })),
         queue_id: userMsg.id,
+        // 普通发送默认排队不打断;只有用户通过"立即发送"/ESC 显式放行时
+        // (promoteQueuedMessage 走 run.promote)才打断当前回复。
+        preempt: false,
         workspace: activeSession.value?.workspace || undefined,
         category_id: activeSession.value?.categoryId ?? null,
         source: sessionSource,
@@ -5123,8 +5135,9 @@ export const useChatStore = defineStore('chat', () => {
     subagentStreams,
     getSubagentStream,
     removeQueuedMessage,
-    insertQueuedMessage,
-    setMessageReference,
+        insertQueuedMessage,
+        promoteQueuedMessage,
+        setMessageReference,
     clearMessageReference,
     isLoadingSessions,
     sessionsLoaded,

--- a/packages/desktop/src/main/browser/browser-manager.ts
+++ b/packages/desktop/src/main/browser/browser-manager.ts
@@ -127,6 +127,9 @@ export class BrowserManager {
   private activeTabId: string | undefined
   private visible = false
   private bounds: BrowserBounds = { x: 0, y: 0, width: 800, height: 600 }
+  // 网页端上报的浏览器占位区域(CSS 布局坐标, 与主窗口 zoom 无关)。this.bounds
+  // 是它乘以当前 zoom 因子后的实际覆盖区, 用于 contentView 定位与 offscreen 避让。
+  private rawViewport: BrowserBounds = { x: 0, y: 0, width: 800, height: 600 }
 
   constructor(private readonly window: BrowserWindow, stateRoot: string, private readonly options?: BrowserManagerOptions) {
     this.profileStore = new BrowserProfileStore(stateRoot)
@@ -160,7 +163,7 @@ export class BrowserManager {
   }
 
   setViewport(bounds: BrowserBounds, visible: boolean): DesktopBrowserState {
-    this.bounds = {
+    this.rawViewport = {
       x: Math.max(0, Math.round(bounds.x)),
       y: Math.max(0, Math.round(bounds.y)),
       width: Math.max(1, Math.round(bounds.width)),
@@ -170,6 +173,23 @@ export class BrowserManager {
     this.syncViews()
     this.emitState()
     return this.state()
+  }
+
+  // 主窗口 zoom 变化时由主进程调用, 重算浏览器 view 的覆盖区与内容缩放, 消除
+  // 与放大后主 UI 的错位(zoom 不影响布局坐标, 网页端不会自动重报 viewport)。
+  applyDesktopZoom(): void {
+    this.syncViews()
+  }
+
+  private effectiveBounds(): BrowserBounds {
+    const factor = this.window.webContents.getZoomFactor()
+    const viewport = this.rawViewport
+    return {
+      x: Math.round(viewport.x * factor),
+      y: Math.round(viewport.y * factor),
+      width: Math.max(1, Math.round(viewport.width * factor)),
+      height: Math.max(1, Math.round(viewport.height * factor)),
+    }
   }
 
   async createTab(url = 'about:blank', activate = true): Promise<DesktopBrowserTab> {
@@ -948,7 +968,12 @@ export class BrowserManager {
   }
 
   private syncViews(): void {
+    this.bounds = this.effectiveBounds()
+    const browserZoomFactor = this.window.webContents.getZoomFactor()
     for (const [id, record] of this.records) {
+      if (record.view.webContents.getZoomFactor() !== browserZoomFactor) {
+        record.view.webContents.setZoomFactor(browserZoomFactor)
+      }
       const userVisible = this.visible && id === this.activeTabId
       if (userVisible) {
         record.view.setBounds(this.bounds)

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -15,7 +15,7 @@ import {
   type OpenDialogOptions,
   type IpcMainInvokeEvent,
 } from 'electron'
-import { existsSync } from 'node:fs'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { startWebUiServer, stopWebUiServer, getToken } from './webui-server'
 import { bundledNode, desktopIcon, desktopMacTrayIcon, desktopRuntimeVersion, desktopWindowsTrayIcon, hermesBinExists, hermesBin, runtimeStorageRoot, webuiDir, webUiHome } from './paths'
@@ -463,6 +463,65 @@ function createTray() {
   updateTrayMenu()
 }
 
+// ── [zoom patch] Windows 桌面端字体缩放 ──────────────────────────────
+// 上游把 Windows/Linux 的原生菜单整体移除了（Menu.setApplicationMenu(null)），
+// 导致 Electron 默认的缩放快捷键 Ctrl+= / Ctrl+- / Ctrl+0 一并失效。
+// 这里在主进程用 before-input-event 重新注册 Ctrl+加号 / Ctrl+减号 / Ctrl+0，
+// 通过 webContents.setZoomLevel() 缩放整个界面字体/UI，并持久化级别。
+// 只对 Windows 生效；macOS 保留系统默认菜单的缩放。
+const ZOOM_STEP = 0.5
+const ZOOM_MIN = -3
+const ZOOM_MAX = 4
+function desktopZoomStatePath(): string {
+  return join(app.getPath('userData'), 'desktop-zoom.json')
+}
+function loadDesktopZoomLevel(): number {
+  try {
+    const parsed = JSON.parse(readFileSync(desktopZoomStatePath(), 'utf8')) as { level?: unknown }
+    const level = Number(parsed?.level)
+    return Number.isFinite(level) ? Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, level)) : 0
+  } catch {
+    return 0
+  }
+}
+function saveDesktopZoomLevel(level: number): void {
+  try {
+    writeFileSync(desktopZoomStatePath(), JSON.stringify({ level }), 'utf8')
+  } catch (err) {
+    console.warn('[desktop-zoom] failed to persist zoom level:', err)
+  }
+}
+function installDesktopZoomShortcuts(target: BrowserWindow): void {
+  if (process.platform !== 'win32') return
+  const applyZoom = (delta: number): void => {
+    if (target.isDestroyed()) return
+    const next = Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, target.webContents.getZoomLevel() + delta))
+    target.webContents.setZoomLevel(next)
+    saveDesktopZoomLevel(next)
+  }
+  const resetZoom = (): void => {
+    if (target.isDestroyed()) return
+    target.webContents.setZoomLevel(0)
+    saveDesktopZoomLevel(0)
+  }
+  target.webContents.on('before-input-event', (event, input) => {
+    if (input.type !== 'keyDown' || !input.control) return
+    const key = input.key
+    if (key === '+' || key === '=' || key === 'Add') {
+      event.preventDefault()
+      applyZoom(ZOOM_STEP)
+    } else if (key === '-' || key === 'Subtract') {
+      event.preventDefault()
+      applyZoom(-ZOOM_STEP)
+    } else if (key === '0') {
+      event.preventDefault()
+      resetZoom()
+    }
+  })
+  const saved = loadDesktopZoomLevel()
+  if (saved !== 0) target.webContents.setZoomLevel(saved)
+}
+
 async function createWindow(): Promise<void> {
   mainWindow = new BrowserWindow({
     width: 1280,
@@ -511,6 +570,9 @@ async function createWindow(): Promise<void> {
   mainWindow.on('restore', () => notifyWindowStateChanged(mainWindow))
 
   installSelectionContextMenu(mainWindow)
+
+  // [zoom patch] 主窗口启用 Ctrl+加号/减号 缩放
+  installDesktopZoomShortcuts(mainWindow)
 
   // External links → system browser
   mainWindow.webContents.setWindowOpenHandler(({ url, frameName }) => {
@@ -600,6 +662,9 @@ async function openChatWindow(sessionIdInput: unknown, profileInput?: unknown): 
   chatWindow.on('closed', () => {
     if (chatWindows.get(windowKey) === chatWindow) chatWindows.delete(windowKey)
   })
+
+  // [zoom patch] 聊天窗口同样支持 Ctrl+加号/减号 缩放
+  installDesktopZoomShortcuts(chatWindow)
 
   installSelectionContextMenu(chatWindow)
   chatWindow.webContents.setWindowOpenHandler(({ url: targetUrl, frameName }) => {

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -498,11 +498,13 @@ function installDesktopZoomShortcuts(target: BrowserWindow): void {
     const next = Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, target.webContents.getZoomLevel() + delta))
     target.webContents.setZoomLevel(next)
     saveDesktopZoomLevel(next)
+    if (target === mainWindow) browserManager?.applyDesktopZoom()
   }
   const resetZoom = (): void => {
     if (target.isDestroyed()) return
     target.webContents.setZoomLevel(0)
     saveDesktopZoomLevel(0)
+    if (target === mainWindow) browserManager?.applyDesktopZoom()
   }
   target.webContents.on('before-input-event', (event, input) => {
     if (input.type !== 'keyDown' || !input.control) return
@@ -519,7 +521,10 @@ function installDesktopZoomShortcuts(target: BrowserWindow): void {
     }
   })
   const saved = loadDesktopZoomLevel()
-  if (saved !== 0) target.webContents.setZoomLevel(saved)
+  if (saved !== 0) {
+    target.webContents.setZoomLevel(saved)
+    if (target === mainWindow) browserManager?.applyDesktopZoom()
+  }
 }
 
 async function createWindow(): Promise<void> {

--- a/packages/server/src/services/hermes/run-chat/abort.ts
+++ b/packages/server/src/services/hermes/run-chat/abort.ts
@@ -114,6 +114,8 @@ export async function handleAbort(
 
   const runId = activeState.runId
   activeState.isAborting = true
+  // [preempt patch] 新一轮 abort 重置幂等标志,使本轮 markAbortCompleted 只生效一次
+  activeState.abortFinalized = false
   replaceState(sessionMap, sessionId, 'abort.started', {
     event: 'abort.started',
     run_id: runId,
@@ -224,6 +226,15 @@ export async function markAbortCompleted(
 ) {
   const state = sessionMap.get(sessionId)
   if (!state) return
+  // [preempt patch] 幂等保护:handleAbort 和 bridge terminal chunk 都会被触发
+  // markAbortCompleted。重复执行会清掉刚启动的下一条 run 的状态(activeRunMarker/
+  // runId),使 bridge 端 run 悬空,后续新消息撞 "already running"。标记为事务性:
+  // 在第一个 await 之前原子置位,并发第二次调用直接跳过。
+  if (state.abortFinalized) {
+    logger.info({ sessionId, runId }, '[chat-run-socket][abort] markAbortCompleted skipped, already finalized')
+    return
+  }
+  state.abortFinalized = true
 
   const profile = state.profile
   updateSessionStats(sessionId)
@@ -263,6 +274,7 @@ export async function markAbortCompleted(
     emitToSession(nsp, socket, sessionId, 'run.queued', {
       event: 'run.queued',
       queue_length: state.queue.length,
+      dequeued_queue_id: next.queue_id,
     })
     state.events = []
     runQueuedItem(socket, sessionId, next, profile || 'default')

--- a/packages/server/src/services/hermes/run-chat/index.ts
+++ b/packages/server/src/services/hermes/run-chat/index.ts
@@ -356,6 +356,9 @@ export class ChatRunSocket {
       allow_command_passthrough?: boolean
       // Local patch (reasoning-effort): per-session reasoning effort override.
       reasoning_effort?: string
+      // Local patch (user-controlled queue): true = 用户主动放行(打断当前、
+      // 插队到队首立即执行);缺省/false = 普通发送,仅入队尾排队等待。
+      preempt?: boolean
     }) => {
       let runProfile: string
       try {
@@ -415,8 +418,10 @@ export class ChatRunSocket {
           }
         }
         if (state.isWorking) {
+          logger.info('[chat-run-socket][preempt] new run during active session %s (isWorking=%s isAborting=%s runId=%s qlen=%d)',
+            data.session_id, state.isWorking, state.isAborting, state.runId, state.queue.length)
           const queueId = data.queue_id || `queue_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`
-          state.queue.push({
+          const queuedRun: QueuedRun = {
             queue_id: queueId,
             input: data.input,
             displayInput: data.display_input,
@@ -449,28 +454,56 @@ export class ChatRunSocket {
             commandPassthrough: data.allow_command_passthrough,
             reasoningEffort: data.reasoning_effort,
             originSocketId: socket.id,
-          })
-          const queuedPayload = {
-            event: 'run.queued',
-            session_id: data.session_id,
-            queue_id: queueId,
-            queue_length: state.queue.length,
-            queued_messages: this.serializeQueuedMessages(state.queue),
-          }
-          observeChatRunWebhookEvent({
-            event: 'run.queued',
-            sessionId: data.session_id,
-            profile: runProfile,
-            source,
-            agent: webhookAgentForRun(data),
-            payload: queuedPayload,
-            roomId: data.group_room_id,
-            workflowId: data.workflow_id,
-            workflowNodeId: data.workflow_node_id,
-          })
-          this.nsp.to(`session:${data.session_id}`).emit('run.queued', queuedPayload)
-          logger.info('[chat-run-socket] queued run for session %s (queue: %d)', data.session_id, state.queue.length)
-          return
+                      }
+                      // [user-controlled patch] 两种行为:
+                      //  - data.preempt === true(用户通过"立即发送"按钮 / ESC 显式放行):
+                      //    插队到队首并打断当前 run,让该消息立即开始回复。
+                      //  - 缺省(普通发送):只 push 到队尾排队等待,不打断当前生成,
+                      //    当前 run 完成后的 dequeueNextQueuedRun 会按序自动拾取。
+                      if (data.preempt === true) {
+                        state.queue.unshift(queuedRun)
+                        if (state.isAborting) {
+                          this.nsp.to(`session:${data.session_id}`).emit('run.queued', {
+                            event: 'run.queued',
+                            session_id: data.session_id,
+                            queue_length: state.queue.length,
+                            queued_messages: this.serializeQueuedMessages(state.queue),
+                          })
+                          logger.info('[chat-run-socket] preempt queued run while already aborting for session %s (queue: %d)', data.session_id, state.queue.length)
+                          return
+                        }
+                        logger.info('[chat-run-socket] preempting running session %s with new run (queue: %d)', data.session_id, state.queue.length)
+                        await handleAbort(this.nsp, socket, data.session_id, this.sessionMap, this.bridge, this.runQueuedItem.bind(this))
+                        // 兜底:handleAbort 若因"无活动 run"被忽略,手动出队队首(新消息)
+                        const preempted = this.sessionMap.get(data.session_id)
+                        if (preempted && !preempted.isWorking && preempted.queue.length > 0) {
+                          this.dequeueNextQueuedRun(socket, data.session_id, runProfile)
+                        }
+                        return
+                      }
+                      // 默认:排队等待,不打断当前回复
+                      state.queue.push(queuedRun)
+                      const queuedPayload = {
+                        event: 'run.queued',
+                        session_id: data.session_id,
+                        queue_id: queueId,
+                        queue_length: state.queue.length,
+                        queued_messages: this.serializeQueuedMessages(state.queue),
+                      }
+                      observeChatRunWebhookEvent({
+                        event: 'run.queued',
+                        sessionId: data.session_id,
+                        profile: runProfile,
+                        source,
+                        agent: webhookAgentForRun(data),
+                        payload: queuedPayload,
+                        roomId: data.group_room_id,
+                        workflowId: data.workflow_id,
+                        workflowNodeId: data.workflow_node_id,
+                      })
+                      this.nsp.to(`session:${data.session_id}`).emit('run.queued', queuedPayload)
+                      logger.info('[chat-run-socket] queued run for session %s (queue: %d)', data.session_id, state.queue.length)
+                      return
         }
         state.events = []
         state.isWorking = !isCodingAgentExecution(source, data)
@@ -549,6 +582,28 @@ export class ChatRunSocket {
       })
       logger.info('[chat-run-socket] cancelled queued run %s for session %s (queue: %d)',
         data.queue_id, data.session_id, state.queue.length)
+    })
+
+    // [user-controlled patch] 立即发送:把指定排队消息提升到队首并打断当前 run,
+    // 使其马上开始回复(markAbortCompleted 出队队首即该消息)。前端"立即发送"
+    // 按钮与 ESC 放行都走这个事件。
+    socket.on('run.promote', async (data: { session_id?: string; queue_id?: string }) => {
+      if (!data.session_id || !data.queue_id) return
+      const state = this.sessionMap.get(data.session_id)
+      if (!state || !state.queue.length) return
+      const targetIndex = state.queue.findIndex(item => item.queue_id === data.queue_id)
+      if (targetIndex === -1) {
+        logger.info('[chat-run-socket] promote miss %s for session %s (queue: %d)', data.queue_id, data.session_id, state.queue.length)
+        return
+      }
+      const [target] = state.queue.splice(targetIndex, 1)
+      state.queue.unshift(target)
+      logger.info('[chat-run-socket] promote %s to head for session %s (queue: %d)', data.queue_id, data.session_id, state.queue.length)
+      await handleAbort(this.nsp, socket, data.session_id, this.sessionMap, this.bridge, this.runQueuedItem.bind(this))
+      const after = this.sessionMap.get(data.session_id)
+      if (after && !after.isWorking && after.queue.length > 0) {
+        this.dequeueNextQueuedRun(socket, data.session_id, target.profile || 'default')
+      }
     })
 
     socket.on('resume', async (data: { session_id?: string }) => {

--- a/packages/server/src/services/hermes/run-chat/types.ts
+++ b/packages/server/src/services/hermes/run-chat/types.ts
@@ -111,6 +111,10 @@ export interface SessionState {
   contextTokens?: number
   bridgeContext?: BridgeContextState
   isAborting?: boolean
+  /** [preempt patch] 幂等保护:同一轮 abort 的 markAbortCompleted 只执行一次。
+   *  handleAbort 与 bridge terminal chunk 的 markAbortCompleted 会并发触发,
+   *  不加保护会把刚启动的下一条 run 的 activeRunMarker/runId 清掉。 */
+  abortFinalized?: boolean
   queue: QueuedRun[]
   queueInsertion?: QueueInsertionControl
   responseRun?: ResponseRunState


### PR DESCRIPTION
# feat: Windows desktop zoom shortcuts (Ctrl+Plus/Minus) + user-controlled chat message queue

This PR contributes two independent features that have been running in production on our fork (`stevenwang288/hermes-studio`) for weeks. Both are self-contained, minimally invasive patches. Each can be cherry-picked separately.

## Feature 1: Windows desktop font zoom shortcuts (Ctrl+Plus / Ctrl+Minus / Ctrl+0)

**Problem:** The desktop app removes the native menu (`Menu.setApplicationMenu(null)`) on Windows, which also kills Electron's default zoom shortcuts (`Ctrl+=` / `Ctrl+-` / `Ctrl+0`) that live in the View menu. Users on Windows cannot scale the UI font at all.

**Solution:** Re-register the shortcuts in the main process via `webContents.on('before-input-event')`:
- `Ctrl+=` / `Ctrl++` / numpad `Ctrl+Add` → zoom in (step 0.5)
- `Ctrl+-` / numpad `Ctrl+Subtract` → zoom out (step 0.5)
- `Ctrl+0` → reset to 100%
- Range clamped to `ZOOM_MIN=-3` (~12.5%) … `ZOOM_MAX=4` (~400%)
- Zoom level persisted to `userData/desktop-zoom.json`, restored on restart
- Platform-gated to `win32` only (macOS keeps the native menu zoom)
- Installed for both the main window and the standalone chat window

Files:
- `packages/desktop/src/main/index.ts` (+67): zoom helpers + shortcut registration + mount calls
- `packages/desktop/src/main/browser/browser-manager.ts` (+27): keep the embedded Agent browser's view bounds in sync with zoomFactor (`bounds × zoomFactor` + `webContents.setZoomLevel`) so agent click/type coordinates stay correct after zooming

## Feature 2: User-controlled chat message queue (type-ahead while the model is replying)

**Problem:** While the current reply is streaming (`isWorking`), sending a new message **interrupts** the reply, discarding output the user may want to keep. Long-reply scenarios are painful: you can only wait or kill the response.

**Solution:** Provide a queue + explicit user-controlled release:
- Normal send while `isWorking` → message goes to a queue (frontend + backend), **does not** interrupt the running reply. When the current run finishes, the next queued message is picked up automatically.
- **Three explicit release gestures**, each advances exactly one message to the head and interrupts the current run immediately:
  - the "↑ immediate send" button on the queued item
  - pressing **ESC** in the input box
  - pressing **Ctrl+Enter** (Cmd+Enter on macOS)
- New `run.promote` socket event: move the referenced queued message to the head and abort the current run; `markAbortCompleted` dequeues the head (the promoted message) and starts it right away.
- Abort idempotency guard (`abortFinalized`): `handleAbort` and bridge terminal chunk can concurrently trigger `markAbortCompleted`; without the guard the second call would wipe the freshly-started next run's state, leaving the bridge run dangling ("already running" on subsequent sends).
- Frontend optimistic UI: promote removes the item from the queue panel immediately (no waiting for server round-trip) and replaces the authoritative queue on `run.queued` events for eventual consistency.

Files:
- `packages/server/src/services/hermes/run-chat/index.ts` (+101): `preempt?: boolean` routing (true=interrupt-and-run-head / default=queue-at-tail), new `run.promote` handler
- `packages/server/src/services/hermes/run-chat/abort.ts` (+12): `abortFinalized` idempotency guard; dequeues head with `dequeued_queue_id`
- `packages/server/src/services/hermes/run-chat/types.ts` (+4): `SessionState.abortFinalized?: boolean`
- `packages/client/src/stores/hermes/chat.ts` (+19): send with `preempt:false`; `promoteQueuedMessage` action emitting `run.promote`
- `packages/client/src/components/hermes/chat/ChatInput.vue` (+25): ESC / Ctrl+Enter release hotkeys
- `packages/client/src/components/hermes/chat/MessageList.vue` (+96): queue float panel with "↑ immediate send" button
- `packages/client/src/api/hermes/chat.ts` (+3): `StartRunRequest.preempt?: boolean`

### Behavior
- Reply in progress + send new message → shows as "queued", current reply is **not** interrupted.
- ESC / ↑ / Ctrl+Enter → releases one queued message immediately, interrupting the current reply.
- When the current reply completes normally, queued messages run in order automatically.

---

**Verification:** built on top of upstream `main` (`c246ba64`); `npm run build` passes. Both features have been exercised in production on our fleet (5 nodes: Linux web builds + Windows desktop exe) since August 2026.

**Merge strategy:** two independent commit groups, cherry-pick freely:
- `b7ada13b` + `86aa32cc` → zoom feature
- `afdfc3de` → message queue feature