### PR TITLE
fix(desktop): keep the desktop window from stealing focus on startup

### DIFF
--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -107,9 +107,10 @@ function showWindowWithFade(focus = true) {
   if (mainWindow.isMinimized()) mainWindow.restore()
 
   cancelWindowFade()
+  const showWindow = focus ? () => mainWindow.show() : () => mainWindow.showInactive()
   if (process.platform !== 'win32' || mainWindow.isVisible()) {
     mainWindow.setOpacity(1)
-    mainWindow.show()
+    showWindow()
     if (focus) mainWindow.focus()
     return
   }
@@ -117,7 +118,7 @@ function showWindowWithFade(focus = true) {
   const durationMs = 180
   const startedAt = Date.now()
   mainWindow.setOpacity(0)
-  mainWindow.show()
+  showWindow()
   if (focus) mainWindow.focus()
   windowFadeTimer = setInterval(() => {
     if (!mainWindow || mainWindow.isDestroyed()) {
@@ -517,7 +518,7 @@ async function createWindow(): Promise<void> {
   })
 
   mainWindow.once('ready-to-show', () => {
-    if (!START_HIDDEN) showWindowWithFade(true)
+    if (!START_HIDDEN) showWindowWithFade(false)
   })
 
   mainWindow.webContents.on('render-process-gone', (_event, details) => {

--- a/tests/desktop/windows-main-window.test.ts
+++ b/tests/desktop/windows-main-window.test.ts
@@ -20,4 +20,13 @@ describe('Windows desktop main window', () => {
     expect(createWindowBody).not.toContain('transparent: true')
     expect(petWindowBody).toContain('transparent: true')
   })
+
+  it('shows the desktop window without stealing focus on the automatic ready-to-show path', () => {
+    const source = readFileSync(resolve('packages/desktop/src/main/index.ts'), 'utf8')
+    const createWindowBody = source.match(/async function createWindow\(\): Promise<void> \{([\s\S]*?)\n\}/)?.[1] || ''
+    const showWindowBody = source.match(/function showWindowWithFade\(focus = true\) \{([\s\S]*?)\n\}/)?.[1] || ''
+
+    expect(createWindowBody).toContain('showWindowWithFade(false)')
+    expect(showWindowBody).toContain('mainWindow.showInactive()')
+  })
 })


### PR DESCRIPTION
## Summary
- Keep the desktop window visible on startup without stealing focus on Windows.
- Preserve explicit foreground activation when the user clicks tray, notifications, or second-instance entry points.

Closes #2835

## Validation
- `npm test -- tests/desktop/windows-main-window.test.ts tests/desktop/chat-window.test.ts`
- `npm run harness:check`
- `npm run build`