### PR TITLE
fix(server): stop env parser regex from crossing lines on empty values

### DIFF
--- a/packages/server/src/modules/hermes/controllers/models.ts
+++ b/packages/server/src/modules/hermes/controllers/models.ts
@@ -199,12 +199,12 @@ function profileAuthPath(profile: string): string {
 function envReader(envContent: string) {
   const envHasValue = (key: string): boolean => {
     if (!key) return false
-    const match = envContent.match(new RegExp(`^${key}\\s*=\\s*(.+)`, 'm'))
+    const match = envContent.match(new RegExp(`^${key}\\s*=[ \\t]*(.+)`, 'm'))
     return !!match && match[1].trim() !== '' && !match[1].trim().startsWith('#')
   }
   const envGetValue = (key: string): string => {
     if (!key) return ''
-    const match = envContent.match(new RegExp(`^${key}\\s*=\\s*(.+)`, 'm'))
+    const match = envContent.match(new RegExp(`^${key}\\s*=[ \\t]*(.+)`, 'm'))
     return match?.[1]?.trim() || ''
   }
   return { envHasValue, envGetValue }
@@ -681,12 +681,12 @@ export async function getAvailable(ctx: any) {
 
     const envHasValue = (key: string): boolean => {
       if (!key) return false
-      const match = envContent.match(new RegExp(`^${key}\\s*=\\s*(.+)`, 'm'))
+      const match = envContent.match(new RegExp(`^${key}\\s*=[ \\t]*(.+)`, 'm'))
       return !!match && match[1].trim() !== '' && !match[1].trim().startsWith('#')
     }
     const envGetValue = (key: string): string => {
       if (!key) return ''
-      const match = envContent.match(new RegExp(`^${key}\\s*=\\s*(.+)`, 'm'))
+      const match = envContent.match(new RegExp(`^${key}\\s*=[ \\t]*(.+)`, 'm'))
       return match?.[1]?.trim() || ''
     }
     const addGroup = (provider: string, label: string, base_url: string, models: string[], api_key: string, builtin?: boolean, model_meta?: Record<string, ModelMeta>, extra?: Pick<AvailableGroup, 'provider_source' | 'provider_key'>) => {

--- a/packages/server/src/modules/hermes/services/providers/copilot-models.ts
+++ b/packages/server/src/modules/hermes/services/providers/copilot-models.ts
@@ -76,7 +76,7 @@ function unquote(raw: string): string {
 
 function readEnvVar(envContent: string, key: string): string {
   if (process.env[key]) return unquote(process.env[key]!)
-  const m = envContent.match(new RegExp(`^${key}\\s*=\\s*(.+)`, 'm'))
+  const m = envContent.match(new RegExp(`^${key}\\s*=[ \\t]*(.+)`, 'm'))
   if (m && m[1].trim() && !m[1].trim().startsWith('#')) return unquote(m[1])
   return ''
 }

--- a/tests/server/copilot-models.test.ts
+++ b/tests/server/copilot-models.test.ts
@@ -78,6 +78,15 @@ describe('resolveCopilotOAuthToken', () => {
     expect(await resolveCopilotOAuthToken('GH_TOKEN=# comment\n')).toBe('')
   })
 
+  it('空值 KEY 不跨行吞掉下一行内容（回归：env 正则 \\s 跨行 bug）', async () => {
+    // 回归场景：GH_TOKEN 为空值时，修复前的 /^GH_TOKEN\s*=\s*(.+)/ 中 \s* 包含换行符，
+    // 会跨过换行把下一行整行（含 KEY 名前缀）当成 GH_TOKEN 的值，
+    // 错误返回 'GITHUB_TOKEN=gho_github' 而非真正的 'gho_github'。
+    // 修复（\s* → [ \t]*）后 GH_TOKEN 无值应继续落到下一优先级 GITHUB_TOKEN。
+    const env = 'GH_TOKEN=\nGITHUB_TOKEN=gho_github\n'
+    expect(await resolveCopilotOAuthToken(env)).toBe('gho_github')
+  })
+
   it('回退到 ~/.config/github-copilot/apps.json 的 oauth_token', async () => {
     mockReadFile.mockImplementation(async (p: string) => {
       if (p.includes('apps.json')) {


### PR DESCRIPTION
## Problem

`/api/hermes/available-models` returned a corrupted `base_url` for the `kimi-coding` provider:

```
base_url: "WEIXIN_APP_ID=OmMEJ2Z4pcuNa42"   # ← a stray line from .env, not a URL
```

The `.env` in question contained:

```
KIMI_BASE_URL=          ← empty value
WEIXIN_APP_ID=OmMEJ2Z4pcuNa42
```

## Root cause

The `.env` value regex used `\s*` between `=` and the capture group:

```js
envContent.match(new RegExp(`^${key}\\s*=\\s*(.+)`, 'm'))
```

In JavaScript, `\s` **includes line terminators**. When a key has an empty value
(e.g. `KIMI_BASE_URL=`), the `\s*` after `=` consumed the newline and `(.+)`
captured the **entire next line, including its key name**, as the value.

The same broken pattern existed in:

- `controllers/models.ts` — both copies of `envHasValue` / `envGetValue` (two separate `envReader` blocks)
- `services/providers/copilot-models.ts` — `readEnvVar()`

## Fix

Restrict the separator to spaces/tabs so values stay on the same line as their key:

```js
new RegExp(`^${key}\\s*=[ \\t]*(.+)`, 'm')
```

## Verification

- New regression test: an empty `GH_TOKEN` followed by a real `GITHUB_TOKEN` now resolves to the real token. **Before the fix this test fails** — it returns the literal string `GITHUB_TOKEN=gho_github`; after the fix it returns `gho_github`.
- `npx vitest run tests/server/copilot-models.test.ts tests/server/model-visibility-controller.test.ts tests/server/provider-editor.test.ts tests/server/provider-editor-controller.test.ts tests/server/provider-model-refresh.test.ts` → **77/77 passed**
- Live check: after the fix, `available-models` reports `kimi-coding` `base_url` as the correct preset `https://api.kimi.com/coding/v1` instead of the stray `.env` line.
