### PR TITLE
fix: stop idle Runtime polling and restrict it to super admins

### DIFF
--- a/packages/client/src/App.vue
+++ b/packages/client/src/App.vue
@@ -23,6 +23,7 @@ import { useSessionSearch } from "@/composables/useSessionSearch";
 import { watchServerTtsSettingsHydration } from "@/composables/useTtsSettingsHydration";
 import { useAppStore } from "@/stores/hermes/app";
 import { useProfilesStore } from "@/stores/hermes/profiles";
+import { isStoredSuperAdmin } from "@/api/client";
 import AuthEventListener from "@/components/auth/AuthEventListener.vue";
 import { desktopBridge } from "@/utils/desktop-bridge";
 import { naiveLocaleFor } from "@/constants/naiveLocale";
@@ -341,7 +342,7 @@ useKeyboard();
             v-if="!isLoginPage && !isDesktopPetRoute && !isStandaloneChatPage"
           />
           <RuntimeRestartPrompt
-            v-if="!isLoginPage && !isDesktopPetRoute && !isStandaloneChatPage"
+            v-if="!isLoginPage && !isDesktopPetRoute && !isStandaloneChatPage && isStoredSuperAdmin()"
           />
         </NNotificationProvider>
       </NDialogProvider>

--- a/packages/client/src/components/layout/RuntimeRestartPrompt.vue
+++ b/packages/client/src/components/layout/RuntimeRestartPrompt.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onBeforeUnmount, onMounted, ref } from 'vue'
+import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { NButton, NCard, NModal, useMessage } from 'naive-ui'
 import { useI18n } from 'vue-i18n'
 import {
@@ -7,6 +7,7 @@ import {
   restartWebUiAfterRuntimeChange,
 } from '@/api/hermes/runtime-versions'
 import { useRuntimeRestartPrompt } from '@/composables/useRuntimeRestartPrompt'
+import { isStoredSuperAdmin } from '@/api/client'
 import { desktopBridge } from '@/utils/desktop-bridge'
 
 const POLL_INTERVAL_MS = 2000
@@ -15,13 +16,17 @@ const HANDLED_JOBS_KEY = 'hermes-runtime-restart-handled-jobs'
 const { t } = useI18n()
 const message = useMessage()
 const {
+  runtimeDownloadCheckRevision,
   pendingRuntimeRestart,
   requestRuntimeRestart,
   clearRuntimeRestart,
 } = useRuntimeRestartPrompt()
 const restarting = ref(false)
 const handledJobIds = new Set<string>()
-let pollTimer: ReturnType<typeof setInterval> | null = null
+let mounted = false
+let checking = false
+let checkRequested = false
+let pollTimer: ReturnType<typeof setTimeout> | null = null
 let restartWaitTimer: ReturnType<typeof setInterval> | null = null
 
 function restoreHandledJobs() {
@@ -45,9 +50,26 @@ function rememberHandledJob(jobId?: string) {
   }
 }
 
+function stopPolling() {
+  if (pollTimer) clearTimeout(pollTimer)
+  pollTimer = null
+}
+
 async function checkCompletedRuntimeDownloads() {
+  stopPolling()
+  if (!mounted || !isStoredSuperAdmin()) return
+  if (checking) {
+    checkRequested = true
+    return
+  }
+  checking = true
+  let hasRunningJobs = false
   try {
     const response = await fetchVersionDownloadJobs()
+    if (!mounted || !isStoredSuperAdmin()) return
+    hasRunningJobs = response.jobs.some(job =>
+      job.kind === 'runtime' && (job.status === 'queued' || job.status === 'running'),
+    )
     const completed = response.jobs.filter(job =>
       job.kind === 'runtime'
       && job.status === 'completed'
@@ -61,9 +83,27 @@ async function checkCompletedRuntimeDownloads() {
     for (const job of completed.slice(1)) rememberHandledJob(job.id)
     requestRuntimeRestart(completed[0].version, completed[0].id)
   } catch {
-    // Authentication and transient network failures are retried by the poller.
+    // Stop on errors, including denied access. Opening version management or
+    // starting a download explicitly retries without an endless error loop.
+    checkRequested = false
+  } finally {
+    checking = false
+    if (mounted && isStoredSuperAdmin()) {
+      if (checkRequested) {
+        checkRequested = false
+        void checkCompletedRuntimeDownloads()
+      } else if (hasRunningJobs) {
+        pollTimer = setTimeout(() => {
+          void checkCompletedRuntimeDownloads()
+        }, POLL_INTERVAL_MS)
+      }
+    }
   }
 }
+
+watch(runtimeDownloadCheckRevision, () => {
+  void checkCompletedRuntimeDownloads()
+})
 
 function restartStandaloneWebUi() {
   let attempts = 0
@@ -89,7 +129,7 @@ function restartStandaloneWebUi() {
 }
 
 async function restartNow() {
-  if (!pendingRuntimeRestart.value || restarting.value) return
+  if (!isStoredSuperAdmin() || !pendingRuntimeRestart.value || restarting.value) return
   restarting.value = true
   try {
     const bridge = desktopBridge()
@@ -113,15 +153,14 @@ function restartLater() {
 }
 
 onMounted(() => {
+  mounted = true
   restoreHandledJobs()
   void checkCompletedRuntimeDownloads()
-  pollTimer = setInterval(() => {
-    void checkCompletedRuntimeDownloads()
-  }, POLL_INTERVAL_MS)
 })
 
 onBeforeUnmount(() => {
-  if (pollTimer) clearInterval(pollTimer)
+  mounted = false
+  stopPolling()
   if (restartWaitTimer) clearInterval(restartWaitTimer)
 })
 </script>

--- a/packages/client/src/components/layout/VersionManagementModal.vue
+++ b/packages/client/src/components/layout/VersionManagementModal.vue
@@ -25,7 +25,7 @@ const emit = defineEmits<{ (event: 'update:show', value: boolean): void }>()
 
 const { t } = useI18n()
 const message = useMessage()
-const { requestRuntimeRestart } = useRuntimeRestartPrompt()
+const { requestRuntimeRestart, checkRuntimeDownloads } = useRuntimeRestartPrompt()
 
 const status = ref<RuntimeVersionStatus | null>(null)
 const jobs = ref<VersionDownloadJob[]>([])
@@ -89,6 +89,7 @@ async function loadAll() {
   loadError.value = ''
   try {
     await Promise.all([loadStatus(), loadJobs()])
+    checkRuntimeDownloads()
     if (hasRunningJobs()) startPolling()
   } catch (err) {
     loadError.value = err instanceof Error ? err.message : String(err)
@@ -215,6 +216,7 @@ async function startRuntimeDownload(version: string, source: VersionDownloadSour
   await runAction(`download-runtime-${source}-${version}`, async () => {
     const response = await downloadRuntimeVersion(version, source)
     jobs.value = [response.job, ...jobs.value.filter(job => job.id !== response.job.id)]
+    checkRuntimeDownloads()
     message.success(t('runtimeVersions.downloadStarted'))
     startPolling()
   })

--- a/packages/client/src/composables/useRuntimeRestartPrompt.ts
+++ b/packages/client/src/composables/useRuntimeRestartPrompt.ts
@@ -5,6 +5,7 @@ export interface PendingRuntimeRestart {
   jobId?: string
 }
 
+const runtimeDownloadCheckRevision = ref(0)
 const pendingRuntimeRestart = ref<PendingRuntimeRestart | null>(null)
 
 export function useRuntimeRestartPrompt() {
@@ -17,7 +18,13 @@ export function useRuntimeRestartPrompt() {
     pendingRuntimeRestart.value = null
   }
 
+  function checkRuntimeDownloads() {
+    runtimeDownloadCheckRevision.value += 1
+  }
+
   return {
+    runtimeDownloadCheckRevision: readonly(runtimeDownloadCheckRevision),
+    checkRuntimeDownloads,
     pendingRuntimeRestart: readonly(pendingRuntimeRestart),
     requestRuntimeRestart,
     clearRuntimeRestart,

--- a/tests/client/app-web-pet.test.ts
+++ b/tests/client/app-web-pet.test.ts
@@ -140,6 +140,7 @@ function mountApp() {
 describe('App web pet mounting', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    localStorage.removeItem('hermes_api_key')
     routeMock.name = 'hermes.chat'
     routeMock.meta = {}
     appStoreMock.sidebarCollapsed = false
@@ -157,13 +158,20 @@ describe('App web pet mounting', () => {
     expect(sources.activeProfileName()).toBe('default')
   })
 
-  it('mounts the global pending-action host in the normal app shell', async () => {
-    const wrapper = mountApp()
-    await flushPromises()
+  it.each(['super_admin', 'admin', null] as const)(
+    'mounts pending actions but restricts the Runtime prompt for role %s', async (role) => {
+      if (role) {
+        const payload = btoa(JSON.stringify({ sub: '1', role }))
+        localStorage.setItem('hermes_api_key', `header.${payload}.signature`)
+      }
+      const wrapper = mountApp()
+      await flushPromises()
 
-    expect(wrapper.findComponent({ name: 'GlobalPendingActions' }).exists()).toBe(true)
-    expect(wrapper.findComponent({ name: 'RuntimeRestartPrompt' }).exists()).toBe(true)
-  })
+      expect(wrapper.findComponent({ name: 'GlobalPendingActions' }).exists()).toBe(true)
+      expect(wrapper.findComponent({ name: 'RuntimeRestartPrompt' }).exists()).toBe(role === 'super_admin')
+    wrapper.unmount()
+    },
+  )
 
   it('mounts the web pet in the browser web app', async () => {
     const wrapper = mountApp()

--- a/tests/client/runtime-restart-prompt.test.ts
+++ b/tests/client/runtime-restart-prompt.test.ts
@@ -9,6 +9,9 @@ const api = vi.hoisted(() => ({
 const desktop = vi.hoisted(() => ({
   bridge: null as null | { isDesktop: boolean; restartApp?: ReturnType<typeof vi.fn> },
 }))
+const auth = vi.hoisted(() => ({ isStoredSuperAdmin: vi.fn(() => true) }))
+vi.mock('@/api/client', () => auth)
+
 const message = vi.hoisted(() => ({ error: vi.fn() }))
 
 vi.mock('@/api/hermes/runtime-versions', () => api)
@@ -52,6 +55,7 @@ function completedRuntimeJob(id = 'runtime-job-1') {
 describe('RuntimeRestartPrompt', () => {
   beforeEach(() => {
     vi.useFakeTimers()
+    auth.isStoredSuperAdmin.mockReturnValue(true)
     sessionStorage.clear()
     localStorage.clear()
     useRuntimeRestartPrompt().clearRuntimeRestart()
@@ -123,4 +127,90 @@ describe('RuntimeRestartPrompt', () => {
     expect(api.restartWebUiAfterRuntimeChange).not.toHaveBeenCalled()
     second.unmount()
   })
+
+  it('never queries jobs for an ordinary administrator, even after a download notification', async () => {
+    auth.isStoredSuperAdmin.mockReturnValue(false)
+    const wrapper = mount(RuntimeRestartPrompt)
+    useRuntimeRestartPrompt().checkRuntimeDownloads()
+    await flushPromises()
+    await vi.advanceTimersByTimeAsync(10000)
+    expect(api.fetchVersionDownloadJobs).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  it('checks once on mount and stays idle when no Runtime download is active', async () => {
+    api.fetchVersionDownloadJobs.mockResolvedValue({ jobs: [] })
+    const wrapper = mount(RuntimeRestartPrompt)
+    await flushPromises()
+    await vi.advanceTimersByTimeAsync(10000)
+    expect(api.fetchVersionDownloadJobs).toHaveBeenCalledTimes(1)
+    wrapper.unmount()
+  })
+
+  it.each(['completed', 'failed'])('resumes on a new download and stops when it is %s', async (status) => {
+    api.fetchVersionDownloadJobs.mockResolvedValue({ jobs: [] })
+    const wrapper = mount(RuntimeRestartPrompt)
+    await flushPromises()
+    api.fetchVersionDownloadJobs.mockResolvedValue({ jobs: [{ ...completedRuntimeJob(), status: 'running' }] })
+    useRuntimeRestartPrompt().checkRuntimeDownloads()
+    await flushPromises()
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(api.fetchVersionDownloadJobs).toHaveBeenCalledTimes(3)
+    api.fetchVersionDownloadJobs.mockResolvedValue({ jobs: [{ ...completedRuntimeJob(), status }] })
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(wrapper.find('[data-testid="runtime-restart-prompt"]').exists()).toBe(status === 'completed')
+    await vi.advanceTimersByTimeAsync(10000)
+    expect(api.fetchVersionDownloadJobs).toHaveBeenCalledTimes(4)
+    wrapper.unmount()
+  })
+
+  it('restores a queued download after a page reload', async () => {
+    api.fetchVersionDownloadJobs.mockResolvedValue({ jobs: [{ ...completedRuntimeJob(), status: 'queued' }] })
+    const wrapper = mount(RuntimeRestartPrompt)
+    await flushPromises()
+    api.fetchVersionDownloadJobs.mockResolvedValue({ jobs: [completedRuntimeJob()] })
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(wrapper.find('[data-testid="runtime-restart-prompt"]').exists()).toBe(true)
+    await vi.advanceTimersByTimeAsync(6000)
+    expect(api.fetchVersionDownloadJobs).toHaveBeenCalledTimes(2)
+    wrapper.unmount()
+  })
+
+  it('stops after a forbidden response instead of repeatedly triggering permission errors', async () => {
+    api.fetchVersionDownloadJobs.mockResolvedValueOnce({ jobs: [{ ...completedRuntimeJob(), status: 'running' }] })
+    api.fetchVersionDownloadJobs.mockRejectedValue(Object.assign(new Error('Forbidden'), { status: 403 }))
+    const wrapper = mount(RuntimeRestartPrompt)
+    await flushPromises()
+    await vi.advanceTimersByTimeAsync(10000)
+    expect(api.fetchVersionDownloadJobs).toHaveBeenCalledTimes(2)
+    wrapper.unmount()
+  })
+
+  it('does not overlap slow requests and rechecks a download started during an in-flight check', async () => {
+    let resolve!: (value: { jobs: ReturnType<typeof completedRuntimeJob>[] }) => void
+    api.fetchVersionDownloadJobs.mockReturnValueOnce(new Promise(done => { resolve = done }))
+    const wrapper = mount(RuntimeRestartPrompt)
+    await flushPromises()
+    useRuntimeRestartPrompt().checkRuntimeDownloads()
+    await vi.advanceTimersByTimeAsync(10000)
+    expect(api.fetchVersionDownloadJobs).toHaveBeenCalledTimes(1)
+    resolve({ jobs: [] })
+    await flushPromises()
+    expect(api.fetchVersionDownloadJobs).toHaveBeenCalledTimes(2)
+    expect(wrapper.find('[data-testid="runtime-restart-prompt"]').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('ignores a response received after unmounting', async () => {
+    let resolve!: (value: { jobs: ReturnType<typeof completedRuntimeJob>[] }) => void
+    api.fetchVersionDownloadJobs.mockReturnValueOnce(new Promise(done => { resolve = done }))
+    const wrapper = mount(RuntimeRestartPrompt)
+    wrapper.unmount()
+    resolve({ jobs: [completedRuntimeJob()] })
+    await flushPromises()
+    expect(useRuntimeRestartPrompt().pendingRuntimeRestart.value).toBeNull()
+    await vi.advanceTimersByTimeAsync(6000)
+    expect(api.fetchVersionDownloadJobs).toHaveBeenCalledTimes(1)
+  })
+
 })

--- a/tests/client/version-management-modal.test.ts
+++ b/tests/client/version-management-modal.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { flushPromises, mount } from '@vue/test-utils'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const api = vi.hoisted(() => ({
   activateRuntimeVersion: vi.fn(),
@@ -75,6 +75,7 @@ function runtimeStatus() {
 }
 
 describe('VersionManagementModal Runtime storage selector', () => {
+  afterEach(() => vi.useRealTimers())
   beforeEach(() => {
     useRuntimeRestartPrompt().clearRuntimeRestart()
     for (const mock of Object.values(api)) mock.mockReset()
@@ -280,4 +281,30 @@ describe('VersionManagementModal Runtime storage selector', () => {
     expect(useRuntimeRestartPrompt().pendingRuntimeRestart.value?.version).toBe('0.20.4')
     wrapper.unmount()
   })
+
+  it('notifies the global monitor when starting a Runtime download before the drawer closes', async () => {
+    vi.useFakeTimers()
+    const status = {
+      ...runtimeStatus(),
+      hermes: { ...runtimeStatus().hermes, remoteVersions: ['0.20.6'] },
+    }
+    api.fetchRuntimeVersionStatus.mockResolvedValue(status)
+    api.downloadRuntimeVersion.mockResolvedValue({ success: true, job: {
+      id: 'new-runtime-job', kind: 'runtime', version: '0.20.6', status: 'queued',
+      source: 'github', stage: 'queued', message: '', error: '', createdAt: '', updatedAt: '',
+    } })
+    const monitor = useRuntimeRestartPrompt()
+    const wrapper = mount(VersionManagementModal, { props: { show: false } })
+    await wrapper.setProps({ show: true })
+    await flushPromises()
+    const beforeDownload = monitor.runtimeDownloadCheckRevision.value
+    const download = wrapper.findAll('button').find(button => button.text() === 'runtimeVersions.downloadGithub')!
+    await download.trigger('click')
+    await flushPromises()
+    expect(api.downloadRuntimeVersion).toHaveBeenCalledWith('0.20.6', 'github')
+    expect(monitor.runtimeDownloadCheckRevision.value).toBeGreaterThan(beforeDownload)
+    await wrapper.setProps({ show: false })
+    wrapper.unmount()
+  })
+
 })

--- a/tests/e2e/runtime-download-polling.spec.ts
+++ b/tests/e2e/runtime-download-polling.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from '@playwright/test'
+import { authenticate, mockHermesApi, TEST_ACCESS_KEY } from './fixtures'
+
+for (const role of ['admin', 'super_admin'] as const) {
+  test(`${role} does not continuously poll Runtime jobs while idle`, async ({ page }) => {
+    const tokenParts = TEST_ACCESS_KEY.split('.')
+    const payload = JSON.parse(Buffer.from(tokenParts[1], 'base64url').toString())
+    tokenParts[1] = Buffer.from(JSON.stringify({ ...payload, role })).toString('base64url')
+    await authenticate(page, tokenParts.join('.'))
+    await mockHermesApi(page)
+    let requests = 0
+    await page.route('**/api/hermes/runtime-versions/jobs', async route => {
+      requests += 1
+      await route.fulfill({
+        status: role === 'admin' ? 403 : 200,
+        contentType: 'application/json',
+        body: JSON.stringify(role === 'admin' ? { error: 'Super administrator privileges are required' } : { jobs: [] }),
+      })
+    })
+    await page.goto('/#/hermes/jobs')
+    await expect(page.getByRole('heading', { name: 'Scheduled Jobs' })).toBeVisible()
+    if (role === 'super_admin') await expect.poll(() => requests).toBe(1)
+    await page.clock.install()
+    await page.clock.runFor(8000)
+    expect(requests).toBe(role === 'admin' ? 0 : 1)
+    await expect(page.locator('.n-message--error')).toHaveCount(0)
+  })
+}
+
+test('restores an active download, prompts on completion and then stops polling', async ({ page }) => {
+  await authenticate(page)
+  await mockHermesApi(page)
+  let requests = 0
+  let status = 'running'
+  await page.route('**/api/hermes/runtime-versions/jobs', async route => {
+    requests += 1
+    await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ jobs: [{
+      id: 'restored-runtime-job', kind: 'runtime', version: '0.20.6', status,
+      source: 'github', stage: status, message: '', error: '', createdAt: '', updatedAt: '',
+    }] }) })
+  })
+  await page.goto('/#/hermes/jobs')
+  await expect(page.getByRole('heading', { name: 'Scheduled Jobs' })).toBeVisible()
+  await expect.poll(() => requests).toBeGreaterThanOrEqual(1)
+  await expect(page.getByTestId('runtime-restart-prompt')).toHaveCount(0)
+  status = 'completed'
+  await expect(page.getByTestId('runtime-restart-prompt')).toBeVisible()
+  const completedRequests = requests
+  await page.getByTestId('runtime-restart-later').click()
+  await page.clock.install()
+  await page.clock.runFor(8000)
+  expect(requests).toBe(completedRequests)
+  await expect(page.getByTestId('runtime-restart-prompt')).toHaveCount(0)
+})


### PR DESCRIPTION
## Summary

Ordinary administrators received repeated permission errors because the global Runtime restart prompt polled a super-admin-only endpoint every two seconds. The same poller kept running even when no download was active.

- Mount and query the restart prompt only for super administrators. Keep server permissions unchanged.
- Check once on mount to recover existing downloads, then poll sequentially only while Runtime jobs are queued or running. Stop on completion, failure, request errors, or unmount.
- Notify the global monitor when version management is opened/refreshed or a download starts, so completion prompts still work after the drawer closes. Retain completed-job dismissal tracking and explicit restart confirmation.

Refs #2880. This addresses the repeated Runtime polling permission errors; the separately reported inability to create sessions has not been reproduced or established as the same cause.

## Validation

- 34 focused Vitest tests passed (`app-web-pet`, `runtime-restart-prompt`, `version-management-modal`), including super-admin, ordinary-admin, and missing-role shell mounting.
- Full `npm run test:coverage` passed locally: 606 test files, 5009 tests passed, 6 tests skipped.
- 3 Playwright tests passed using system Chrome: ordinary administrator access, idle super administrator checks, and download recovery/completion.
- `npm run harness:check` passed.
- `npm run build` passed.
- `git diff --check` passed.

## Limits

Idle clients discover downloads started on other devices when version management is opened/refreshed or the page reloads. A failed status request stops background polling; opening version management or starting another download triggers a fresh check.
