### PR TITLE
fix(client): keep mobile custom-background drawers opaque

### DIFF
--- a/packages/client/src/App.vue
+++ b/packages/client/src/App.vue
@@ -438,6 +438,20 @@ useKeyboard();
     backdrop-filter: blur(8px) saturate(110%);
   }
 
+  @media (max-width: $breakpoint-mobile) {
+    :deep(.sidebar),
+    :deep(.hermes-config-sidebar),
+    :deep(.ekko-config-sidebar),
+    :deep(.chat-panel > .session-list),
+    :deep(.history-panel > .session-list),
+    :deep(.group-chat-panel > .room-sidebar),
+    :deep(.workflow-view > .workflow-sidebar) {
+      background-color: var(--bg-sidebar-surface);
+      -webkit-backdrop-filter: none;
+      backdrop-filter: none;
+    }
+  }
+
   :deep(.history-panel > .chat-main),
   :deep(.workflow-view > .workflow-main) {
     background-color: rgba(var(--bg-main-surface-rgb), 0.72);

--- a/tests/client/style-system.test.ts
+++ b/tests/client/style-system.test.ts
@@ -181,4 +181,15 @@ describe('client style system', () => {
     )
   })
 
+  it('keeps mobile custom-background drawers opaque instead of glassy', () => {
+    const app = readClientFile('App.vue')
+    const customBackgroundStyles = app
+      .split('.app-shell--custom-background {')[1]
+      ?.split('.app-shell.desktop-platform-darwin')[0]
+
+    expect(customBackgroundStyles).toMatch(
+      /@media \(max-width: \$breakpoint-mobile\) \{[\s\S]*:deep\(\.sidebar\),[\s\S]*:deep\(\.hermes-config-sidebar\),[\s\S]*:deep\(\.ekko-config-sidebar\),[\s\S]*:deep\(\.chat-panel > \.session-list\),[\s\S]*:deep\(\.history-panel > \.session-list\),[\s\S]*:deep\(\.group-chat-panel > \.room-sidebar\),[\s\S]*:deep\(\.workflow-view > \.workflow-sidebar\) \{[\s\S]*background-color: var\(--bg-sidebar-surface\);[\s\S]*-webkit-backdrop-filter: none;[\s\S]*backdrop-filter: none;/,
+    )
+  })
+
 })


### PR DESCRIPTION
## Summary
- Keep mobile drawers opaque when custom background mode is enabled so the overlay stays readable and tappable on <=768px viewports.
- Preserve the existing glass treatment on desktop while adding a mobile-only override in `App.vue`.
- Add a regression test that asserts the mobile custom-background override is present in the client style contract.

Closes #2806

## Validation
- `npx vitest run tests/client/style-system.test.ts`
- `npm run build`