### PR TITLE
[codex] align group chat tool folding and mobile layout with single chat

### DIFF
--- a/packages/client/src/components/hermes/chat/ToolRunCard.vue
+++ b/packages/client/src/components/hermes/chat/ToolRunCard.vue
@@ -1,180 +1,23 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
-import { useI18n } from 'vue-i18n'
 import type { Message } from '@/stores/hermes/chat'
 import MessageItem from './MessageItem.vue'
+import ToolRunSummary from './ToolRunSummary.vue'
 
-const props = defineProps<{
+defineProps<{
   runId: string
   tools: Message[]
 }>()
-
-const { t } = useI18n()
-const expanded = ref(false)
-
-const toolNames = computed(() => {
-  const names = [...new Set(props.tools.map(tool => tool.toolName).filter(Boolean) as string[])]
-  const visible = names.slice(0, 3).join(' · ')
-  return names.length > 3 ? `${visible} · +${names.length - 3}` : visible
-})
-
-const hasError = computed(() => props.tools.some(tool => tool.toolStatus === 'error'))
 </script>
 
 <template>
-  <section class="tool-run-card" :data-run-id="runId">
-    <button
-      type="button"
-      class="tool-run-header"
-      :aria-expanded="expanded"
-      @click="expanded = !expanded"
-    >
-      <svg
-        class="tool-run-chevron"
-        :class="{ expanded }"
-        width="11"
-        height="11"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="2"
-        aria-hidden="true"
-      >
-        <polyline points="9 18 15 12 9 6" />
-      </svg>
-      <svg
-        class="tool-run-icon"
-        width="13"
-        height="13"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="1.5"
-        aria-hidden="true"
-      >
-        <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z" />
-      </svg>
-      <span class="tool-run-count">{{ t('subagent.tools', { count: tools.length }) }}</span>
-      <span v-if="toolNames" class="tool-run-names">{{ toolNames }}</span>
-      <span v-if="hasError" class="tool-run-error">{{ t('chat.error') }}</span>
-      <svg
-        v-else
-        class="tool-run-success"
-        width="14"
-        height="14"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="2"
-        aria-hidden="true"
-      >
-        <path d="m7 12 3 3 7-7" />
-      </svg>
-    </button>
-
-    <Transition name="tool-run-expand">
-      <div v-if="expanded" class="tool-run-expand">
-        <div class="tool-run-expand-inner">
-          <div class="tool-run-items">
-            <MessageItem
-              v-for="tool in tools"
-              :key="tool.id"
-              :message="tool"
-            />
-          </div>
-        </div>
-      </div>
-    </Transition>
-  </section>
+  <ToolRunSummary :run-id="runId" :tools="tools">
+    <div class="tool-run-items">
+      <MessageItem v-for="tool in tools" :key="tool.id" :message="tool" />
+    </div>
+  </ToolRunSummary>
 </template>
 
 <style scoped lang="scss">
-@use "@/styles/variables" as *;
-
-.tool-run-card {
-  width: 520px;
-  max-width: 100%;
-  min-width: 0;
-}
-
-.tool-run-header {
-  display: flex;
-  align-items: center;
-  gap: 7px;
-  width: 100%;
-  min-width: 0;
-  min-height: 30px;
-  padding: 4px 8px;
-  border: 1px solid rgba(var(--text-primary-rgb), 0.09);
-  border-radius: 8px;
-  background: rgba(var(--bg-main-surface-rgb), 0.28);
-  color: $text-secondary;
-  font: inherit;
-  font-size: 11px;
-  text-align: start;
-  cursor: pointer;
-
-  &:hover,
-  &:focus-visible {
-    outline: none;
-    border-color: rgba(var(--accent-primary-rgb), 0.24);
-    background: rgba(var(--accent-primary-rgb), 0.055);
-  }
-}
-
-.tool-run-chevron {
-  flex: 0 0 auto;
-  color: $text-muted;
-  transition: transform 0.15s ease;
-
-  &.expanded {
-    transform: rotate(90deg);
-  }
-}
-
-.tool-run-icon {
-  flex: 0 0 auto;
-  color: rgba(var(--accent-primary-rgb), 0.82);
-}
-
-.tool-run-count {
-  flex: 0 0 auto;
-  color: $text-secondary;
-  font-weight: 500;
-}
-
-.tool-run-names {
-  min-width: 0;
-  overflow: hidden;
-  color: $text-muted;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.tool-run-error {
-  flex: 0 0 auto;
-  margin-inline-start: auto;
-  color: $error;
-}
-
-.tool-run-success {
-  flex: 0 0 auto;
-  margin-inline-start: auto;
-  color: rgba(var(--accent-primary-rgb), 0.78);
-}
-
-.tool-run-expand {
-  display: grid;
-  grid-template-rows: 1fr;
-  opacity: 1;
-  transform: translateY(0);
-}
-
-.tool-run-expand-inner {
-  min-height: 0;
-  overflow: hidden;
-}
-
 .tool-run-items {
   display: flex;
   flex-direction: column;
@@ -185,26 +28,4 @@ const hasError = computed(() => props.tools.some(tool => tool.toolStatus === 'er
   border-inline-start: 1px solid rgba(var(--text-primary-rgb), 0.12);
 }
 
-.tool-run-expand-enter-active,
-.tool-run-expand-leave-active {
-  transition:
-    grid-template-rows 220ms cubic-bezier(0.22, 1, 0.36, 1),
-    opacity 150ms ease,
-    transform 220ms cubic-bezier(0.22, 1, 0.36, 1);
-}
-
-.tool-run-expand-enter-from,
-.tool-run-expand-leave-to {
-  grid-template-rows: 0fr;
-  opacity: 0;
-  transform: translateY(-4px);
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .tool-run-chevron,
-  .tool-run-expand-enter-active,
-  .tool-run-expand-leave-active {
-    transition: none;
-  }
-}
 </style>

--- a/packages/client/src/components/hermes/chat/ToolRunSummary.vue
+++ b/packages/client/src/components/hermes/chat/ToolRunSummary.vue
@@ -1,0 +1,199 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+const props = defineProps<{
+  runId: string
+  tools: { toolName?: string; toolStatus?: 'running' | 'done' | 'error' | 'interrupted' }[]
+  active?: boolean
+}>()
+
+const { t } = useI18n()
+const expandedOverride = ref<boolean | null>(null)
+const expanded = computed(() => expandedOverride.value ?? !!props.active)
+watch(() => props.active, () => { expandedOverride.value = null })
+
+const toolNames = computed(() => {
+  const names = [...new Set(props.tools.map(tool => tool.toolName).filter(Boolean) as string[])]
+  const visible = names.slice(0, 3).join(' · ')
+  return names.length > 3 ? `${visible} · +${names.length - 3}` : visible
+})
+
+const hasError = computed(() => props.tools.some(tool => tool.toolStatus === 'error'))
+const hasInterrupted = computed(() => props.tools.some(tool => tool.toolStatus === 'interrupted'))
+</script>
+
+<template>
+  <section class="tool-run-card" :data-run-id="runId">
+    <button
+      type="button"
+      class="tool-run-header"
+      :aria-expanded="expanded"
+      @click="expandedOverride = !expanded"
+    >
+      <svg
+        class="tool-run-chevron"
+        :class="{ expanded }"
+        width="11"
+        height="11"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        aria-hidden="true"
+      >
+        <polyline points="9 18 15 12 9 6" />
+      </svg>
+      <svg
+        class="tool-run-icon"
+        width="13"
+        height="13"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.5"
+        aria-hidden="true"
+      >
+        <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z" />
+      </svg>
+      <span class="tool-run-count">{{ t('subagent.tools', { count: tools.length }) }}</span>
+      <span v-if="toolNames" class="tool-run-names">{{ toolNames }}</span>
+      <span v-if="hasError" class="tool-run-error">{{ t('chat.error') }}</span>
+      <span v-else-if="hasInterrupted" class="tool-run-error">{{ t('chat.toolResultUnavailable') }}</span>
+      <span v-else-if="active" class="tool-run-active" aria-busy="true">•••</span>
+      <svg
+        v-else
+        class="tool-run-success"
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        aria-hidden="true"
+      >
+        <path d="m7 12 3 3 7-7" />
+      </svg>
+    </button>
+
+    <Transition name="tool-run-expand">
+      <div v-if="expanded" class="tool-run-expand">
+        <div class="tool-run-expand-inner">
+          <slot />
+        </div>
+      </div>
+    </Transition>
+  </section>
+</template>
+
+<style scoped lang="scss">
+@use "@/styles/variables" as *;
+
+.tool-run-card {
+  width: 520px;
+  max-width: 100%;
+  min-width: 0;
+}
+
+.tool-run-header {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  width: 100%;
+  min-width: 0;
+  min-height: 30px;
+  padding: 4px 8px;
+  border: 1px solid rgba(var(--text-primary-rgb), 0.09);
+  border-radius: 8px;
+  background: rgba(var(--bg-main-surface-rgb), 0.28);
+  color: $text-secondary;
+  font: inherit;
+  font-size: 11px;
+  text-align: start;
+  cursor: pointer;
+
+  &:hover,
+  &:focus-visible {
+    outline: none;
+    border-color: rgba(var(--accent-primary-rgb), 0.24);
+    background: rgba(var(--accent-primary-rgb), 0.055);
+  }
+}
+
+.tool-run-chevron {
+  flex: 0 0 auto;
+  color: $text-muted;
+  transition: transform 0.15s ease;
+
+  &.expanded {
+    transform: rotate(90deg);
+  }
+}
+
+.tool-run-icon {
+  flex: 0 0 auto;
+  color: rgba(var(--accent-primary-rgb), 0.82);
+}
+
+.tool-run-count {
+  flex: 0 0 auto;
+  color: $text-secondary;
+  font-weight: 500;
+}
+
+.tool-run-names {
+  min-width: 0;
+  overflow: hidden;
+  color: $text-muted;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.tool-run-error {
+  flex: 0 0 auto;
+  margin-inline-start: auto;
+  color: $error;
+}
+
+.tool-run-active,
+.tool-run-success {
+  flex: 0 0 auto;
+  margin-inline-start: auto;
+  color: rgba(var(--accent-primary-rgb), 0.78);
+}
+
+.tool-run-expand {
+  display: grid;
+  grid-template-rows: 1fr;
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.tool-run-expand-inner {
+  min-height: 0;
+  overflow: hidden;
+}
+
+.tool-run-expand-enter-active,
+.tool-run-expand-leave-active {
+  transition:
+    grid-template-rows 220ms cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 150ms ease,
+    transform 220ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.tool-run-expand-enter-from,
+.tool-run-expand-leave-to {
+  grid-template-rows: 0fr;
+  opacity: 0;
+  transform: translateY(-4px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tool-run-chevron,
+  .tool-run-expand-enter-active,
+  .tool-run-expand-leave-active {
+    transition: none;
+  }
+}
+</style>

--- a/packages/client/src/components/hermes/group-chat/GroupAgentRunCard.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupAgentRunCard.vue
@@ -6,6 +6,7 @@ import { formatChatTimestamp } from '@/utils/chat-timestamp'
 import type { ChatMessage, MemberInfo, RoomAgent } from '@/api/studio/group-chat'
 import { groupMessageAgent, parseStoredAvatar } from '@/utils/group-agent-avatar'
 import GroupMessageItem from './GroupMessageItem.vue'
+import ToolRunSummary from '../chat/ToolRunSummary.vue'
 import GroupAgentMessageAvatar from './GroupAgentMessageAvatar.vue'
 import GroupAgentRobotIcon from './GroupAgentRobotIcon.vue'
 
@@ -32,6 +33,7 @@ const items = computed(() =>
 const runToolItems = computed(() =>
     items.value.filter(item => item.role === 'tool').reverse()
 )
+const toolsActive = computed(() => !!props.message.isStreaming || runToolItems.value.some(item => item.toolStatus === 'running'))
 const transcriptItems = computed(() =>
     runToolItems.value.length > 0
         ? items.value.filter(item => item.role !== 'tool')
@@ -105,32 +107,39 @@ function handleToolListWheel(event: WheelEvent): void {
                 <GroupAgentRobotIcon v-if="agentInfo" class="run-agent-icon" />
             </div>
             <div class="run-card" :class="{ streaming: message.isStreaming }">
-                <div
+                <ToolRunSummary
                     v-if="runToolItems.length"
-                    class="run-tool-list"
-                    tabindex="0"
-                    role="region"
-                    :aria-label="t('chat.showToolCalls')"
-                    :data-agent-id="stableAgentId"
-                    :data-run-id="message.run_id || undefined"
-                    @wheel="handleToolListWheel"
+                    class="run-tools"
+                    :run-id="message.run_id || message.id"
+                    :tools="runToolItems"
+                    :active="toolsActive"
                 >
                     <div
-                        v-for="item in runToolItems"
-                        :key="item.id"
-                        class="run-tool-item"
-                        :data-message-id="item.id"
+                        class="run-tool-list"
+                        tabindex="0"
+                        role="region"
+                        :aria-label="t('chat.showToolCalls')"
+                        :data-agent-id="stableAgentId"
+                        :data-run-id="message.run_id || undefined"
+                        @wheel="handleToolListWheel"
                     >
-                        <GroupMessageItem
-                            :message="item"
-                            :agents="agents"
-                            :members="members"
-                            :current-user-id="currentUserId"
-                            :allow-speech="props.allowSpeech"
-                            embedded
-                        />
+                        <div
+                            v-for="item in runToolItems"
+                            :key="item.id"
+                            class="run-tool-item"
+                            :data-message-id="item.id"
+                        >
+                            <GroupMessageItem
+                                :message="item"
+                                :agents="agents"
+                                :members="members"
+                                :current-user-id="currentUserId"
+                                :allow-speech="props.allowSpeech"
+                                embedded
+                            />
+                        </div>
                     </div>
-                </div>
+                </ToolRunSummary>
                 <div v-if="transcriptItems.length" class="run-transcript">
                     <div
                         v-for="item in transcriptItems"
@@ -297,6 +306,11 @@ function handleToolListWheel(event: WheelEvent): void {
     }
 }
 
+.run-tools {
+    box-sizing: border-box;
+    padding: 6px;
+}
+
 .run-tool-list {
     display: flex;
     flex-direction: column;
@@ -323,7 +337,7 @@ function handleToolListWheel(event: WheelEvent): void {
     min-width: 0;
 }
 
-.run-tool-list + .run-transcript {
+.run-tools + .run-transcript {
     border-top: 1px solid rgba(var(--text-primary-rgb), 0.08);
 }
 
@@ -342,11 +356,11 @@ function handleToolListWheel(event: WheelEvent): void {
     backdrop-filter: blur(8px) saturate(110%);
 }
 
-@media (max-width: 768px) {
+@media (max-width: $breakpoint-mobile) {
     .run-column {
-        min-width: min(260px, calc(100% - 46px));
+        min-width: 0;
         width: fit-content;
-        max-width: calc(100% - 46px);
+        max-width: 100%;
     }
 }
 </style>

--- a/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
@@ -2203,8 +2203,11 @@ function handleClarifyKeydown(event: KeyboardEvent) {
             <div class="chat-header">
                 <div class="header-left">
                     <button v-if="!props.standalone" class="icon-btn header-sidebar-toggle" @click="toggleSidebar">
-                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-                            <rect x="3" y="3" width="18" height="18" rx="2" ry="2" /><line x1="9" y1="3" x2="9" y2="21" />
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                            <rect x="3" y="3" width="7" height="7" />
+                            <rect x="14" y="3" width="7" height="7" />
+                            <rect x="3" y="14" width="7" height="7" />
+                            <rect x="14" y="14" width="7" height="7" />
                         </svg>
                     </button>
                     <span class="room-title-text">{{ store.roomName || (store.currentRoomId || t('groupChat.title')) }}</span>

--- a/packages/client/src/components/hermes/group-chat/GroupMessageItem.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupMessageItem.vue
@@ -1499,4 +1499,18 @@ onBeforeUnmount(() => {
         transform: scale(1);
     }
 }
+@media (max-width: $breakpoint-mobile) {
+    .group-message .msg-body {
+        min-width: 0;
+        max-width: 100%;
+    }
+
+    .group-message.embedded {
+        .msg-content,
+        &.agent .msg-content.agent-content,
+        &.self .msg-content {
+            padding: 10px 14px;
+        }
+    }
+}
 </style>

--- a/tests/client/chat-message-mobile-layout.test.ts
+++ b/tests/client/chat-message-mobile-layout.test.ts
@@ -1,4 +1,4 @@
-// @vitest-environment jsdom
+// @vitest-environment node
 import { readFileSync } from 'fs'
 import { describe, expect, it } from 'vitest'
 

--- a/tests/client/group-agent-run-tool-list.test.ts
+++ b/tests/client/group-agent-run-tool-list.test.ts
@@ -110,17 +110,26 @@ describe('GroupAgentRunCard tool list', () => {
     expect(wrapper.get('.run-column').element.children[0]).toBe(wrapper.get('.run-header').element)
     const runAvatar = wrapper.get('.run-header .message-agent-avatar, .run-header group-agent-message-avatar-stub')
     expect(`${runAvatar.attributes('style') || ''} ${runAvatar.attributes('size') || ''}`).toContain('22')
-    expect(wrapper.get('.run-card').element.children[0]).toBe(panel.element)
+    expect(wrapper.get('.run-card').element.children[0]).toBe(wrapper.get('.run-tools').element)
     expect(wrapper.get('.run-card').element.children[1]).toBe(wrapper.get('.run-transcript').element)
     expect(wrapper.get('.run-column').element.children[2]).toBe(wrapper.get('.run-time').element)
   })
 
-  it('keeps completed historical tool calls in the same bounded panel before its transcript', () => {
+  it('folds completed historical tools and expands the bounded panel without hiding the transcript', async () => {
     const wrapper = mountCard(runMessage([
       runItem({ id: 'historical-tool-1', role: 'tool', toolName: 'read_file', toolStatus: 'done' }),
       runItem({ id: 'historical-answer', content: 'Finished.', timestamp: 2 }),
       runItem({ id: 'historical-tool-2', role: 'tool', toolName: 'search', toolStatus: 'done', timestamp: 3 }),
     ], false))
+
+    const toggle = wrapper.get('.tool-run-header')
+    expect(toggle.attributes('aria-expanded')).toBe('false')
+    await vi.waitFor(() => expect(wrapper.find('.run-tool-list').exists()).toBe(false))
+    expect(wrapper.get('.run-transcript-item').attributes('data-message-id')).toMatch(/answer$/)
+    expect(toggle.text()).toContain('read_file')
+    expect(toggle.text()).toContain('search')
+    await toggle.trigger('click')
+    expect(toggle.attributes('aria-expanded')).toBe('true')
 
     expect(wrapper.get('.run-tool-list').findAll('.run-tool-item').map(item => item.attributes('data-message-id'))).toEqual([
       'historical-tool-2',
@@ -132,7 +141,41 @@ describe('GroupAgentRunCard tool list', () => {
     expect(wrapper.get('.run-transcript').text()).not.toContain('read_file')
     expect(wrapper.findAll('.run-tool-item[data-message-id="historical-tool-1"]')).toHaveLength(1)
     expect(wrapper.findAll('.run-tool-item[data-message-id="historical-tool-2"]')).toHaveLength(1)
-    expect(wrapper.get('.run-card').element.children[0]).toBe(wrapper.get('.run-tool-list').element)
+    expect(wrapper.get('.run-card').element.children[0]).toBe(wrapper.get('.run-tools').element)
     expect(wrapper.get('.run-card').element.children[1]).toBe(wrapper.get('.run-transcript').element)
   })
+
+  it('allows folding during execution and folds automatically when the run finishes', async () => {
+    const tool = runItem({ id: 'tool-1', role: 'tool', toolName: 'search', toolStatus: 'running' })
+    const wrapper = mountCard(runMessage([tool], true))
+    const toggle = wrapper.get('.tool-run-header')
+    expect(toggle.attributes('aria-expanded')).toBe('true')
+    expect(wrapper.find('.tool-run-success').exists()).toBe(false)
+
+    await toggle.trigger('click')
+    await vi.waitFor(() => expect(wrapper.find('.run-tool-list').exists()).toBe(false))
+    await wrapper.setProps({ message: runMessage([tool, runItem({ id: 'progress', content: 'Working' })], true) })
+    expect(toggle.attributes('aria-expanded')).toBe('false')
+    await toggle.trigger('click')
+
+    await wrapper.setProps({ message: runMessage([
+      { ...tool, toolStatus: 'done' },
+      runItem({ id: 'answer', content: 'Finished.' }),
+    ], false) })
+    expect(toggle.attributes('aria-expanded')).toBe('false')
+    await vi.waitFor(() => expect(wrapper.find('.run-tool-list').exists()).toBe(false))
+    expect(wrapper.get('.run-transcript-item').attributes('data-message-id')).toMatch(/answer$/)
+    await toggle.trigger('click')
+    expect(wrapper.find('.run-tool-item').exists()).toBe(true)
+  })
+
+  it.each(['error', 'interrupted'] as const)('keeps %s visible in the collapsed summary', (toolStatus) => {
+    const wrapper = mountCard(runMessage([
+      runItem({ id: 'failed-tool', role: 'tool', toolName: 'search', toolStatus }),
+    ], false))
+    expect(wrapper.get('.tool-run-header').attributes('aria-expanded')).toBe('false')
+    expect(wrapper.get('.tool-run-error').text()).toBe(toolStatus === 'error' ? 'chat.error' : 'chat.toolResultUnavailable')
+    expect(wrapper.find('.tool-run-success').exists()).toBe(false)
+  })
+
 })

--- a/tests/e2e/group-chat-room-deeplink.spec.ts
+++ b/tests/e2e/group-chat-room-deeplink.spec.ts
@@ -628,12 +628,15 @@ test.describe('group chat room deep links', () => {
     const outer = page.locator('.group-message-list .virtual-message-list')
     await expect(panel).toBeVisible()
     await expect(panel.locator('.tool-message')).toHaveCount(12)
+    const historicalRun = page.locator('.group-agent-run[data-run-id="run-history-tools"]')
+    const historicalToggle = historicalRun.locator('.tool-run-header')
     const historicalPanel = page.locator('.run-tool-list[data-run-id="run-history-tools"]')
+    await expect(historicalToggle).toHaveAttribute('aria-expanded', 'false')
+    await expect(historicalPanel).toHaveCount(0)
+    await historicalToggle.click()
     await expect(historicalPanel).toBeVisible()
     await expect(historicalPanel.locator('.tool-name')).toHaveText('historical_tool')
-    await expect.poll(() => page.locator('.group-agent-run[data-run-id="run-history-tools"] .run-card').evaluate(
-      element => Array.from(element.children, child => child.className),
-    )).toEqual(['run-tool-list', 'run-transcript'])
+    await expect(historicalRun.locator('.run-card > .run-tools + .run-transcript')).toContainText('Historical run finished.')
 
     const dimensions = await panel.evaluate(element => ({
       clientHeight: element.clientHeight,
@@ -916,7 +919,7 @@ test.describe('group chat room deep links', () => {
     await expect(page.locator('.room-title-text', { hasText: 'Beta Room' })).toBeVisible()
   })
 
-  test('keeps runtime Tools bounded, newest-first, and stable after completion and refresh', async ({ page }) => {
+  test('folds runtime Tools after completion and refresh while preserving newest-first details', async ({ page }) => {
     const api = await setup(page, '/#/hermes/group-chat/room/room-beta')
     await expect(page.getByText('Beta room message')).toBeVisible()
 
@@ -991,12 +994,14 @@ test.describe('group chat room deep links', () => {
       status: 'ready',
     })
 
+    const toggle = runCard.locator('.tool-run-header')
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    await expect(panel).toHaveCount(0)
+    await toggle.click()
     await expect(panel).toBeVisible()
     await expect(panel.locator('.tool-name')).toHaveText(['terminal', 'read_file'])
     await expect(runCard.locator('.tool-message')).toHaveCount(2)
-    await expect.poll(() => runCard.locator('.run-card').evaluate(
-      element => Array.from(element.children, child => child.className),
-    )).toEqual(['run-tool-list', 'run-transcript'])
+    await expect(runCard.locator('.run-card > .run-tools + .run-transcript')).toBeVisible()
 
     api.setRoomMessages({
       ...messagesByRoom,
@@ -1030,13 +1035,15 @@ test.describe('group chat room deep links', () => {
     const refreshedRunCard = page.locator('.group-agent-run[data-run-id="run-runtime-tools"]')
     const refreshedPanel = page.locator('.run-tool-list[data-agent-id="agent-row-runtime"][data-run-id="run-runtime-tools"]')
     await expect(refreshedRunCard).toHaveCount(1)
+    const refreshedToggle = refreshedRunCard.locator('.tool-run-header')
+    await expect(refreshedToggle).toHaveAttribute('aria-expanded', 'false')
+    await expect(refreshedPanel).toHaveCount(0)
+    await expect(refreshedRunCard.locator('.run-card > .run-tools + .run-transcript')).toContainText('Finished.')
+    await refreshedToggle.click()
     await expect(refreshedPanel).toBeVisible()
     await expect(refreshedPanel.locator('.tool-name')).toHaveText(['terminal', 'read_file'])
     await expect(refreshedRunCard.locator('.tool-message')).toHaveCount(2)
     await expect(page.locator('.group-message-list > .tool-message')).toHaveCount(0)
-    await expect.poll(() => refreshedRunCard.locator('.run-card').evaluate(
-      element => Array.from(element.children, child => child.className),
-    )).toEqual(['run-tool-list', 'run-transcript'])
   })
 
   test('shows a selected room link when browser clipboard APIs cannot copy', async ({ page }) => {

--- a/tests/e2e/group-chat-share.spec.ts
+++ b/tests/e2e/group-chat-share.spec.ts
@@ -19,7 +19,7 @@ const previewPng = Buffer.from(
   'base64',
 )
 
-async function mockInviteSocket(page: Page, joinFailure: { code: string, error: string } | null = null, workerContent = 'How can I help?') {
+async function mockInviteSocket(page: Page, joinFailure: { code: string, error: string } | null = null, workerContent = 'How can I help?', withTools = false) {
   const joinFailureJson = JSON.stringify(joinFailure)
   await page.route('**/node_modules/.vite/deps/socket__io-client.js*', async (route) => {
     await route.fulfill({
@@ -71,13 +71,19 @@ export function io(url, options) {
             content: 'Welcome to the shared room',
             timestamp: 1,
             role: 'user',
-          }, {
+          }, ...${JSON.stringify(withTools ? [{
+            id: 'shared-tool-1', roomId: 'room-shared', senderId: 'agent-worker',
+            senderName: 'Worker', role: 'tool', run_id: 'shared-run',
+            content: 'File contents', timestamp: 2, tool_name: 'read_file',
+            tool_call_id: 'read-call',
+          }] : [])}, {
             id: 'shared-message-2',
             roomId: 'room-shared',
             senderId: 'agent-worker',
             senderName: 'Worker',
+            run_id: 'shared-run',
             content: ${JSON.stringify(workerContent)},
-            timestamp: 2,
+            timestamp: 3,
             role: 'assistant',
           }],
           agents: [{
@@ -96,9 +102,9 @@ export function io(url, options) {
             invited: 1,
           }],
           rooms: ['room-shared'],
-          total: 2,
+          total: ${withTools ? 3 : 2},
           offset: 0,
-          limit: 2,
+          limit: ${withTools ? 3 : 2},
           hasMore: false,
           typingUsers: [],
           contextStatuses: [],
@@ -180,6 +186,30 @@ async function mockInviteApi(page: Page, valid = true, delayMs = 0) {
 }
 
 test.describe('invite-only group chat share page', () => {
+  test('folds group tool calls with the same summary used in single chat', async ({ page }) => {
+    await mockInviteSocket(page, null, 'Read the project files.', true)
+    await mockInviteApi(page)
+    await page.goto('/#/share/group-chat/ROOM1')
+    await page.locator('#group-chat-guest-name input').fill('Visitor')
+    await page.getByRole('button', { name: 'Enter room' }).click()
+
+    const card = page.locator('.group-agent-run').filter({ has: page.locator('.tool-run-card') })
+    const toggle = card.locator('.tool-run-header')
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    await expect(toggle).toContainText('read_file')
+    await expect(card.locator('.run-tool-list')).toHaveCount(0)
+    await toggle.click()
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    await expect(card.locator('.run-tool-item')).toHaveCount(1)
+    await expect(card.locator('.run-tool-list')).toBeVisible()
+    await card.locator('.tool-line').click()
+    await expect(card.locator('.tool-details')).toContainText('File contents')
+    await toggle.press('Enter')
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    await expect(card.locator('.run-tool-list')).toHaveCount(0)
+    await expect(page.getByText('Read the project files.', { exact: true })).toBeVisible()
+  })
+
   test('loads an Agent Markdown image through the room invite without filesystem API access', async ({ page }) => {
     await mockInviteSocket(page, null, 'Here is the image: ![result](/Users/owner/workspace/agent-result.png)')
     const protectedRequests = await mockInviteApi(page)


### PR DESCRIPTION
## Summary
- Group chat tool calls now reuse the single-chat summary: active runs expand by default, completed runs collapse, and users can toggle details while errors and interrupted results remain visible.
- Match single-chat mobile bubble widths and text padding, and use the same four-square sidebar icon as chat, workflows, and history.
- Cover completion, manual toggling, error summaries, and browser detail expansion. Run the existing filesystem-only mobile layout guard in the Node test environment.

## Validation
- Updated the room deep-link browser tests to verify collapsed history, completion, and reload behavior before expanding tool details. The focused regression checks passed.
- Full local browser suite: 156 passed; one session-category retry test failed once. Re-running the complete session-category suite passed all 13 tests.
- Focused Vitest suites passed for group tool cards, tool visibility, live reasoning, group scrolling, mobile layout, and room drafts.
- Chat streaming and group share browser suites passed (22 tests); the group share suite also passed at a 390 × 844 mobile viewport (5 tests).
- `npm run harness:check`
- `npm run build`
- `git diff --check`

