### PR TITLE
feat: consolidate mobile calendar and reminder consent support

### DIFF
--- a/bin/hermes-studio-mcp.mjs
+++ b/bin/hermes-studio-mcp.mjs
@@ -1303,7 +1303,7 @@ const tools = [
       end_ms: { type: 'number', description: 'List range end as Unix milliseconds; maximum range is 31 days.' },
       limit: { type: 'number', description: 'Maximum list result count, from 1 to 100.' },
       item: { type: 'object', additionalProperties: true, description: 'Event fields for create/update: id (update), title, start_ms, end_ms, all_day, location, notes, reminder_minutes.' },
-      timeout_ms: { type: 'number', description: 'Wait time for user confirmation, from 3000 to 60000 milliseconds.' },
+      timeout_ms: { type: 'number', minimum: 3000, maximum: 300000, default: 300000, description: 'Wait time for user confirmation, from 3000 to 300000 milliseconds. Defaults to 5 minutes, matching the App consent card. Omit unless the user requests a shorter wait.' },
     }, ['session_id', 'action', 'purpose']),
   },
   {
@@ -1319,7 +1319,7 @@ const tools = [
       include_completed: { type: 'boolean', description: 'Include completed reminders when listing.' },
       limit: { type: 'number', description: 'Maximum list result count, from 1 to 100.' },
       item: { type: 'object', additionalProperties: true, description: 'Reminder fields: id (update/complete), title, due_ms, notes, priority, completed.' },
-      timeout_ms: { type: 'number', description: 'Wait time for user confirmation, from 3000 to 60000 milliseconds.' },
+      timeout_ms: { type: 'number', minimum: 3000, maximum: 300000, default: 300000, description: 'Wait time for user confirmation, from 3000 to 300000 milliseconds. Defaults to 5 minutes, matching the App consent card. Omit unless the user requests a shorter wait.' },
     }, ['session_id', 'action', 'purpose']),
   },
   {

--- a/bin/hermes-studio-mcp.mjs
+++ b/bin/hermes-studio-mcp.mjs
@@ -1294,10 +1294,10 @@ const tools = [
   {
     name: 'hermes_studio_use_mobile_calendar',
     toolset: 'use',
-    description: 'With the user’s explicit request, ask their mobile App to list, create, or update calendar events in the current direct chat. The App always requires one-time confirmation. Delete and background access are not supported.',
+    description: 'With the user’s explicit request, ask their mobile App to list, create, update, or delete calendar events in the current direct chat. The App always requires one-time confirmation. Single-item delete requires exact listed id, title and start_ms (calendar) or due_ms when present (reminder), with fresh App confirmation. Background access is not supported.',
     inputSchema: inputSchema({
       session_id: { type: 'string', description: 'Exact current Hermes Studio direct-chat session id supplied in the run context.' },
-      action: { type: 'string', enum: ['list', 'create', 'update'], description: 'Calendar operation.' },
+      action: { type: 'string', enum: ['list', 'create', 'update', 'delete'], description: 'Calendar operation.' },
       purpose: { type: 'string', description: 'Short user-visible reason for the request.' },
       start_ms: { type: 'number', description: 'List range start as Unix milliseconds.' },
       end_ms: { type: 'number', description: 'List range end as Unix milliseconds; maximum range is 31 days.' },
@@ -1309,10 +1309,10 @@ const tools = [
   {
     name: 'hermes_studio_use_mobile_reminders',
     toolset: 'use',
-    description: 'With the user’s explicit request, ask their mobile App to list, create, update, or complete reminders in the current direct chat. The App always requires one-time confirmation. Delete and background access are not supported.',
+    description: 'With the user’s explicit request, ask their mobile App to list, create, update, complete, or delete reminders in the current direct chat. The App always requires one-time confirmation. Single-item delete requires exact listed id, title and start_ms (calendar) or due_ms when present (reminder), with fresh App confirmation. Background access is not supported.',
     inputSchema: inputSchema({
       session_id: { type: 'string', description: 'Exact current Hermes Studio direct-chat session id supplied in the run context.' },
-      action: { type: 'string', enum: ['list', 'create', 'update', 'complete'], description: 'Reminder operation.' },
+      action: { type: 'string', enum: ['list', 'create', 'update', 'complete', 'delete'], description: 'Reminder operation.' },
       purpose: { type: 'string', description: 'Short user-visible reason for the request.' },
       start_ms: { type: 'number', description: 'List range start as Unix milliseconds.' },
       end_ms: { type: 'number', description: 'List range end as Unix milliseconds; maximum range is 31 days.' },

--- a/bin/hermes-studio-mcp.mjs
+++ b/bin/hermes-studio-mcp.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { request as httpRequest } from 'node:http'
+import { request as httpsRequest } from 'node:https'
 import { createInterface } from 'node:readline'
 import { randomUUID } from 'node:crypto'
 import { readFileSync, statSync } from 'node:fs'
@@ -181,6 +183,33 @@ function normalizePublicHeaders(headers) {
   return normalized
 }
 
+// Mobile consent can wait five minutes before producing response headers.
+// Avoid fetch's 300-second headers deadline racing that business deadline.
+async function fetchMobileConsent(url, options) {
+  return new Promise((resolve, reject) => {
+    const target = new URL(url)
+    const transport = target.protocol === 'https:' ? httpsRequest : httpRequest
+    let timer
+    const req = transport(target, { method: options.method, headers: options.headers }, res => {
+      const chunks = []
+      res.on('data', chunk => chunks.push(chunk))
+      res.on('error', error => { clearTimeout(timer); reject(error) })
+      res.on('end', () => {
+        clearTimeout(timer)
+        const text = Buffer.concat(chunks).toString('utf8')
+        const headers = new Headers()
+        for (const [name, value] of Object.entries(res.headers)) {
+          if (value != null) headers.set(name, Array.isArray(value) ? value.join(', ') : value)
+        }
+        resolve({ status: res.statusCode || 500, headers, text: async () => text })
+      })
+    })
+    timer = setTimeout(() => req.destroy(new Error('Mobile consent transport timed out')), 330_000)
+    req.on('error', error => { clearTimeout(timer); reject(error) })
+    req.end(options.body)
+  })
+}
+
 async function requestEnvelope(path, options = {}) {
   const profile = typeof options.profile === 'string' && options.profile.trim()
     ? options.profile.trim()
@@ -194,7 +223,8 @@ async function requestEnvelope(path, options = {}) {
     ...(token ? { Authorization: `Bearer ${token}` } : {}),
     ...(profile ? { 'X-Hermes-Profile': profile } : {}),
   }
-  const response = await fetch(`${baseUrl()}${appendQuery(path, options.query)}`, {
+  const fetchRequest = path === '/api/studio/mobile-calendar/request' ? fetchMobileConsent : fetch
+  const response = await fetchRequest(`${baseUrl()}${appendQuery(path, options.query)}`, {
     method,
     headers,
     body: body !== undefined ? JSON.stringify(body) : undefined,

--- a/bin/hermes-studio-mcp.mjs
+++ b/bin/hermes-studio-mcp.mjs
@@ -660,6 +660,10 @@ function pickDefined(source, keys) {
   return picked
 }
 
+function currentMobileSessionArgs(args) {
+  const sessionId = String(process.env.HERMES_STUDIO_SESSION_ID || '').trim()
+  return sessionId ? { ...args, session_id: sessionId } : args
+}
 function boundedInteger(value, fallback, min, max) {
   const parsed = Number.parseInt(String(value ?? ''), 10)
   if (!Number.isFinite(parsed)) return fallback
@@ -1288,6 +1292,37 @@ const tools = [
       }, ['session_id', 'purpose']),
   },
   {
+    name: 'hermes_studio_use_mobile_calendar',
+    toolset: 'use',
+    description: 'With the user’s explicit request, ask their mobile App to list, create, or update calendar events in the current direct chat. The App always requires one-time confirmation. Delete and background access are not supported.',
+    inputSchema: inputSchema({
+      session_id: { type: 'string', description: 'Exact current Hermes Studio direct-chat session id supplied in the run context.' },
+      action: { type: 'string', enum: ['list', 'create', 'update'], description: 'Calendar operation.' },
+      purpose: { type: 'string', description: 'Short user-visible reason for the request.' },
+      start_ms: { type: 'number', description: 'List range start as Unix milliseconds.' },
+      end_ms: { type: 'number', description: 'List range end as Unix milliseconds; maximum range is 31 days.' },
+      limit: { type: 'number', description: 'Maximum list result count, from 1 to 100.' },
+      item: { type: 'object', additionalProperties: true, description: 'Event fields for create/update: id (update), title, start_ms, end_ms, all_day, location, notes, reminder_minutes.' },
+      timeout_ms: { type: 'number', description: 'Wait time for user confirmation, from 3000 to 60000 milliseconds.' },
+    }, ['session_id', 'action', 'purpose']),
+  },
+  {
+    name: 'hermes_studio_use_mobile_reminders',
+    toolset: 'use',
+    description: 'With the user’s explicit request, ask their mobile App to list, create, update, or complete reminders in the current direct chat. The App always requires one-time confirmation. Delete and background access are not supported.',
+    inputSchema: inputSchema({
+      session_id: { type: 'string', description: 'Exact current Hermes Studio direct-chat session id supplied in the run context.' },
+      action: { type: 'string', enum: ['list', 'create', 'update', 'complete'], description: 'Reminder operation.' },
+      purpose: { type: 'string', description: 'Short user-visible reason for the request.' },
+      start_ms: { type: 'number', description: 'List range start as Unix milliseconds.' },
+      end_ms: { type: 'number', description: 'List range end as Unix milliseconds; maximum range is 31 days.' },
+      include_completed: { type: 'boolean', description: 'Include completed reminders when listing.' },
+      limit: { type: 'number', description: 'Maximum list result count, from 1 to 100.' },
+      item: { type: 'object', additionalProperties: true, description: 'Reminder fields: id (update/complete), title, due_ms, notes, priority, completed.' },
+      timeout_ms: { type: 'number', description: 'Wait time for user confirmation, from 3000 to 60000 milliseconds.' },
+    }, ['session_id', 'action', 'purpose']),
+  },
+  {
     name: 'hermes_studio_use_workflows_list',
     toolset: 'use',
     description: 'List Hermes Studio workflows for the selected or requested profile.',
@@ -1645,8 +1680,8 @@ const CATEGORY_TOOLSETS = {
   },
   use: {
     name: 'hermes_studio_use_toolset',
-    coverage: 'Explicit user-requested Studio chat/coding runs; one-time confirmed mobile location; session list/count/detail/messages/context/rename/delete; usage statistics; profiles and available models; provider add/delete; worker status; workflow CRUD and workflow run list/start/stop/rerun/delete.',
-    description: 'Discover and invoke high-level Hermes Studio operations without loading every Studio-use tool schema into the model context. Covers explicit user-requested chat or coding runs, one-time confirmed mobile location, session management and clean context, usage statistics, profiles/models/providers, worker status, workflow CRUD, and workflow run lifecycle. Never use chat/session or mobile-location operations as an internal delegation mechanism. Use action=list for the compact category catalog, action=describe for one full tool schema, then action=call with that exact tool name and arguments.',
+    coverage: 'Explicit user-requested Studio chat/coding runs; one-time confirmed mobile location, calendar and reminder operations; session list/count/detail/messages/context/rename/delete; usage statistics; profiles and available models; provider add/delete; worker status; workflow CRUD and workflow run list/start/stop/rerun/delete.',
+    description: 'Discover and invoke high-level Hermes Studio operations without loading every Studio-use tool schema into the model context. Covers explicit user-requested chat or coding runs, one-time confirmed mobile location, calendar/reminder operations, session management and clean context, usage statistics, profiles/models/providers, worker status, workflow CRUD, and workflow run lifecycle. Never use chat/session or mobile-device operations as an internal delegation mechanism. Use action=list for the compact operation catalog, action=describe for one full input schema, then action=call with that exact tool name and arguments.',
   },
 }
 
@@ -1931,6 +1966,22 @@ async function callTool(name, args = {}) {
       return jsonText(await request('/api/studio/mobile-location/request', withAuthArgs(args, {
         method: 'POST',
         body: pickDefined(args, ['session_id', 'purpose', 'accuracy', 'timeout_ms']),
+      })))
+    case 'hermes_studio_use_mobile_calendar':
+      return jsonText(await request('/api/studio/mobile-calendar/request', withAuthArgs(currentMobileSessionArgs(args), {
+        method: 'POST',
+        body: {
+          capability: 'calendar',
+          ...pickDefined(currentMobileSessionArgs(args), ['session_id', 'action', 'purpose', 'start_ms', 'end_ms', 'limit', 'item', 'timeout_ms']),
+        },
+      })))
+    case 'hermes_studio_use_mobile_reminders':
+      return jsonText(await request('/api/studio/mobile-calendar/request', withAuthArgs(currentMobileSessionArgs(args), {
+        method: 'POST',
+        body: {
+          capability: 'reminder',
+          ...pickDefined(currentMobileSessionArgs(args), ['session_id', 'action', 'purpose', 'start_ms', 'end_ms', 'include_completed', 'limit', 'item', 'timeout_ms']),
+        },
       })))
     case 'hermes_studio_use_workflows_list':
       return jsonText(await request('/api/studio/workflows', withAuthArgs(args, {

--- a/docs/chat-chain-changes/2026-09-04-mobile-calendar-reminders.md
+++ b/docs/chat-chain-changes/2026-09-04-mobile-calendar-reminders.md
@@ -1,0 +1,16 @@
+# Mobile calendar and reminders
+
+Direct Hermes Studio chats can request one-time, user-confirmed access to mobile calendar events and reminders.
+
+- MCP tools: `hermes_studio_use_mobile_calendar` and `hermes_studio_use_mobile_reminders`
+- Server endpoint: `POST /api/studio/mobile-calendar/request`
+- Calendar events: list, create, update
+- Reminders: list, create, update, complete
+- Delete, background access, workflow/group/delegated use, and cross-session persistence are not supported.
+- Every request is bound to the authenticated profile and exact direct-chat session.
+- App responses are allowlisted and sanitized before being returned to the MCP caller.
+
+2026-09-05 integration update (PR #2892): merge current main while retaining
+location, calendar and reminder routes, MCP operations, relay events and socket
+lifecycles. Preserve distinct MCP test request IDs and expect the bound Studio
+session environment in the global Codex resume regression.

--- a/docs/chat-chain-changes/2026-09-05-confirmed-mobile-delete.md
+++ b/docs/chat-chain-changes/2026-09-05-confirmed-mobile-delete.md
@@ -1,0 +1,10 @@
+---
+date: 2026-09-05
+pr: pending
+feature: Confirmed single-item mobile deletion
+impact: Calendar/reminder delete requires exact id and title, calendar occurrence time, one-time App confirmation and a bounded deadline.
+---
+
+Extends #2892. Delete results must match the requested id and explicitly report
+deleted=true. No list/batch/series deletion, profile scope or background access
+expansion. Requires the matching App update; older Apps do not support delete.

--- a/docs/chat-chain-changes/2026-09-05-mobile-consent-timeout.md
+++ b/docs/chat-chain-changes/2026-09-05-mobile-consent-timeout.md
@@ -1,0 +1,11 @@
+---
+date: 2026-09-05
+pr: pending
+feature: Mobile calendar and reminder consent duration
+impact: Default to five minutes like the App generic consent card, with matching server and device deadlines instead of a 30-second device cap.
+---
+
+MCP and OpenAPI allow 3–300 seconds and advertise a five-minute default.
+Explicit shorter waits remain supported. Expired delete protection remains;
+location and other Agent-specific approval timeouts are unchanged. Current App
+already consumes timeout_ms/expires_at_ms so no App/native rebuild is required.

--- a/docs/chat-chain-changes/2026-09-05-mobile-device-target.md
+++ b/docs/chat-chain-changes/2026-09-05-mobile-device-target.md
@@ -1,0 +1,12 @@
+---
+date: 2026-09-05
+pr: pending
+feature: Bind calendar/reminder consent to authenticated originating device
+impact: No broadcast to every App; foreign responses ignored and replay filtered. Unknown origin or offline target fails closed.
+---
+
+Identity comes from verified app_access token, not client-declared device ID.
+Capture target when each direct run starts; reading/resuming a session does not
+transfer ownership. Return a pseudonymous device_id for acceptance evidence.
+Requires new originating mobile run after deployment. Web/unknown-origin runs
+cannot silently choose a device. Location is unchanged in this scoped patch.

--- a/docs/chat-chain-changes/2026-09-05-mobile-mcp-transport-budget.md
+++ b/docs/chat-chain-changes/2026-09-05-mobile-mcp-transport-budget.md
@@ -1,0 +1,11 @@
+---
+date: 2026-09-05
+pr: pending
+feature: Mobile consent transport timeout budget
+impact: Keep five-minute consent while allowing HTTP 330 seconds and managed Codex/Grok/Pi tool calls 360 seconds for the terminal result.
+---
+
+New/resumed launches must regenerate their managed MCP configuration; an
+already-running client does not reload its tool timeout automatically. The
+special HTTP transport applies only to mobile-calendar requests and does not
+retry writes. Other external MCP servers and location remain unchanged.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -14938,7 +14938,8 @@
                   "timeout_ms": {
                     "type": "integer",
                     "minimum": 3000,
-                    "maximum": 60000
+                    "maximum": 300000,
+                    "default": 300000
                   }
                 }
               }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -14867,6 +14867,102 @@
         }
       }
     },
+    "/api/studio/mobile-calendar/request": {
+      "post": {
+        "tags": [
+          "Chat Run"
+        ],
+        "summary": "Request one-time mobile calendar or reminder access",
+        "description": "Requests a user-confirmed calendar/reminder operation from the App for the exact authenticated direct-chat session. Delete, background, workflow, group-chat, and delegated use are not supported.",
+        "operationId": "requestMobileCalendar",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "session_id",
+                  "capability",
+                  "action",
+                  "purpose"
+                ],
+                "properties": {
+                  "session_id": {
+                    "type": "string"
+                  },
+                  "capability": {
+                    "type": "string",
+                    "enum": [
+                      "calendar",
+                      "reminder"
+                    ]
+                  },
+                  "action": {
+                    "type": "string",
+                    "enum": [
+                      "list",
+                      "create",
+                      "update",
+                      "complete"
+                    ]
+                  },
+                  "purpose": {
+                    "type": "string",
+                    "maxLength": 240
+                  },
+                  "start_ms": {
+                    "type": "number"
+                  },
+                  "end_ms": {
+                    "type": "number"
+                  },
+                  "include_completed": {
+                    "type": "boolean"
+                  },
+                  "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 100
+                  },
+                  "item": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "timeout_ms": {
+                    "type": "integer",
+                    "minimum": 3000,
+                    "maximum": 60000
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Confirmed App result, denial, or sanitized device error"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "503": {
+            "description": "Chat run service unavailable"
+          }
+        }
+      }
+    },
     "/api/studio/mobile-location/request": {
       "post": {
         "tags": [

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -14873,7 +14873,7 @@
           "Chat Run"
         ],
         "summary": "Request one-time mobile calendar or reminder access",
-        "description": "Requests a user-confirmed calendar/reminder operation from the App for the exact authenticated direct-chat session. Delete, background, workflow, group-chat, and delegated use are not supported.",
+        "description": "Requests a user-confirmed calendar/reminder operation from the App for the exact authenticated direct-chat session. Single-item delete requires exact id, title and occurrence time with fresh App confirmation. Background, workflow, group-chat, and delegated use are not supported.",
         "operationId": "requestMobileCalendar",
         "security": [
           {
@@ -14909,7 +14909,8 @@
                       "list",
                       "create",
                       "update",
-                      "complete"
+                      "complete",
+                      "delete"
                     ]
                   },
                   "purpose": {

--- a/packages/server/src/modules/coding-agents/services/index.ts
+++ b/packages/server/src/modules/coding-agents/services/index.ts
@@ -99,6 +99,7 @@ const LEGACY_HERMES_MCP_COMMANDS = new Set([
   'hermes-studio-mcp',
 ])
 const HERMES_MCP_MANAGED_ENV_KEY = 'HERMES_WEB_UI_MANAGED_MCP'
+const HERMES_STUDIO_SESSION_ENV_KEY = 'HERMES_STUDIO_SESSION_ID'
 const GLOBAL_CODEX_SHADOW_LINK_DIRS = new Set(['memories', 'plugins', 'rules', 'skills', 'vendor_imports', 'visualizations'])
 
 let cachedCodexVersion: { version: string; checkedAt: number } | null = null
@@ -3111,6 +3112,8 @@ export async function prepareCodingAgentLaunch(id: string, input: CodingAgentLau
       files = [{ key: 'prompt', path: 'APPEND_SYSTEM.md', absolutePath: promptFile }]
       args = ['--append-system-prompt', promptFile]
     }
+    const chatSessionId = String(input.sessionId || '').trim()
+    if (chatSessionId) env[HERMES_STUDIO_SESSION_ENV_KEY] = chatSessionId
     const shellCommand = buildLaunchShellCommand({
       workspaceDir,
       env,
@@ -3516,6 +3519,8 @@ export async function prepareCodingAgentLaunch(id: string, input: CodingAgentLau
     args = ['--model', `${OPENCODE_PROVIDER_ID}/${model}`]
   }
 
+  const chatSessionId = String(isolatedInput.sessionId || '').trim()
+  if (chatSessionId) env[HERMES_STUDIO_SESSION_ENV_KEY] = chatSessionId
   let shellCommand = buildLaunchShellCommand({
     workspaceDir,
     env,

--- a/packages/server/src/modules/coding-agents/services/index.ts
+++ b/packages/server/src/modules/coding-agents/services/index.ts
@@ -1372,6 +1372,7 @@ function codexMcpConfigToml(
     if (Array.isArray(server.args) && server.args.length) lines.push(`args = ${tomlStringArray(server.args.map(String))}`)
     if (disabledManaged.has(item.name)) lines.push('enabled = false')
     lines.push(`startup_timeout_sec = ${typeof server.startup_timeout_sec === 'number' ? server.startup_timeout_sec : 120}`)
+    if (item.toolset === 'use') lines.push(`tool_timeout_sec = ${Math.max(360, Number(server.tool_timeout_sec) || 0)}`)
     if (server.env && typeof server.env === 'object' && !Array.isArray(server.env)) {
       lines.push(`env = ${tomlInlineStringTable(server.env as Record<string, string>)}`)
     }
@@ -1497,7 +1498,7 @@ function piMcpConfig(profile: string, ...externalContents: Array<string | null |
     .filter(item => !disabledManaged.has(item.name))
     .map((item) => {
     const server = managedHermesMcpServerConfig('pi', profile, item.name, item.toolset)
-    const requestTimeoutMs = item.toolset === 'api' || item.toolset === 'use' ? 120_000 : 1_860_000
+    const requestTimeoutMs = item.toolset === 'api' ? 120_000 : item.toolset === 'use' ? 360_000 : 1_860_000
     return [item.name, {
       ...server,
       lifecycle: 'lazy',
@@ -1694,7 +1695,7 @@ export function getCodingAgentManagedMcpServerConfigs(
   return Object.fromEntries(HERMES_MCP_SERVERS.map((item) => {
     const server = managedHermesMcpServerConfig(id, profile || 'default', item.name, item.toolset)
     if (id === 'pi') {
-      const requestTimeoutMs = item.toolset === 'api' || item.toolset === 'use' ? 120_000 : 1_860_000
+      const requestTimeoutMs = item.toolset === 'api' ? 120_000 : item.toolset === 'use' ? 360_000 : 1_860_000
       return [item.name, {
         ...server,
         lifecycle: 'lazy',
@@ -1708,6 +1709,7 @@ export function getCodingAgentManagedMcpServerConfigs(
       return [item.name, {
         ...server,
         startup_timeout_sec: 120,
+        ...(item.toolset === 'use' ? { tool_timeout_sec: Math.max(360, Number(server.tool_timeout_sec) || 0) } : {}),
         ...(disabledManaged.has(item.name) ? { enabled: false } : {}),
       }]
     }

--- a/packages/server/src/modules/studio/controllers/chat-run.ts
+++ b/packages/server/src/modules/studio/controllers/chat-run.ts
@@ -54,6 +54,10 @@ const CHAT_RUN_EVENTS = [
   'clarify.resolved',
   'location.requested',
   'location.resolved',
+  'calendar.requested',
+  'calendar.resolved',
+  'reminder.requested',
+  'reminder.resolved',
   'peer.user.message',
 ]
 
@@ -92,6 +96,42 @@ export async function requestMobileLocation(ctx: Context) {
   }
 }
 
+export async function requestMobileCalendar(ctx: Context) {
+  const body = (ctx.request.body || {}) as Record<string, unknown>
+  const sessionId = String(body.session_id || '').trim()
+  if (!sessionId) {
+    ctx.status = 400
+    ctx.body = { ok: false, error: 'session_id is required' }
+    return
+  }
+  const server = getChatRunServer()
+  if (!server?.requestMobileCalendar) {
+    ctx.status = 503
+    ctx.body = { ok: false, error: 'Chat run service is unavailable' }
+    return
+  }
+  const profile = String(ctx.state.profile?.name || 'default').trim() || 'default'
+  try {
+    const result = await server.requestMobileCalendar({
+      sessionId,
+      profile,
+      capability: body.capability === 'reminder' ? 'reminder' : 'calendar',
+      action: body.action,
+      purpose: body.purpose,
+      startMs: body.start_ms,
+      endMs: body.end_ms,
+      includeCompleted: body.include_completed,
+      limit: body.limit,
+      item: body.item,
+      timeoutMs: body.timeout_ms,
+    })
+    ctx.body = { ok: true, session_id: sessionId, ...result }
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err)
+    ctx.status = error === 'Session not found' ? 404 : 400
+    ctx.body = { ok: false, error }
+  }
+}
 function bearerToken(ctx: Context): string {
   const match = ctx.get('authorization').match(/^Bearer\s+(.+)$/i)
   return match?.[1]?.trim() || ''

--- a/packages/server/src/modules/studio/public/auth.ts
+++ b/packages/server/src/modules/studio/public/auth.ts
@@ -1,5 +1,6 @@
 export {
   authenticateUserToken,
+  inspectAppUserToken,
   getUserJwtExpiresSeconds,
   isAuthEnabled,
   issueAppJwt,

--- a/packages/server/src/modules/studio/routes/chat-run.ts
+++ b/packages/server/src/modules/studio/routes/chat-run.ts
@@ -5,4 +5,5 @@ export { getChatRunServer, setChatRunServer } from '../public/chat-run'
 export const chatRunRoutes = new Router()
 
 chatRunRoutes.post('/api/studio/chat-run/runs', ctrl.runOnce)
+chatRunRoutes.post('/api/studio/mobile-calendar/request', ctrl.requestMobileCalendar)
 chatRunRoutes.post('/api/studio/mobile-location/request', ctrl.requestMobileLocation)

--- a/packages/server/src/modules/studio/services/app-relay/client.ts
+++ b/packages/server/src/modules/studio/services/app-relay/client.ts
@@ -52,6 +52,8 @@ const ALLOWED_CHAT_RUN_CLIENT_EVENTS = new Set([
   'cancel_queued_run',
   'approval.respond',
   'clarify.respond',
+  'calendar.respond',
+  'reminder.respond',
   'location.respond',
 ])
 const ALLOWED_GROUP_CHAT_CLIENT_EVENTS = new Set([

--- a/packages/server/src/modules/studio/services/app-relay/server.ts
+++ b/packages/server/src/modules/studio/services/app-relay/server.ts
@@ -55,6 +55,8 @@ const ALLOWED_CHAT_RUN_CLIENT_EVENTS = new Set([
   'cancel_queued_run',
   'approval.respond',
   'clarify.respond',
+  'calendar.respond',
+  'reminder.respond',
   'location.respond',
 ])
 const ALLOWED_GROUP_CHAT_CLIENT_EVENTS = new Set([

--- a/packages/server/src/modules/studio/services/chat-run/mobile-calendar.ts
+++ b/packages/server/src/modules/studio/services/chat-run/mobile-calendar.ts
@@ -1,0 +1,165 @@
+export type MobileCalendarCapability = 'calendar' | 'reminder'
+export type MobileCalendarAction = 'list' | 'create' | 'update' | 'complete'
+
+export type MobileCalendarRequest = {
+  capability: MobileCalendarCapability
+  action: MobileCalendarAction
+  purpose: string
+  start_ms?: number
+  end_ms?: number
+  include_completed?: boolean
+  limit: number
+  item?: Record<string, unknown>
+}
+
+export type MobileCalendarResponse =
+  | {
+      status: 'success'
+      result: {
+        capability: MobileCalendarCapability
+        action: MobileCalendarAction
+        items?: Array<Record<string, unknown>>
+        item?: Record<string, unknown>
+      }
+    }
+  | { status: 'denied' }
+  | { status: 'error'; error: { code: string } }
+
+const DAY_MS = 24 * 60 * 60_000
+const MAX_RANGE_MS = 31 * DAY_MS
+const MAX_FUTURE_MS = 5 * 365 * DAY_MS
+const MIN_TIME_MS = Date.UTC(2001, 0, 1)
+const ERROR_CODES = new Set([
+  'calendar_permission_denied',
+  'calendar_unavailable',
+  'calendar_item_not_found',
+  'calendar_invalid_request',
+  'calendar_failed',
+])
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function text(value: unknown, max: number): string {
+  return String(value || '').trim().slice(0, max)
+}
+
+function integer(value: unknown, fallback: number, min: number, max: number): number {
+  const normalized = Math.round(Number(value))
+  return Number.isFinite(normalized) ? Math.max(min, Math.min(max, normalized)) : fallback
+}
+
+function timestamp(value: unknown, fallback: number, now: number): number {
+  const normalized = Math.round(Number(value))
+  if (!Number.isFinite(normalized)) return fallback
+  return Math.max(MIN_TIME_MS, Math.min(now + MAX_FUTURE_MS, normalized))
+}
+
+function cleanItem(value: unknown, capability: MobileCalendarCapability, action: MobileCalendarAction): Record<string, unknown> | null {
+  if (!isRecord(value)) return null
+  const now = Date.now()
+  const id = text(value.id || value.event_id || value.reminder_id, 512)
+  if ((action === 'update' || action === 'complete') && !id) return null
+  const item: Record<string, unknown> = {}
+  if (id) item.id = id
+  if (action !== 'complete') {
+    const title = text(value.title, 500)
+    if (!title) return null
+    item.title = title
+  }
+  const notes = text(value.notes, 4_000)
+  const location = text(value.location, 500)
+  if (notes) item.notes = notes
+  if (location) item.location = location
+  if (capability === 'calendar') {
+    const startMs = timestamp(value.start_ms || value.startMs, now + 5 * 60_000, now)
+    const requestedEnd = timestamp(value.end_ms || value.endMs, startMs + 60 * 60_000, now)
+    item.start_ms = startMs
+    item.end_ms = Math.max(startMs + 60_000, Math.min(requestedEnd, startMs + MAX_RANGE_MS))
+    item.all_day = value.all_day === true || value.allDay === true
+    item.reminder_minutes = integer(value.reminder_minutes || value.reminderMinutes, 0, 0, 30 * 24 * 60)
+  } else {
+    if (value.due_ms != null || value.dueMs != null) {
+      item.due_ms = timestamp(value.due_ms || value.dueMs, now + 60 * 60_000, now)
+    }
+    item.priority = integer(value.priority, 0, 0, 9)
+    if (action === 'complete') item.completed = value.completed !== false
+  }
+  return item
+}
+
+export function normalizeMobileCalendarRequest(value: Record<string, unknown>): MobileCalendarRequest {
+  const capability = String(value.capability || '').trim() as MobileCalendarCapability
+  if (capability !== 'calendar' && capability !== 'reminder') throw new Error('capability must be calendar or reminder')
+  const action = String(value.action || '').trim() as MobileCalendarAction
+  const allowed = capability === 'calendar'
+    ? new Set<MobileCalendarAction>(['list', 'create', 'update'])
+    : new Set<MobileCalendarAction>(['list', 'create', 'update', 'complete'])
+  if (!allowed.has(action)) throw new Error(`Unsupported ${capability} action`)
+  const purpose = text(value.purpose, 240)
+  if (!purpose) throw new Error('purpose is required')
+  const request: MobileCalendarRequest = {
+    capability,
+    action,
+    purpose,
+    limit: integer(value.limit, 50, 1, 100),
+  }
+  if (action === 'list') {
+    const now = Date.now()
+    const start = timestamp(value.start_ms, capability === 'calendar' ? now : now - DAY_MS, now)
+    const end = timestamp(value.end_ms, start + 7 * DAY_MS, now)
+    request.start_ms = start
+    request.end_ms = Math.max(start + 60_000, Math.min(end, start + MAX_RANGE_MS))
+    if (capability === 'reminder') request.include_completed = value.include_completed === true
+  } else {
+    const item = cleanItem(value.item, capability, action)
+    if (!item) throw new Error('A valid item is required')
+    request.item = item
+  }
+  return request
+}
+
+function cleanResultItem(value: unknown): Record<string, unknown> | null {
+  if (!isRecord(value)) return null
+  const output: Record<string, unknown> = {}
+  for (const key of ['id', 'title', 'notes', 'location']) {
+    const normalized = text(value[key], key === 'notes' ? 4_000 : 1_000)
+    if (normalized) output[key] = normalized
+  }
+  for (const key of ['startMs', 'endMs', 'dueMs', 'priority', 'reminderMinutes']) {
+    const normalized = Number(value[key])
+    if (Number.isFinite(normalized)) output[key] = normalized
+  }
+  for (const key of ['allDay', 'completed']) {
+    if (typeof value[key] === 'boolean') output[key] = value[key]
+  }
+  return output
+}
+
+export function normalizeMobileCalendarResponse(
+  value: unknown,
+  expected: Pick<MobileCalendarRequest, 'capability' | 'action'>,
+): MobileCalendarResponse | null {
+  if (!isRecord(value)) return null
+  const status = String(value.status || '').trim()
+  if (status === 'denied') return { status: 'denied' }
+  if (status === 'error') {
+    const error = isRecord(value.error) ? String(value.error.code || '') : ''
+    return { status: 'error', error: { code: ERROR_CODES.has(error) ? error : 'calendar_failed' } }
+  }
+  if (status !== 'success' || !isRecord(value.result)) return null
+  const capability = String(value.result.capability || expected.capability)
+  const action = String(value.result.action || expected.action)
+  if (capability !== expected.capability || action !== expected.action) return null
+  const result: Extract<MobileCalendarResponse, { status: 'success' }>['result'] = {
+    capability: expected.capability,
+    action: expected.action,
+  }
+  if (Array.isArray(value.result.items)) {
+    result.items = value.result.items.slice(0, 100).map(cleanResultItem).filter(Boolean) as Array<Record<string, unknown>>
+  }
+  const item = cleanResultItem(value.result.item)
+  if (item) result.item = item
+  return { status: 'success', result }
+}

--- a/packages/server/src/modules/studio/services/chat-run/mobile-calendar.ts
+++ b/packages/server/src/modules/studio/services/chat-run/mobile-calendar.ts
@@ -1,5 +1,5 @@
 export type MobileCalendarCapability = 'calendar' | 'reminder'
-export type MobileCalendarAction = 'list' | 'create' | 'update' | 'complete'
+export type MobileCalendarAction = 'list' | 'create' | 'update' | 'complete' | 'delete'
 
 export type MobileCalendarRequest = {
   capability: MobileCalendarCapability
@@ -58,6 +58,15 @@ function timestamp(value: unknown, fallback: number, now: number): number {
 
 function cleanItem(value: unknown, capability: MobileCalendarCapability, action: MobileCalendarAction): Record<string, unknown> | null {
   if (!isRecord(value)) return null
+  if (action === 'delete') {
+    if (typeof value.id !== 'string' || !value.id.trim() || value.id.length > 512) return null
+    if (typeof value.title !== 'string' || !value.title.trim() || value.title.length > 500) return null
+    // Require the exact listed occurrence; never invent a time for deletion.
+    const start = capability === 'calendar' ? value.start_ms : value.due_ms
+    if (capability === 'calendar' && (typeof start !== 'number' || !Number.isFinite(start) || start < MIN_TIME_MS)) return null
+    if (capability === 'reminder' && start != null && (typeof start !== 'number' || !Number.isFinite(start))) return null
+    return { id: value.id.trim(), title: value.title.trim(), ...(start != null ? { [capability === 'calendar' ? 'start_ms' : 'due_ms']: start } : {}) }
+  }
   const now = Date.now()
   const id = text(value.id || value.event_id || value.reminder_id, 512)
   if ((action === 'update' || action === 'complete') && !id) return null
@@ -94,8 +103,8 @@ export function normalizeMobileCalendarRequest(value: Record<string, unknown>): 
   if (capability !== 'calendar' && capability !== 'reminder') throw new Error('capability must be calendar or reminder')
   const action = String(value.action || '').trim() as MobileCalendarAction
   const allowed = capability === 'calendar'
-    ? new Set<MobileCalendarAction>(['list', 'create', 'update'])
-    : new Set<MobileCalendarAction>(['list', 'create', 'update', 'complete'])
+    ? new Set<MobileCalendarAction>(['list', 'create', 'update', 'delete'])
+    : new Set<MobileCalendarAction>(['list', 'create', 'update', 'complete', 'delete'])
   if (!allowed.has(action)) throw new Error(`Unsupported ${capability} action`)
   const purpose = text(value.purpose, 240)
   if (!purpose) throw new Error('purpose is required')
@@ -139,7 +148,7 @@ function cleanResultItem(value: unknown): Record<string, unknown> | null {
 
 export function normalizeMobileCalendarResponse(
   value: unknown,
-  expected: Pick<MobileCalendarRequest, 'capability' | 'action'>,
+  expected: Pick<MobileCalendarRequest, 'capability' | 'action'> & { item?: Record<string, unknown> },
 ): MobileCalendarResponse | null {
   if (!isRecord(value)) return null
   const status = String(value.status || '').trim()
@@ -158,6 +167,10 @@ export function normalizeMobileCalendarResponse(
   }
   if (Array.isArray(value.result.items)) {
     result.items = value.result.items.slice(0, 100).map(cleanResultItem).filter(Boolean) as Array<Record<string, unknown>>
+  }
+  if (expected.action === 'delete') {
+    if (!isRecord(value.result.item) || value.result.item.id !== expected.item?.id || value.result.item.deleted !== true) return null
+    return { status: 'success', result: { capability: expected.capability, action: 'delete', item: { id: expected.item?.id, deleted: true } } }
   }
   const item = cleanResultItem(value.result.item)
   if (item) result.item = item

--- a/packages/server/src/modules/studio/services/chat-run/mobile-calendar.ts
+++ b/packages/server/src/modules/studio/services/chat-run/mobile-calendar.ts
@@ -12,7 +12,7 @@ export type MobileCalendarRequest = {
   item?: Record<string, unknown>
 }
 
-export type MobileCalendarResponse =
+export type MobileCalendarResponse = (
   | {
       status: 'success'
       result: {
@@ -24,6 +24,7 @@ export type MobileCalendarResponse =
     }
   | { status: 'denied' }
   | { status: 'error'; error: { code: string } }
+) & { device_id?: string }
 
 const DAY_MS = 24 * 60 * 60_000
 const MAX_RANGE_MS = 31 * DAY_MS

--- a/packages/server/src/modules/studio/services/chat-run/mobile-device-target.ts
+++ b/packages/server/src/modules/studio/services/chat-run/mobile-device-target.ts
@@ -1,0 +1,15 @@
+import { createHash } from 'node:crypto'
+
+export type MobileDeviceTarget = { deviceCode: string; userId: string; profile: string }
+export function mobileDeviceId(target: MobileDeviceTarget): string {
+  return createHash('sha256').update(JSON.stringify([target.userId, target.deviceCode])).digest('hex').slice(0, 24)
+}
+export function mobileDeviceRoom(target: MobileDeviceTarget): string {
+  return `mobile-consent:${mobileDeviceId(target)}:${encodeURIComponent(target.profile)}`
+}
+export function sameMobileDevice(a: MobileDeviceTarget | undefined, b: MobileDeviceTarget | undefined): boolean {
+  return Boolean(a && b && a.deviceCode === b.deviceCode && a.userId === b.userId && a.profile === b.profile)
+}
+export function mobileEventAllowed(data: Record<string, any> | undefined, target: MobileDeviceTarget | undefined): boolean {
+  return Boolean(target && data?.target_device_id === target.deviceCode && data?.target_user_id === target.userId && data?.target_profile === target.profile)
+}

--- a/packages/server/src/modules/studio/sockets/chat-run.ts
+++ b/packages/server/src/modules/studio/sockets/chat-run.ts
@@ -356,11 +356,11 @@ type PendingMobileCalendarRequest = {
   timer: NodeJS.Timeout
 }
 const MOBILE_CALENDAR_MIN_TIMEOUT_MS = 3_000
-const MOBILE_CALENDAR_MAX_TIMEOUT_MS = 60_000
-const MOBILE_CALENDAR_DEVICE_TIMEOUT_MS = 30_000
+const MOBILE_CALENDAR_MAX_TIMEOUT_MS = 300_000
+const MOBILE_CALENDAR_DEFAULT_TIMEOUT_MS = 300_000
 function boundedMobileCalendarTimeout(value: unknown): number {
   const numeric = Math.round(Number(value))
-  if (!Number.isFinite(numeric)) return 35_000
+  if (value == null || !Number.isFinite(numeric) || numeric <= 0) return MOBILE_CALENDAR_DEFAULT_TIMEOUT_MS
   return Math.max(MOBILE_CALENDAR_MIN_TIMEOUT_MS, Math.min(MOBILE_CALENDAR_MAX_TIMEOUT_MS, numeric))
 }
 export class ChatRunSocket {
@@ -503,8 +503,8 @@ export class ChatRunSocket {
         event,
         [idKey]: requestId,
         ...request,
-        timeout_ms: Math.min(timeoutMs, MOBILE_CALENDAR_DEVICE_TIMEOUT_MS),
-        expires_at_ms: Date.now() + Math.min(timeoutMs, MOBILE_CALENDAR_DEVICE_TIMEOUT_MS),
+        timeout_ms: timeoutMs,
+        expires_at_ms: Date.now() + timeoutMs,
       })
     })
   }

--- a/packages/server/src/modules/studio/sockets/chat-run.ts
+++ b/packages/server/src/modules/studio/sockets/chat-run.ts
@@ -2308,7 +2308,6 @@ export class ChatRunSocket {
         error: { code: 'location_failed' },
       })
     }
-    codingAgentRunManager.stop(sid, { reportClosed: false })
     for (const [requestId, pending] of this.pendingMobileCalendar.entries()) {
       if (pending.sessionId !== sid) continue
       this.finishMobileCalendarRequest(requestId, {

--- a/packages/server/src/modules/studio/sockets/chat-run.ts
+++ b/packages/server/src/modules/studio/sockets/chat-run.ts
@@ -184,7 +184,7 @@ function mobileCalendarRunInstruction(sessionId: string | undefined, source: str
     `The current Hermes Studio direct-chat session id is ${JSON.stringify(sessionId)}.`,
     'Only when the user explicitly asks to read or change calendar events, use hermes_studio_use_toolset to describe and call hermes_studio_use_mobile_calendar with this exact session_id.',
     'Only when the user explicitly asks to read or change reminders, use hermes_studio_use_toolset to describe and call hermes_studio_use_mobile_reminders with this exact session_id.',
-    'The App always asks the user to share once or confirm the write. Never use these tools proactively, in delegated/workflow/group tasks, for background access, or for delete operations.',
+    'The App always asks the user to share once or confirm the write. Never use these tools proactively, in delegated/workflow/group tasks, or for background access. Delete only the exact listed item after fresh App confirmation; never delete a whole recurring series.',
   ].join(' ')
 }
 type ChatRunBridgeReadiness =
@@ -504,6 +504,7 @@ export class ChatRunSocket {
         [idKey]: requestId,
         ...request,
         timeout_ms: Math.min(timeoutMs, MOBILE_CALENDAR_DEVICE_TIMEOUT_MS),
+        expires_at_ms: Date.now() + Math.min(timeoutMs, MOBILE_CALENDAR_DEVICE_TIMEOUT_MS),
       })
     })
   }

--- a/packages/server/src/modules/studio/sockets/chat-run.ts
+++ b/packages/server/src/modules/studio/sockets/chat-run.ts
@@ -1,3 +1,4 @@
+import { mobileDeviceRoom, mobileDeviceId, sameMobileDevice, mobileEventAllowed, type MobileDeviceTarget } from '../services/chat-run/mobile-device-target'
 /**
  * ChatRunSocket — Socket.IO namespace /chat-run.
  *
@@ -50,7 +51,7 @@ import type {
   QueuedRun,
   SessionState,
 } from '../services/chat-run/types'
-import { authenticateUserToken, isAuthEnabled, type AuthenticatedUser } from '../public/auth'
+import { authenticateUserToken, inspectAppUserToken, isAuthEnabled, type AuthenticatedUser } from '../public/auth'
 import { userCanAccessProfile } from '../repositories/users-store'
 import { observeRunChatPetEvent } from '../public/pet-events'
 import { observeChatRunWebhookEvent, type ChatRunWebhookAgent } from '../services/webhooks'
@@ -349,6 +350,7 @@ function normalizeMobileLocationResponse(value: unknown): MobileLocationResponse
 }
 
 type PendingMobileCalendarRequest = {
+  target: MobileDeviceTarget
   sessionId: string
   profile: string
   request: MobileCalendarRequest
@@ -372,6 +374,7 @@ export class ChatRunSocket {
   private bridgeResumePolls = new Set<string>()
   private readonly runWaiters = new Map<string, Set<(event: string, payload: any) => void>>()
   private readonly pendingMobileLocations = new Map<string, PendingMobileLocationRequest>()
+  private readonly mobileRunTargets = new Map<string, MobileDeviceTarget>()
   private readonly pendingMobileCalendar = new Map<string, PendingMobileCalendarRequest>()
   private backgroundPollTimer?: NodeJS.Timeout
   private backgroundPollInFlight = false
@@ -476,6 +479,10 @@ export class ChatRunSocket {
     for (const pending of this.pendingMobileCalendar.values()) {
       if (pending.sessionId === sessionId) throw new Error('A mobile calendar or reminder request is already pending')
     }
+    const target = this.mobileRunTargets.get(sessionId)
+    if (!target || target.profile !== profile) throw new Error('Mobile target unavailable; send a new message from the intended mobile device')
+    const room = this.nsp.adapter.rooms.get(mobileDeviceRoom(target))
+    if (!room?.size) throw new Error('Target mobile device is offline; reconnect the same device')
     const request = normalizeMobileCalendarRequest({
       capability: options.capability,
       action: options.action,
@@ -498,11 +505,14 @@ export class ChatRunSocket {
         })
       }, timeoutMs)
       timer.unref?.()
-      this.pendingMobileCalendar.set(requestId, { sessionId, profile, request, resolve, timer })
+      this.pendingMobileCalendar.set(requestId, { sessionId, profile, target, request, resolve, timer })
       this.emitMobileCalendarEvent(profile, sessionId, event, {
         event,
         [idKey]: requestId,
         ...request,
+        target_device_id: target.deviceCode,
+        target_user_id: target.userId,
+        target_profile: target.profile,
         timeout_ms: timeoutMs,
         expires_at_ms: Date.now() + timeoutMs,
       })
@@ -522,6 +532,13 @@ export class ChatRunSocket {
 
   private async authMiddleware(socket: Socket, next: (err?: Error) => void) {
     const token = socket.handshake.auth?.token as string | undefined
+    const appToken = token ? await inspectAppUserToken(token) : null
+    if (appToken) {
+      if (appToken.status !== 'active' || !appToken.user) return next(new Error('App device authentication failed'))
+      const profile = String(socket.handshake.query?.profile || 'default')
+      if (!this.canAccessProfile(appToken.user, profile)) return next(new Error('Profile access denied'))
+      socket.data.mobileDeviceTarget = { deviceCode: appToken.deviceCode, userId: String(appToken.user.id), profile }
+    }
     if (!await isAuthEnabled()) {
       next()
       return
@@ -545,6 +562,8 @@ export class ChatRunSocket {
     const socketUser = socket.data.user as AuthenticatedUser | undefined
     const socketProfile = (socket.handshake.query?.profile as string) || 'default'
     const currentProfile = () => socketProfile || getActiveProfileName() || 'default'
+    const mobileTarget = socket.data.mobileDeviceTarget as MobileDeviceTarget | undefined
+    if (mobileTarget) socket.join(mobileDeviceRoom(mobileTarget))
     socket.join(`pending-interactions:${currentProfile()}`)
     socket.emit('session.activity.snapshot', {
       event: 'session.activity.snapshot',
@@ -1122,6 +1141,10 @@ export class ChatRunSocket {
         })
         return
       }
+      if (!sameMobileDevice(pending.target, socket.data.mobileDeviceTarget)) {
+        socket.emit(resolvedEvent, { event: resolvedEvent, session_id: data.session_id, [idKey]: requestId, resolved: false, error: 'Response is not from the target device' })
+        return
+      }
       const response = normalizeMobileCalendarResponse(data, pending.request)
       if (!response) {
         this.finishMobileCalendarRequest(requestId, {
@@ -1203,6 +1226,12 @@ export class ChatRunSocket {
     backgroundContinuationContext?: BackgroundContinuationContext,
   ) {
     const source = resolveRunSource(data.source, data.session_id)
+    if (data.session_id) {
+      const target = socket.data?.mobileDeviceTarget as MobileDeviceTarget | undefined
+      if (target && target.profile === profile && source !== 'workflow' && source !== 'group_chat' && !backgroundContinuationContext) {
+        this.mobileRunTargets.set(data.session_id, { ...target })
+      } else this.mobileRunTargets.delete(data.session_id)
+    }
     const locationInstruction = mobileLocationRunInstruction(data.session_id, source)
     if (locationInstruction) {
       data.instructions = [String(data.instructions || '').trim(), locationInstruction]
@@ -1683,7 +1712,9 @@ export class ChatRunSocket {
       isWorking: state.isWorking,
       runStartedAt: state.runStartedAt,
       isAborting: state.isAborting || false,
-      events: buildResumeEvents(resumeEvents),
+      events: buildResumeEvents(resumeEvents.filter(entry =>
+        !['calendar.requested', 'reminder.requested', 'calendar.resolved', 'reminder.resolved'].includes(entry.event)
+        || mobileEventAllowed(entry.data, socket.data.mobileDeviceTarget))),
       inputTokens: state.inputTokens,
       outputTokens: state.outputTokens,
       contextTokens: state.contextTokens,
@@ -2277,6 +2308,7 @@ export class ChatRunSocket {
   async abortSession(sessionId: string, reason = 'Run canceled'): Promise<void> {
     const sid = String(sessionId || '').trim()
     if (!sid) return
+    this.mobileRunTargets.delete(sid)
     const fakeSocket = {
       id: `workflow-abort-${sid}`,
       connected: false,
@@ -2532,11 +2564,14 @@ export class ChatRunSocket {
     this.emitMobileCalendarEvent(pending.profile, pending.sessionId, event, {
       event,
       [idKey]: requestId,
+      target_device_id: pending.target.deviceCode,
+      target_user_id: pending.target.userId,
+      target_profile: pending.target.profile,
       status: response.status,
       resolved: true,
       ...(response.status === 'error' ? { error: response.error } : {}),
     })
-    pending.resolve(response)
+    pending.resolve({ ...response, device_id: mobileDeviceId(pending.target) })
     return true
   }
   private clearMobileCalendarEventState(sessionId: string, requestId: string): void {
@@ -2555,8 +2590,8 @@ export class ChatRunSocket {
         !['calendar.requested', 'calendar.resolved', 'reminder.requested', 'reminder.resolved'].includes(current))
       state.events.push({ event, data: tagged })
     }
-    this.emitPendingInteraction(profile, event, tagged)
-    this.nsp.to(`session:${sessionId}`).emit(event, tagged)
+    const target: MobileDeviceTarget = { deviceCode: payload.target_device_id, userId: payload.target_user_id, profile: payload.target_profile }
+    this.nsp.to(mobileDeviceRoom(target)).emit(event, tagged)
   }
   private emitToSession(socket: Socket, sessionId: string, event: string, payload: any) {
     const tagged = { ...payload, session_id: sessionId }

--- a/packages/server/src/modules/studio/sockets/chat-run.ts
+++ b/packages/server/src/modules/studio/sockets/chat-run.ts
@@ -55,6 +55,13 @@ import { userCanAccessProfile } from '../repositories/users-store'
 import { observeRunChatPetEvent } from '../public/pet-events'
 import { observeChatRunWebhookEvent, type ChatRunWebhookAgent } from '../services/webhooks'
 import { getAgentStatusSnapshot } from '../public/agent-status-registry'
+import {
+  normalizeMobileCalendarRequest,
+  normalizeMobileCalendarResponse,
+  type MobileCalendarCapability,
+  type MobileCalendarResponse,
+  type MobileCalendarRequest,
+} from '../services/chat-run/mobile-calendar'
 
 type AgentBridgeBackgroundNotification = any
 type AgentBridgeBackgroundSession = any
@@ -171,6 +178,15 @@ function mobileLocationRunInstruction(sessionId: string | undefined, source: str
   ].join(' ')
 }
 
+function mobileCalendarRunInstruction(sessionId: string | undefined, source: string | undefined): string {
+  if (!sessionId || source === 'workflow' || source === 'group_chat') return ''
+  return [
+    `The current Hermes Studio direct-chat session id is ${JSON.stringify(sessionId)}.`,
+    'Only when the user explicitly asks to read or change calendar events, use hermes_studio_use_toolset to describe and call hermes_studio_use_mobile_calendar with this exact session_id.',
+    'Only when the user explicitly asks to read or change reminders, use hermes_studio_use_toolset to describe and call hermes_studio_use_mobile_reminders with this exact session_id.',
+    'The App always asks the user to share once or confirm the write. Never use these tools proactively, in delegated/workflow/group tasks, for background access, or for delete operations.',
+  ].join(' ')
+}
 type ChatRunBridgeReadiness =
   | { ok: true }
   | { ok: false; error: string; runtimeUnavailable?: true }
@@ -332,6 +348,21 @@ function normalizeMobileLocationResponse(value: unknown): MobileLocationResponse
   return { status: 'success', location }
 }
 
+type PendingMobileCalendarRequest = {
+  sessionId: string
+  profile: string
+  request: MobileCalendarRequest
+  resolve: (response: MobileCalendarResponse) => void
+  timer: NodeJS.Timeout
+}
+const MOBILE_CALENDAR_MIN_TIMEOUT_MS = 3_000
+const MOBILE_CALENDAR_MAX_TIMEOUT_MS = 60_000
+const MOBILE_CALENDAR_DEVICE_TIMEOUT_MS = 30_000
+function boundedMobileCalendarTimeout(value: unknown): number {
+  const numeric = Math.round(Number(value))
+  if (!Number.isFinite(numeric)) return 35_000
+  return Math.max(MOBILE_CALENDAR_MIN_TIMEOUT_MS, Math.min(MOBILE_CALENDAR_MAX_TIMEOUT_MS, numeric))
+}
 export class ChatRunSocket {
   private nsp: ReturnType<Server['of']>
   private bridge = createPrimaryAgentBridge()
@@ -341,6 +372,7 @@ export class ChatRunSocket {
   private bridgeResumePolls = new Set<string>()
   private readonly runWaiters = new Map<string, Set<(event: string, payload: any) => void>>()
   private readonly pendingMobileLocations = new Map<string, PendingMobileLocationRequest>()
+  private readonly pendingMobileCalendar = new Map<string, PendingMobileCalendarRequest>()
   private backgroundPollTimer?: NodeJS.Timeout
   private backgroundPollInFlight = false
   private backgroundRecoveryNeeded = true
@@ -418,6 +450,63 @@ export class ChatRunSocket {
     })
   }
 
+  requestMobileCalendar(options: {
+    sessionId: string
+    profile: string
+    capability: MobileCalendarCapability
+    action?: unknown
+    purpose?: unknown
+    startMs?: unknown
+    endMs?: unknown
+    includeCompleted?: unknown
+    limit?: unknown
+    item?: unknown
+    timeoutMs?: unknown
+  }): Promise<MobileCalendarResponse> {
+    const sessionId = String(options.sessionId || '').trim()
+    const profile = String(options.profile || '').trim() || 'default'
+    const session = getSession(sessionId)
+    if (!session) throw new Error('Session not found')
+    if ((String(session.profile || '').trim() || 'default') !== profile) {
+      throw new Error('Session is not available for this profile')
+    }
+    if (session.source === 'group_chat' || session.source === 'workflow') {
+      throw new Error('Mobile calendar and reminders are available only in direct chats')
+    }
+    for (const pending of this.pendingMobileCalendar.values()) {
+      if (pending.sessionId === sessionId) throw new Error('A mobile calendar or reminder request is already pending')
+    }
+    const request = normalizeMobileCalendarRequest({
+      capability: options.capability,
+      action: options.action,
+      purpose: options.purpose,
+      start_ms: options.startMs,
+      end_ms: options.endMs,
+      include_completed: options.includeCompleted,
+      limit: options.limit,
+      item: options.item,
+    })
+    const requestId = randomUUID()
+    const timeoutMs = boundedMobileCalendarTimeout(options.timeoutMs)
+    const event = request.capability === 'reminder' ? 'reminder.requested' : 'calendar.requested'
+    const idKey = request.capability === 'reminder' ? 'reminder_request_id' : 'calendar_request_id'
+    return new Promise<MobileCalendarResponse>((resolve) => {
+      const timer = setTimeout(() => {
+        this.finishMobileCalendarRequest(requestId, {
+          status: 'error',
+          error: { code: 'calendar_failed' },
+        })
+      }, timeoutMs)
+      timer.unref?.()
+      this.pendingMobileCalendar.set(requestId, { sessionId, profile, request, resolve, timer })
+      this.emitMobileCalendarEvent(profile, sessionId, event, {
+        event,
+        [idKey]: requestId,
+        ...request,
+        timeout_ms: Math.min(timeoutMs, MOBILE_CALENDAR_DEVICE_TIMEOUT_MS),
+      })
+    })
+  }
   init() {
     this.closing = false
     this.nsp.use(this.authMiddleware.bind(this))
@@ -994,6 +1083,56 @@ export class ChatRunSocket {
       }
       this.finishMobileLocationRequest(data.location_request_id, response)
     })
+    const respondMobileCalendar = (
+      capability: MobileCalendarCapability,
+      data: {
+        session_id?: string
+        calendar_request_id?: string
+        reminder_request_id?: string
+        status?: string
+        result?: unknown
+        error?: unknown
+      },
+    ) => {
+      const requestId = capability === 'reminder' ? data.reminder_request_id : data.calendar_request_id
+      const resolvedEvent = capability === 'reminder' ? 'reminder.resolved' : 'calendar.resolved'
+      const idKey = capability === 'reminder' ? 'reminder_request_id' : 'calendar_request_id'
+      if (!data.session_id || !requestId) return
+      try {
+        requireSocketSessionAccess(data.session_id)
+      } catch (err) {
+        socket.emit(resolvedEvent, {
+          event: resolvedEvent,
+          session_id: data.session_id,
+          [idKey]: requestId,
+          resolved: false,
+          error: err instanceof Error ? err.message : String(err),
+        })
+        return
+      }
+      const pending = this.pendingMobileCalendar.get(requestId)
+      if (!pending || pending.sessionId !== data.session_id || pending.request.capability !== capability) {
+        this.emitToSession(socket, data.session_id, resolvedEvent, {
+          event: resolvedEvent,
+          [idKey]: requestId,
+          resolved: false,
+          stale: true,
+          error: 'Calendar or reminder request is no longer pending.',
+        })
+        return
+      }
+      const response = normalizeMobileCalendarResponse(data, pending.request)
+      if (!response) {
+        this.finishMobileCalendarRequest(requestId, {
+          status: 'error',
+          error: { code: 'calendar_invalid_request' },
+        })
+        return
+      }
+      this.finishMobileCalendarRequest(requestId, response)
+    }
+    socket.on('calendar.respond', data => respondMobileCalendar('calendar', data))
+    socket.on('reminder.respond', data => respondMobileCalendar('reminder', data))
   }
 
   respondCodingAgentApproval(sessionId: string, approvalId: string, choice: string): boolean {
@@ -1066,6 +1205,12 @@ export class ChatRunSocket {
     const locationInstruction = mobileLocationRunInstruction(data.session_id, source)
     if (locationInstruction) {
       data.instructions = [String(data.instructions || '').trim(), locationInstruction]
+        .filter(Boolean)
+        .join('\n\n')
+    }
+    const calendarInstruction = mobileCalendarRunInstruction(data.session_id, source)
+    if (calendarInstruction) {
+      data.instructions = [String(data.instructions || '').trim(), calendarInstruction]
         .filter(Boolean)
         .join('\n\n')
     }
@@ -2164,6 +2309,14 @@ export class ChatRunSocket {
       })
     }
     codingAgentRunManager.stop(sid, { reportClosed: false })
+    for (const [requestId, pending] of this.pendingMobileCalendar.entries()) {
+      if (pending.sessionId !== sid) continue
+      this.finishMobileCalendarRequest(requestId, {
+        status: 'error',
+        error: { code: 'calendar_failed' },
+      })
+    }
+    codingAgentRunManager.stop(sid, { reportClosed: false })
     const state = this.sessionMap.get(sid)
     state?.abortController?.abort()
     this.sessionMap.delete(sid)
@@ -2368,6 +2521,43 @@ export class ChatRunSocket {
     this.emitPendingInteraction(profile, event, tagged)
   }
 
+  private finishMobileCalendarRequest(requestId: string, response: MobileCalendarResponse): boolean {
+    const pending = this.pendingMobileCalendar.get(requestId)
+    if (!pending) return false
+    this.pendingMobileCalendar.delete(requestId)
+    clearTimeout(pending.timer)
+    this.clearMobileCalendarEventState(pending.sessionId, requestId)
+    const event = pending.request.capability === 'reminder' ? 'reminder.resolved' : 'calendar.resolved'
+    const idKey = pending.request.capability === 'reminder' ? 'reminder_request_id' : 'calendar_request_id'
+    this.emitMobileCalendarEvent(pending.profile, pending.sessionId, event, {
+      event,
+      [idKey]: requestId,
+      status: response.status,
+      resolved: true,
+      ...(response.status === 'error' ? { error: response.error } : {}),
+    })
+    pending.resolve(response)
+    return true
+  }
+  private clearMobileCalendarEventState(sessionId: string, requestId: string): void {
+    const state = this.sessionMap.get(sessionId)
+    if (!state?.events.length) return
+    state.events = state.events.filter(({ event, data }) => {
+      if (!['calendar.requested', 'calendar.resolved', 'reminder.requested', 'reminder.resolved'].includes(event)) return true
+      return data?.calendar_request_id !== requestId && data?.reminder_request_id !== requestId
+    })
+  }
+  private emitMobileCalendarEvent(profile: string, sessionId: string, event: string, payload: any): void {
+    const tagged = { ...payload, session_id: sessionId }
+    if (event === 'calendar.requested' || event === 'reminder.requested') {
+      const state = getOrCreateSession(this.sessionMap, sessionId)
+      state.events = state.events.filter(({ event: current }) =>
+        !['calendar.requested', 'calendar.resolved', 'reminder.requested', 'reminder.resolved'].includes(current))
+      state.events.push({ event, data: tagged })
+    }
+    this.emitPendingInteraction(profile, event, tagged)
+    this.nsp.to(`session:${sessionId}`).emit(event, tagged)
+  }
   private emitToSession(socket: Socket, sessionId: string, event: string, payload: any) {
     const tagged = { ...payload, session_id: sessionId }
     const profile = this.resolvePetEventProfile(sessionId, tagged)
@@ -2397,7 +2587,9 @@ export class ChatRunSocket {
     this.emitSessionActivity(profile, event, payload)
     if (event !== 'approval.requested' && event !== 'approval.resolved'
       && event !== 'clarify.requested' && event !== 'clarify.resolved'
-      && event !== 'location.requested' && event !== 'location.resolved') return
+      && event !== 'location.requested' && event !== 'location.resolved'
+      && event !== 'calendar.requested' && event !== 'calendar.resolved'
+      && event !== 'reminder.requested' && event !== 'reminder.resolved') return
     const sessionId = typeof payload?.session_id === 'string' ? payload.session_id : ''
     const source = sessionId
       ? this.sessionMap.get(sessionId)?.source || getSession(sessionId)?.source
@@ -2458,6 +2650,12 @@ export class ChatRunSocket {
       this.finishMobileLocationRequest(requestId, {
         status: 'error',
         error: { code: 'location_failed' },
+      })
+    }
+    for (const requestId of [...this.pendingMobileCalendar.keys()]) {
+      this.finishMobileCalendarRequest(requestId, {
+        status: 'error',
+        error: { code: 'calendar_failed' },
       })
     }
     const releaseClaims: Array<Promise<unknown>> = []

--- a/scripts/generate-openapi.mjs
+++ b/scripts/generate-openapi.mjs
@@ -1033,6 +1033,46 @@ openapi.paths['/api/studio/chat-run/runs'] = {
   },
 }
 
+openapi.paths['/api/studio/mobile-calendar/request'] = {
+  post: {
+    tags: ['Chat Run'],
+    summary: 'Request one-time mobile calendar or reminder access',
+    description: 'Requests a user-confirmed calendar/reminder operation from the App for the exact authenticated direct-chat session. Delete, background, workflow, group-chat, and delegated use are not supported.',
+    operationId: 'requestMobileCalendar',
+    security: [{ BearerAuth: [] }],
+    requestBody: {
+      required: true,
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            required: ['session_id', 'capability', 'action', 'purpose'],
+            properties: {
+              session_id: { type: 'string' },
+              capability: { type: 'string', enum: ['calendar', 'reminder'] },
+              action: { type: 'string', enum: ['list', 'create', 'update', 'complete'] },
+              purpose: { type: 'string', maxLength: 240 },
+              start_ms: { type: 'number' },
+              end_ms: { type: 'number' },
+              include_completed: { type: 'boolean' },
+              limit: { type: 'integer', minimum: 1, maximum: 100 },
+              item: { type: 'object', additionalProperties: true },
+              timeout_ms: { type: 'integer', minimum: 3000, maximum: 60000 },
+            },
+          },
+        },
+      },
+    },
+    responses: {
+      '200': { description: 'Confirmed App result, denial, or sanitized device error' },
+      '400': { $ref: '#/components/responses/BadRequest' },
+      '401': { $ref: '#/components/responses/Unauthorized' },
+      '404': { $ref: '#/components/responses/NotFound' },
+      '503': { description: 'Chat run service unavailable' },
+    },
+  },
+}
+
 // Add WebSocket terminal endpoint
 openapi.paths['/api/hermes/terminal'] = {
   'get': {

--- a/scripts/generate-openapi.mjs
+++ b/scripts/generate-openapi.mjs
@@ -1037,7 +1037,7 @@ openapi.paths['/api/studio/mobile-calendar/request'] = {
   post: {
     tags: ['Chat Run'],
     summary: 'Request one-time mobile calendar or reminder access',
-    description: 'Requests a user-confirmed calendar/reminder operation from the App for the exact authenticated direct-chat session. Delete, background, workflow, group-chat, and delegated use are not supported.',
+    description: 'Requests a user-confirmed calendar/reminder operation from the App for the exact authenticated direct-chat session. Single-item delete requires exact id, title and occurrence time with fresh App confirmation. Background, workflow, group-chat, and delegated use are not supported.',
     operationId: 'requestMobileCalendar',
     security: [{ BearerAuth: [] }],
     requestBody: {
@@ -1050,7 +1050,7 @@ openapi.paths['/api/studio/mobile-calendar/request'] = {
             properties: {
               session_id: { type: 'string' },
               capability: { type: 'string', enum: ['calendar', 'reminder'] },
-              action: { type: 'string', enum: ['list', 'create', 'update', 'complete'] },
+              action: { type: 'string', enum: ['list', 'create', 'update', 'complete', 'delete'] },
               purpose: { type: 'string', maxLength: 240 },
               start_ms: { type: 'number' },
               end_ms: { type: 'number' },

--- a/scripts/generate-openapi.mjs
+++ b/scripts/generate-openapi.mjs
@@ -1057,7 +1057,7 @@ openapi.paths['/api/studio/mobile-calendar/request'] = {
               include_completed: { type: 'boolean' },
               limit: { type: 'integer', minimum: 1, maximum: 100 },
               item: { type: 'object', additionalProperties: true },
-              timeout_ms: { type: 'integer', minimum: 3000, maximum: 60000 },
+              timeout_ms: { type: 'integer', minimum: 3000, maximum: 300000, default: 300000 },
             },
           },
         },

--- a/tests/server/coding-agent-resume-config.test.ts
+++ b/tests/server/coding-agent-resume-config.test.ts
@@ -376,6 +376,7 @@ describe('coding agent resumed session config', () => {
       provider: 'global',
       model: '',
       env: {
+        HERMES_STUDIO_SESSION_ID: 'session-1',
         CODEX_HOME: expect.stringContaining(join('coding-agent', 'model', 'default', 'global', 'codex', 'runs')),
       },
       args: [],

--- a/tests/server/coding-agents-launch.test.ts
+++ b/tests/server/coding-agents-launch.test.ts
@@ -1207,6 +1207,7 @@ describe('coding agent launch preparation', () => {
     expect(codexConfig).toContain('[mcp_servers.hermes-studio-browser]')
     expect(codexConfig).toContain('[mcp_servers.hermes-studio-devices]')
     expect(codexConfig).toContain('[mcp_servers.hermes-studio-use]')
+    expect(codexConfig).toMatch(/\[mcp_servers.hermes-studio-use\][\s\S]*?tool_timeout_sec = 360/)
   })
 
   it('inherits external MCP configs for scoped Claude and Codex launches', async () => {
@@ -1335,6 +1336,7 @@ describe('coding agent launch preparation', () => {
     expect(codexConfig).toContain('[mcp_servers.hermes-studio-browser]')
     expect(codexConfig).toContain('[mcp_servers.hermes-studio-devices]')
     expect(codexConfig).toContain('[mcp_servers.hermes-studio-use]')
+    expect(codexConfig).toMatch(/\[mcp_servers.hermes-studio-use\][\s\S]*?tool_timeout_sec = 360/)
   })
 
   it('isolates Claude Code settings for hidden chat runs only', async () => {

--- a/tests/server/coding-agents-launch.test.ts
+++ b/tests/server/coding-agents-launch.test.ts
@@ -1671,6 +1671,23 @@ describe('coding agent launch preparation', () => {
     ]))
   })
 
+  it('binds managed mobile MCP calls to the current Studio chat session for Codex', async () => {
+    makeHome()
+
+    const result = await prepareCodingAgentLaunch('codex', {
+      profile: 'default',
+      provider: 'openrouter',
+      model: 'openai/gpt-oss-20b:free',
+      baseUrl: 'https://openrouter.ai/api/v1',
+      apiKey: 'sk-test',
+      sessionId: 'studio-chat-session',
+    })
+
+    expect(result.env.HERMES_STUDIO_SESSION_ID).toBe('studio-chat-session')
+    expect(readFileSync(join(result.rootDir, 'launch.sh'), 'utf-8'))
+      .toContain('export HERMES_STUDIO_SESSION_ID=studio-chat-session')
+  })
+
   it('runs scoped Grok through the local proxy without writing the upstream secret to disk', async () => {
     const home = makeHome()
 

--- a/tests/server/hermes-web-ui-mcp.test.ts
+++ b/tests/server/hermes-web-ui-mcp.test.ts
@@ -459,6 +459,18 @@ describe('hermes-web-ui MCP server', () => {
         })
         return
       }
+      if (req.url === '/api/studio/mobile-calendar/request' && req.method === 'POST') {
+        let raw = ''
+        req.on('data', chunk => { raw += chunk })
+        req.on('end', () => {
+          res.end(JSON.stringify({
+            ok: true,
+            status: 'success',
+            body: raw ? JSON.parse(raw) : null,
+          }))
+        })
+        return
+      }
       if (req.url === '/api/studio/workflows?profile=default') {
         res.end(JSON.stringify({ workflows: [{ id: 'workflow-1', name: 'Demo workflow', profile: 'default' }] }))
         return
@@ -528,6 +540,7 @@ describe('hermes-web-ui MCP server', () => {
       env: {
         ...process.env,
         HERMES_WEB_UI_URL: `http://127.0.0.1:${address.port}`,
+        HERMES_STUDIO_SESSION_ID: 'studio-codex-session',
       },
     })
     child.stdout.on('data', (chunk) => {
@@ -562,6 +575,32 @@ describe('hermes-web-ui MCP server', () => {
         action: 'call',
         tool: 'hermes_studio_use_sessions_count',
         arguments: { source: 'coding_agent' },
+      },
+    })
+    writeRpc(child, 136, 'tools/call', {
+      name: 'hermes_studio_use_toolset',
+      arguments: {
+        action: 'call',
+        tool: 'hermes_studio_use_mobile_location',
+        arguments: {
+          session_id: 'session-1',
+          purpose: 'Find nearby restaurants',
+          accuracy: 'coarse',
+          timeout_ms: 10000,
+        },
+      },
+    })
+    writeRpc(child, 36, 'tools/call', {
+      name: 'hermes_studio_use_toolset',
+      arguments: {
+        action: 'call',
+        tool: 'hermes_studio_use_mobile_calendar',
+        arguments: {
+          session_id: 'codex-runtime-thread-id',
+          action: 'list',
+          purpose: 'Verify calendar access',
+          limit: 20,
+        },
       },
     })
     writeRpc(child, 3, 'tools/call', {
@@ -647,19 +686,6 @@ describe('hermes-web-ui MCP server', () => {
       name: 'hermes_studio_use_worker_status',
       arguments: {},
     })
-    writeRpc(child, 36, 'tools/call', {
-      name: 'hermes_studio_use_toolset',
-      arguments: {
-        action: 'call',
-        tool: 'hermes_studio_use_mobile_location',
-        arguments: {
-          session_id: 'session-1',
-          purpose: 'Find nearby restaurants',
-          accuracy: 'coarse',
-          timeout_ms: 10000,
-        },
-      },
-    })
     writeRpc(child, 20, 'tools/call', {
       name: 'hermes_studio_use_workflows_list',
       arguments: { profile: 'default' },
@@ -720,7 +746,7 @@ describe('hermes-web-ui MCP server', () => {
     expect(list.result.tools[0].description).toContain('internal delegation')
 
     const catalog = JSON.parse((await waitForRpc(responses, 32)).result.content[0].text)
-    expect(catalog).toMatchObject({ toolset: 'use', operation_count: 26 })
+    expect(catalog).toMatchObject({ toolset: 'use', operation_count: 28 })
     expect(catalog.operations.map((tool: any) => tool.name)).toEqual(expect.arrayContaining([
       'hermes_studio_use_chat_run',
       'hermes_studio_use_sessions_count',
@@ -729,6 +755,8 @@ describe('hermes-web-ui MCP server', () => {
       'hermes_studio_use_provider_add',
       'hermes_studio_use_worker_status',
       'hermes_studio_use_mobile_location',
+      'hermes_studio_use_mobile_calendar',
+      'hermes_studio_use_mobile_reminders',
       'hermes_studio_use_workflows_list',
       'hermes_studio_use_workflow_rerun_node',
     ]))
@@ -754,7 +782,7 @@ describe('hermes-web-ui MCP server', () => {
     }
     const gatewaySessionCount = JSON.parse((await waitForRpc(responses, 35)).result.content[0].text)
     expect(gatewaySessionCount.count).toBe(7)
-    const mobileLocation = JSON.parse((await waitForRpc(responses, 36)).result.content[0].text)
+    const mobileLocation = JSON.parse((await waitForRpc(responses, 136)).result.content[0].text)
     expect(mobileLocation).toMatchObject({
       ok: true,
       status: 'success',
@@ -771,6 +799,18 @@ describe('hermes-web-ui MCP server', () => {
       },
     })
 
+    const mobileCalendar = JSON.parse((await waitForRpc(responses, 36)).result.content[0].text)
+    expect(mobileCalendar).toMatchObject({
+      ok: true,
+      status: 'success',
+      body: {
+        capability: 'calendar',
+        session_id: 'studio-codex-session',
+        action: 'list',
+        purpose: 'Verify calendar access',
+        limit: 20,
+      },
+    })
     const chatRun = JSON.parse((await waitForRpc(responses, 3)).result.content[0].text)
     expect(chatRun.body).toMatchObject({ input: 'hello', session_id: 'session-1', include_events: true })
     const sessions = JSON.parse((await waitForRpc(responses, 4)).result.content[0].text)

--- a/tests/server/mobile-calendar-delete.test.ts
+++ b/tests/server/mobile-calendar-delete.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import { normalizeMobileCalendarRequest as request, normalizeMobileCalendarResponse as response } from '../../packages/server/src/modules/studio/services/chat-run/mobile-calendar'
+
+describe('confirmed mobile deletion contract', () => {
+  it.each(['calendar', 'reminder'])('requires exact identity for %s', capability => {
+    const base = { capability, action: 'delete', purpose: 'Delete the selected test item' }
+    for (const item of [{}, { title: 'test' }, { id: ['1'], title: 'test' }, { id: '1' }]) {
+      expect(() => request({ ...base, item })).toThrow()
+    }
+    const value = request({ ...base, item: { id: '1', title: 'test', start_ms: 1788624000000, due_ms: 1788624000000, deleteAll: true } })
+    expect(value.item).not.toHaveProperty('deleteAll')
+    expect(response({ status: 'success', result: { item: { id: '1', deleted: true, private: 'hidden' } } }, value))
+      .toEqual({ status: 'success', result: { capability, action: 'delete', item: { id: '1', deleted: true } } })
+    expect(response({ status: 'success', result: { item: { id: 'other', deleted: true } } }, value)).toBeNull()
+    expect(response({ status: 'success', result: {} }, value)).toBeNull()
+    expect(response({ status: 'denied' }, value)).toEqual({ status: 'denied' })
+  })
+  it('does not invent an occurrence for calendar deletion', () => {
+    for (const start_ms of [undefined, null, NaN, 'tomorrow']) {
+      expect(() => request({ capability: 'calendar', action: 'delete', purpose: 'test', item: { id: '1', title: 'test', start_ms } })).toThrow()
+    }
+  })
+})

--- a/tests/server/mobile-consent-transport.test.ts
+++ b/tests/server/mobile-consent-transport.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs'
+import { request as httpRequest, createServer } from 'node:http'
+import { request as httpsRequest } from 'node:https'
+import { runInNewContext } from 'node:vm'
+import { expect, it } from 'vitest'
+
+it('keeps a distinct HTTP deadline and returns the business expiry without retrying', async () => {
+  const source = readFileSync('bin/hermes-studio-mcp.mjs', 'utf8')
+  const fn = source.slice(source.indexOf('async function fetchMobileConsent('), source.indexOf('async function requestEnvelope('))
+  let budget = 0
+  const fetchConsent = runInNewContext(`${fn}; fetchMobileConsent`, {
+    httpRequest, httpsRequest, URL, Headers, Buffer, Error,
+    setTimeout: (callback: () => void, ms: number) => { budget = ms; return setTimeout(callback, ms) }, clearTimeout,
+  })
+  let calls = 0
+  const server = createServer((_req, res) => {
+    calls++
+    setTimeout(() => { res.setHeader('Content-Type', 'application/json'); res.end(JSON.stringify({ status: 'error', error: { code: 'calendar_failed' } })) }, 30)
+  })
+  await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve))
+  try {
+    const port = (server.address() as { port: number }).port
+    const result = await fetchConsent(`http://127.0.0.1:${port}`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}' })
+    expect(budget).toBe(330000)
+    expect(result.status).toBe(200)
+    expect(JSON.parse(await result.text())).toEqual({ status: 'error', error: { code: 'calendar_failed' } })
+    expect(calls).toBe(1)
+  } finally { await new Promise<void>(resolve => server.close(() => resolve())) }
+})

--- a/tests/server/mobile-device-target.test.ts
+++ b/tests/server/mobile-device-target.test.ts
@@ -1,0 +1,13 @@
+import { expect, it } from 'vitest'
+import { mobileDeviceRoom, mobileDeviceId, sameMobileDevice, mobileEventAllowed } from '../../packages/server/src/modules/studio/services/chat-run/mobile-device-target'
+it('isolates room and replay by authenticated user, device and Profile',()=>{
+ const a={userId:'1',deviceCode:'iphone',profile:'default'}
+ for(const b of [{...a,userId:'2'},{...a,deviceCode:'android'},{...a,profile:'work'}]) {
+  expect(mobileDeviceRoom(a)).not.toBe(mobileDeviceRoom(b))
+  expect(sameMobileDevice(a,b)).toBe(false)
+  expect(mobileEventAllowed({target_device_id:a.deviceCode,target_user_id:a.userId,target_profile:a.profile},b)).toBe(false)
+ }
+ expect(mobileEventAllowed({},a)).toBe(false)
+ expect(mobileDeviceId(a)).not.toContain('iphone')
+ expect(sameMobileDevice(a,{...a})).toBe(true)
+})

--- a/tests/server/run-chat-mobile-calendar.test.ts
+++ b/tests/server/run-chat-mobile-calendar.test.ts
@@ -141,6 +141,24 @@ describe('ChatRunSocket mobile calendar and reminders', () => {
     } finally { vi.useRealTimers() }
   })
 
+  it.each([undefined, null, 0, 600000, 300000])('uses a matching five-minute card/server deadline for %s', async timeoutMs => {
+    vi.useFakeTimers()
+    try {
+      const { ChatRunSocket } = await import('../../packages/server/src/modules/studio/sockets/chat-run')
+      const { emitted, io } = harness()
+      const server = new ChatRunSocket(io as any)
+      const promise = server.requestMobileCalendar({ sessionId: 'session-1', profile: 'default', capability: 'reminder', action: 'list', purpose: 'test', timeoutMs })
+      const event = emitted.find(entry => entry.event === 'reminder.requested')!.payload
+      expect(event.timeout_ms).toBe(300000)
+      expect(event.expires_at_ms).toBe(Date.now() + 300000)
+      await vi.advanceTimersByTimeAsync(60001)
+      expect((server as any).pendingMobileCalendar.size).toBe(1)
+      await vi.advanceTimersByTimeAsync(239999)
+      await expect(promise).resolves.toMatchObject({ status: 'error' })
+      expect((server as any).pendingMobileCalendar.size).toBe(0)
+    } finally { vi.useRealTimers() }
+  })
+
   it('supports reminder completion but rejects incomplete delete and workflow requests', async () => {
     const { ChatRunSocket } = await import('../../packages/server/src/modules/studio/sockets/chat-run')
     const { io } = harness()

--- a/tests/server/run-chat-mobile-calendar.test.ts
+++ b/tests/server/run-chat-mobile-calendar.test.ts
@@ -117,7 +117,31 @@ describe('ChatRunSocket mobile calendar and reminders', () => {
     expect((server as any).sessionMap.get('session-1').events).toEqual([])
   })
 
-  it('supports reminder completion but rejects delete and workflow requests', async () => {
+  it('requires fresh deletion confirmation and rejects late responses', async () => {
+    vi.useFakeTimers()
+    try {
+      const { ChatRunSocket } = await import('../../packages/server/src/modules/studio/sockets/chat-run')
+      const { emitted, handlers, io, socket } = harness()
+      const server = new ChatRunSocket(io as any)
+      ;(server as any).onConnection(socket)
+      const options = { sessionId: 'session-1', profile: 'default', capability: 'reminder' as const,
+        action: 'delete', purpose: 'Delete test', item: { id: '1', title: 'test' }, timeoutMs: 3000 }
+      const pending = server.requestMobileCalendar(options)
+      const first = emitted.find(item => item.event === 'reminder.requested')!.payload
+      expect(first.expires_at_ms).toBe(Date.now() + 3000)
+      handlers.get('reminder.respond')?.({ session_id: 'session-1', reminder_request_id: first.reminder_request_id, status: 'denied' })
+      await expect(pending).resolves.toEqual({ status: 'denied' })
+      const timed = server.requestMobileCalendar(options)
+      await vi.advanceTimersByTimeAsync(3001)
+      await expect(timed).resolves.toMatchObject({ status: 'error' })
+      expect((server as any).pendingMobileCalendar.size).toBe(0)
+      handlers.get('reminder.respond')?.({ session_id: 'session-1', reminder_request_id: first.reminder_request_id,
+        status: 'success', result: { item: { id: '1', deleted: true } } })
+      expect((server as any).pendingMobileCalendar.size).toBe(0)
+    } finally { vi.useRealTimers() }
+  })
+
+  it('supports reminder completion but rejects incomplete delete and workflow requests', async () => {
     const { ChatRunSocket } = await import('../../packages/server/src/modules/studio/sockets/chat-run')
     const { io } = harness()
     const server = new ChatRunSocket(io as any)
@@ -128,7 +152,7 @@ describe('ChatRunSocket mobile calendar and reminders', () => {
       action: 'delete',
       purpose: 'Delete it',
       item: { id: '1' },
-    })).toThrow('Unsupported reminder action')
+    })).toThrow('A valid item is required')
     sessionStoreMock.getSession.mockReturnValue({ id: 'session-1', profile: 'default', source: 'workflow' })
     expect(() => server.requestMobileCalendar({
       sessionId: 'session-1',

--- a/tests/server/run-chat-mobile-calendar.test.ts
+++ b/tests/server/run-chat-mobile-calendar.test.ts
@@ -1,3 +1,5 @@
+import { mobileDeviceRoom, mobileDeviceId } from '../../packages/server/src/modules/studio/services/chat-run/mobile-device-target'
+const target = { deviceCode: 'iphone', userId: '1', profile: 'default' }
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const bridgeMock = vi.hoisted(() => ({ statusIfLoaded: vi.fn() }))
@@ -42,7 +44,7 @@ function harness() {
   const handlers = new Map<string, Function>()
   const emitted: Array<{ room: string; event: string; payload: any }> = []
   const namespace = {
-    adapter: { rooms: new Map([['session:session-1', new Set(['socket-1'])]]) },
+    adapter: { rooms: new Map([['session:session-1', new Set(['socket-1'])], [mobileDeviceRoom(target), new Set(['socket-1'])]]) },
     sockets: new Map(),
     to: vi.fn((room: string) => ({ emit: vi.fn((event: string, payload: any) => emitted.push({ room, event, payload })) })),
     use: vi.fn(), on: vi.fn(), emit: vi.fn(),
@@ -50,7 +52,7 @@ function harness() {
   const socket = {
     id: 'socket-1',
     connected: true,
-    data: {},
+    data: { mobileDeviceTarget: target },
     handshake: { auth: {}, query: { profile: 'default' } },
     on: vi.fn((event: string, handler: Function) => handlers.set(event, handler)),
     join: vi.fn(),
@@ -75,6 +77,7 @@ describe('ChatRunSocket mobile calendar and reminders', () => {
     const { ChatRunSocket } = await import('../../packages/server/src/modules/studio/sockets/chat-run')
     const { emitted, handlers, io, socket } = harness()
     const server = new ChatRunSocket(io as any)
+    ;(server as any).mobileRunTargets.set('session-1', target)
     ;(server as any).sessionMap.set('session-1', {
       messages: [], events: [], queue: [], isWorking: true, profile: 'default', source: 'coding_agent',
     })
@@ -107,6 +110,7 @@ describe('ChatRunSocket mobile calendar and reminders', () => {
       },
     })
     await expect(resultPromise).resolves.toEqual({
+      device_id: mobileDeviceId(target),
       status: 'success',
       result: {
         capability: 'calendar',
@@ -123,6 +127,7 @@ describe('ChatRunSocket mobile calendar and reminders', () => {
       const { ChatRunSocket } = await import('../../packages/server/src/modules/studio/sockets/chat-run')
       const { emitted, handlers, io, socket } = harness()
       const server = new ChatRunSocket(io as any)
+    ;(server as any).mobileRunTargets.set('session-1', target)
       ;(server as any).onConnection(socket)
       const options = { sessionId: 'session-1', profile: 'default', capability: 'reminder' as const,
         action: 'delete', purpose: 'Delete test', item: { id: '1', title: 'test' }, timeoutMs: 3000 }
@@ -130,7 +135,7 @@ describe('ChatRunSocket mobile calendar and reminders', () => {
       const first = emitted.find(item => item.event === 'reminder.requested')!.payload
       expect(first.expires_at_ms).toBe(Date.now() + 3000)
       handlers.get('reminder.respond')?.({ session_id: 'session-1', reminder_request_id: first.reminder_request_id, status: 'denied' })
-      await expect(pending).resolves.toEqual({ status: 'denied' })
+      await expect(pending).resolves.toEqual({ status: 'denied', device_id: mobileDeviceId(target) })
       const timed = server.requestMobileCalendar(options)
       await vi.advanceTimersByTimeAsync(3001)
       await expect(timed).resolves.toMatchObject({ status: 'error' })
@@ -147,6 +152,7 @@ describe('ChatRunSocket mobile calendar and reminders', () => {
       const { ChatRunSocket } = await import('../../packages/server/src/modules/studio/sockets/chat-run')
       const { emitted, io } = harness()
       const server = new ChatRunSocket(io as any)
+    ;(server as any).mobileRunTargets.set('session-1', target)
       const promise = server.requestMobileCalendar({ sessionId: 'session-1', profile: 'default', capability: 'reminder', action: 'list', purpose: 'test', timeoutMs })
       const event = emitted.find(entry => entry.event === 'reminder.requested')!.payload
       expect(event.timeout_ms).toBe(300000)
@@ -159,10 +165,38 @@ describe('ChatRunSocket mobile calendar and reminders', () => {
     } finally { vi.useRealTimers() }
   })
 
+  it('rejects non-target responses and never broadcasts requested events to other devices', async () => {
+    const { ChatRunSocket } = await import('../../packages/server/src/modules/studio/sockets/chat-run')
+    const { emitted, handlers, io, socket } = harness()
+    const server = new ChatRunSocket(io as any)
+    ;(server as any).mobileRunTargets.set('session-1', target)
+    ;(server as any).onConnection(socket)
+    const result = server.requestMobileCalendar({ sessionId:'session-1', profile:'default', capability:'reminder', action:'list', purpose:'test' })
+    const requests = emitted.filter(v=>v.event==='reminder.requested')
+    expect(requests).toHaveLength(1)
+    expect(requests[0].room).toBe(mobileDeviceRoom(target))
+    const id=requests[0].payload.reminder_request_id
+    socket.data.mobileDeviceTarget={...target,deviceCode:'android'}
+    handlers.get('reminder.respond')?.({session_id:'session-1',reminder_request_id:id,status:'denied'})
+    expect((server as any).pendingMobileCalendar.size).toBe(1)
+    socket.data.mobileDeviceTarget=target
+    handlers.get('reminder.respond')?.({session_id:'session-1',reminder_request_id:id,status:'denied'})
+    await expect(result).resolves.toMatchObject({status:'denied',device_id:mobileDeviceId(target)})
+  })
+  it('fails closed for missing origin and offline target even if another device is online', async () => {
+    const { ChatRunSocket } = await import('../../packages/server/src/modules/studio/sockets/chat-run')
+    const { io } = harness();const server=new ChatRunSocket(io as any)
+    const options={sessionId:'session-1',profile:'default',capability:'reminder' as const,action:'list',purpose:'test'}
+    expect(()=>server.requestMobileCalendar(options)).toThrow('Mobile target unavailable')
+    ;(server as any).mobileRunTargets.set('session-1',{...target,deviceCode:'offline'})
+    expect(()=>server.requestMobileCalendar(options)).toThrow('offline')
+  })
+
   it('supports reminder completion but rejects incomplete delete and workflow requests', async () => {
     const { ChatRunSocket } = await import('../../packages/server/src/modules/studio/sockets/chat-run')
     const { io } = harness()
     const server = new ChatRunSocket(io as any)
+    ;(server as any).mobileRunTargets.set('session-1', target)
     expect(() => server.requestMobileCalendar({
       sessionId: 'session-1',
       profile: 'default',

--- a/tests/server/run-chat-mobile-calendar.test.ts
+++ b/tests/server/run-chat-mobile-calendar.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const bridgeMock = vi.hoisted(() => ({ statusIfLoaded: vi.fn() }))
+vi.mock('../../packages/server/src/modules/studio/public/chat-agent-runtime', () => ({
+  createPrimaryAgentBridge: vi.fn(() => bridgeMock),
+  getPrimaryAgentBridgeManager: vi.fn(() => ({ start: vi.fn(async () => {}), ensureReady: vi.fn() })),
+  redactPrimaryAgentBridgeError: (error?: string) => error,
+  chatCodingAgentRunManager: {
+    resolveApproval: vi.fn(() => ({ handled: false, resolved: false })),
+    resolveClarification: vi.fn(() => ({ handled: false, resolved: false })),
+    stop: vi.fn(),
+  },
+  handleChatCodingAgentSessionCommand: vi.fn(),
+  parseChatCodingAgentSessionCommand: vi.fn(() => null),
+  getChatEkkoAgent: vi.fn(() => ({ requestBoundaryInterrupt: vi.fn() })),
+  respondToChatEkkoToolApproval: vi.fn(() => ({ handled: false, resolved: false })),
+  respondToChatEkkoClarification: vi.fn(() => ({ handled: false, resolved: false })),
+}))
+vi.mock('../../packages/server/src/modules/studio/public/logging', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+const sessionStoreMock = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  getSessionMetadata: vi.fn(() => null),
+  getSessionDetail: vi.fn(() => null),
+}))
+vi.mock('../../packages/server/src/modules/studio/repositories/session-store', () => sessionStoreMock)
+vi.mock('../../packages/server/src/modules/studio/public/profile-config', () => ({
+  getActiveProfileName: vi.fn(() => 'default'),
+  getProfileDir: vi.fn(() => '/tmp/hermes-default'),
+  listProfileNamesFromDisk: vi.fn(() => ['default']),
+}))
+vi.mock('../../packages/server/src/modules/studio/public/auth', () => ({
+  authenticateUserToken: vi.fn(),
+  isAuthEnabled: vi.fn(async () => false),
+}))
+vi.mock('../../packages/server/src/modules/studio/repositories/users-store', () => ({
+  userCanAccessProfile: vi.fn(() => true),
+}))
+
+function harness() {
+  const handlers = new Map<string, Function>()
+  const emitted: Array<{ room: string; event: string; payload: any }> = []
+  const namespace = {
+    adapter: { rooms: new Map([['session:session-1', new Set(['socket-1'])]]) },
+    sockets: new Map(),
+    to: vi.fn((room: string) => ({ emit: vi.fn((event: string, payload: any) => emitted.push({ room, event, payload })) })),
+    use: vi.fn(), on: vi.fn(), emit: vi.fn(),
+  }
+  const socket = {
+    id: 'socket-1',
+    connected: true,
+    data: {},
+    handshake: { auth: {}, query: { profile: 'default' } },
+    on: vi.fn((event: string, handler: Function) => handlers.set(event, handler)),
+    join: vi.fn(),
+    emit: vi.fn(),
+  }
+  return { emitted, handlers, io: { of: vi.fn(() => namespace) }, socket }
+}
+
+describe('ChatRunSocket mobile calendar and reminders', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    sessionStoreMock.getSession.mockReturnValue({
+      id: 'session-1',
+      profile: 'default',
+      source: 'coding_agent',
+      agent: 'codex',
+    })
+  })
+
+  it('requests a calendar list and sanitizes the App response', async () => {
+    const { ChatRunSocket } = await import('../../packages/server/src/modules/studio/sockets/chat-run')
+    const { emitted, handlers, io, socket } = harness()
+    const server = new ChatRunSocket(io as any)
+    ;(server as any).sessionMap.set('session-1', {
+      messages: [], events: [], queue: [], isWorking: true, profile: 'default', source: 'coding_agent',
+    })
+    ;(server as any).onConnection(socket)
+    const resultPromise = server.requestMobileCalendar({
+      sessionId: 'session-1',
+      profile: 'default',
+      capability: 'calendar',
+      action: 'list',
+      purpose: 'Plan tomorrow',
+      limit: 20,
+      timeoutMs: 10_000,
+    })
+    const requested = emitted.find(item => item.event === 'calendar.requested')
+    expect(requested?.payload).toMatchObject({
+      session_id: 'session-1',
+      capability: 'calendar',
+      action: 'list',
+      purpose: 'Plan tomorrow',
+      limit: 20,
+    })
+    handlers.get('calendar.respond')?.({
+      session_id: 'session-1',
+      calendar_request_id: requested?.payload.calendar_request_id,
+      status: 'success',
+      result: {
+        capability: 'calendar',
+        action: 'list',
+        items: [{ id: '1', title: 'Meeting', startMs: 1, secret: 'drop-me' }],
+      },
+    })
+    await expect(resultPromise).resolves.toEqual({
+      status: 'success',
+      result: {
+        capability: 'calendar',
+        action: 'list',
+        items: [{ id: '1', title: 'Meeting', startMs: 1 }],
+      },
+    })
+    expect((server as any).sessionMap.get('session-1').events).toEqual([])
+  })
+
+  it('supports reminder completion but rejects delete and workflow requests', async () => {
+    const { ChatRunSocket } = await import('../../packages/server/src/modules/studio/sockets/chat-run')
+    const { io } = harness()
+    const server = new ChatRunSocket(io as any)
+    expect(() => server.requestMobileCalendar({
+      sessionId: 'session-1',
+      profile: 'default',
+      capability: 'reminder',
+      action: 'delete',
+      purpose: 'Delete it',
+      item: { id: '1' },
+    })).toThrow('Unsupported reminder action')
+    sessionStoreMock.getSession.mockReturnValue({ id: 'session-1', profile: 'default', source: 'workflow' })
+    expect(() => server.requestMobileCalendar({
+      sessionId: 'session-1',
+      profile: 'default',
+      capability: 'reminder',
+      action: 'complete',
+      purpose: 'Complete it',
+      item: { id: '1' },
+    })).toThrow('available only in direct chats')
+  })
+})


### PR DESCRIPTION
## Summary

Consolidates the mobile calendar/reminder feature stack onto current main so it can be reviewed and tested as one PR. The original feature changes are cherry-picked once, preserving author attribution and source commit references; upstream-only merge commits are omitted.

| Source PR | Included behavior |
| --- | --- |
| #2892 | Read/create/update calendar events and reminders, complete reminders, and bind MCP calls to the Studio chat session |
| #2906 | Confirmed single-item deletion with target ID, title, and occurrence/due-time validation |
| #2909 | Default mobile consent wait of five minutes |
| #2914 | HTTP and MCP timeout budgets beyond the consent deadline |
| #2921 | Bind requests to the authenticated originating App device and reject responses from other devices |

The endpoint, MCP tools, socket handlers, and mobile normalization/device-target services match the final #2921 implementation while retaining newer main changes. No Web UI pages are added. Requires compatible mobile App support; related App PR: https://github.com/EKKOLearnAI/hermes-studio-app/pull/58.

Refs #2892, #2906, #2909, #2914, #2921.

## Known issues — keep as draft

This is a consolidation of the requested commits, not a fix for the following previously reproduced issues:

- **P1: queued messages can target the previous sender’s device.** When device A is running and device B queues a message in the same session, dequeue can pass A’s socket into `handleRun`, which binds the queued run to A. Device identity needs to be captured with the queued message rather than inferred from that socket.
- **P2: normal stop does not clear pending calendar/reminder consent.** Cleanup is in session disposal, while the normal socket abort path leaves the request pending. Old consent remains valid and blocks another request until its timeout.
- Companion App integration and physical-device acceptance are still pending, including verification that each App build implements all selected server capabilities.

## Validation

- Verified the key MCP/calendar/device-target files match source PR #2921.
- `git diff --check` passed.
- `npm run harness:check` passed.
- `npm run build` passed.
- Full coverage run: 5018 tests passed, 6 skipped, and 7 hit the default 5-second timeout while coverage/build/browser checks ran concurrently. All five affected test files passed on a coverage rerun with `--maxWorkers=2` (167 tests), without code or timeout changes.
- Full Playwright run with system Chrome: 155 tests passed; the App download-version page test hit its 5-second visibility timeout. That test passed on an isolated rerun (1 test), without changes.
- These checks validate the consolidation; they do not resolve the known device-target/abort defects listed above or replace physical-device acceptance.
