### PR TITLE
feat: profile-scoped App foreground notification events

### DIFF
--- a/docs/chat-chain-changes/2026-09-06-app-foreground-notifications.md
+++ b/docs/chat-chain-changes/2026-09-06-app-foreground-notifications.md
@@ -1,0 +1,3 @@
+# App foreground notifications
+
+Add profile-scoped `app.notification` events with stable request/run identities, generic kinds, resolution and emission timestamps. Exclude progress, aborts and queued continuations. No prompts or command content. Existing socket authentication and profile room isolation remain unchanged. Mobile clients must ignore snapshots/background replay and deduplicate per account/device.

--- a/packages/server/src/modules/coding-agents/services/runtime/run-manager.ts
+++ b/packages/server/src/modules/coding-agents/services/runtime/run-manager.ts
@@ -3229,6 +3229,7 @@ export class CodingAgentRunManager {
     const workspaceRunChange = this.completeWorkspaceRunDiff(run)
     this.emitToChat(run.launch.sessionId, event, {
       ...(payload || { event }),
+      run_id: typeof payload?.run_id === 'string' && payload.run_id ? payload.run_id : run.id,
       ...(run.assistantMessageId ? { message_id: run.assistantMessageId } : {}),
       ...(queueRemaining > 0 ? { queue_remaining: queueRemaining } : {}),
       workspace_run_change: workspaceRunChange,

--- a/packages/server/src/modules/studio/repositories/session-store.ts
+++ b/packages/server/src/modules/studio/repositories/session-store.ts
@@ -374,6 +374,22 @@ export function getSession(id: string): HermesSessionRow | null {
   return row ? mapSessionRow(row) : null
 }
 
+/** Bounded notification text; never materialize full chat history or tool output. */
+export function getSessionNotificationPreview(id: string): { title: string; preview: string } | null {
+  if (!isSqliteAvailable()) return null
+  const row = getDb()!.prepare(`
+    SELECT SUBSTR(COALESCE(NULLIF(s.title, ''), NULLIF(s.preview, ''),
+      (SELECT SUBSTR(m.content, 1, 63) FROM ${MESSAGES_TABLE} m
+       WHERE m.session_id = s.id AND m.role = 'user' AND m.content != ''
+       ORDER BY m.timestamp, m.id LIMIT 1), ''), 1, 120) AS title,
+      COALESCE((SELECT SUBSTR(COALESCE(NULLIF(m.display_content, ''), m.content), 1, 240)
+       FROM ${MESSAGES_TABLE} m WHERE m.session_id = s.id AND m.role = 'assistant' AND m.content != ''
+       ORDER BY m.timestamp DESC, m.id DESC LIMIT 1), '') AS preview
+    FROM ${SESSIONS_TABLE} s WHERE s.id = ?
+  `).get(id) as { title: string; preview: string } | undefined
+  return row || null
+}
+
 /** Session and branch metadata without loading this session's message bodies. */
 export function getSessionMetadata(id: string): HermesSessionRow | null {
   if (!isSqliteAvailable()) return null

--- a/packages/server/src/modules/studio/services/chat-run/foreground-notification.ts
+++ b/packages/server/src/modules/studio/services/chat-run/foreground-notification.ts
@@ -27,3 +27,12 @@ export function foregroundNotificationPreview(
     content: kind === 'completion' ? plain(payload.output || session?.preview, 240) : '',
   }
 }
+
+/** Stable identity only, never accept an image URL from a notification payload. */
+export function foregroundNotificationAgent(value: unknown): string {
+  if (typeof value !== 'string') return ''
+  const agent = value.toLowerCase().trim()
+  if (agent === 'claude' || agent === 'claude-code') return 'claude-code'
+  if (agent === 'ekko' || agent === 'ekko-agent') return 'ekko-agent'
+  return ['hermes', 'codex', 'pi', 'grok', 'opencode'].includes(agent) ? agent : ''
+}

--- a/packages/server/src/modules/studio/services/chat-run/foreground-notification.ts
+++ b/packages/server/src/modules/studio/services/chat-run/foreground-notification.ts
@@ -13,3 +13,17 @@ export function foregroundNotification(event: string, value: Record<string, unkn
     || value.interrupted === true || value.stop_reason === 'queue_insertion' || value.stop_reason === 'aborted') return null
   return { id: `${sessionId}:run:${id}`, sessionId, kind: event === 'run.failed' ? 'failure' : 'completion', resolved: false, timestamp: now }
 }
+
+/** Only short user-visible text; never serialize commands, tool results or raw errors. */
+export function foregroundNotificationPreview(
+  kind: string,
+  session: { title?: string | null; preview?: string | null } | null,
+  payload: Record<string, unknown>,
+) {
+  const plain = (value: unknown, limit: number) => typeof value === 'string'
+    ? value.replace(/[\u0000-\u001f\u007f]/g, ' ').replace(/\s+/g, ' ').trim().slice(0, limit) : ''
+  return {
+    title: plain(session?.title, 120),
+    content: kind === 'completion' ? plain(payload.output || session?.preview, 240) : '',
+  }
+}

--- a/packages/server/src/modules/studio/services/chat-run/foreground-notification.ts
+++ b/packages/server/src/modules/studio/services/chat-run/foreground-notification.ts
@@ -1,0 +1,15 @@
+/** Payload deliberately excludes prompts, commands, credentials and message text. */
+export function foregroundNotification(event: string, value: Record<string, unknown>, now = Date.now()) {
+  const sessionId = typeof value.session_id === 'string' ? value.session_id : ''
+  if (!sessionId || value.replayed === true || value.restored === true || value.background_snapshot === true) return null
+  if (event.endsWith('.resolved') && (value.resolved === false || value.stale === true)) return null
+  const requestKind = event.startsWith('approval.') ? 'approval' : event.startsWith('clarify.') ? 'clarify' : ''
+  const id = requestKind ? value[`${requestKind}_id`] : value.run_id
+  if (typeof id !== 'string' || !id) return null
+  if (requestKind && (event.endsWith('.requested') || event.endsWith('.resolved'))) {
+    return { id: `${sessionId}:${requestKind}:${id}`, sessionId, kind: 'approval', resolved: event.endsWith('.resolved'), timestamp: now }
+  }
+  if (!['run.completed', 'run.failed'].includes(event) || Number(value.queue_remaining || 0) > 0
+    || value.interrupted === true || value.stop_reason === 'queue_insertion' || value.stop_reason === 'aborted') return null
+  return { id: `${sessionId}:run:${id}`, sessionId, kind: event === 'run.failed' ? 'failure' : 'completion', resolved: false, timestamp: now }
+}

--- a/packages/server/src/modules/studio/sockets/chat-run.ts
+++ b/packages/server/src/modules/studio/sockets/chat-run.ts
@@ -2375,7 +2375,7 @@ export class ChatRunSocket {
       workflowNodeId: state?.webhookWorkflowNodeId,
     })
     this.observePetEvent(profile, event, tagged)
-    this.emitSessionActivity(profile, event, tagged)
+    this.emitPendingInteraction(profile, event, tagged)
     if (state?.isWorking) {
       state.events.push({ event, data: tagged })
       if (state.events.length > 200) state.events.splice(0, state.events.length - 200)

--- a/packages/server/src/modules/studio/sockets/chat-run.ts
+++ b/packages/server/src/modules/studio/sockets/chat-run.ts
@@ -1,4 +1,4 @@
-import { foregroundNotification } from '../services/chat-run/foreground-notification'
+import { foregroundNotification, foregroundNotificationPreview } from '../services/chat-run/foreground-notification'
 import { mobileDeviceRoom, mobileDeviceId, sameMobileDevice, mobileEventAllowed, type MobileDeviceTarget } from '../services/chat-run/mobile-device-target'
 /**
  * ChatRunSocket — Socket.IO namespace /chat-run.
@@ -2625,7 +2625,7 @@ export class ChatRunSocket {
     const notificationSession = notification ? getSession(notification.sessionId) : null
     // Group/workflow navigation is a separate contract; do not misroute it as single chat.
     if (notification && notificationSession?.source !== 'group_chat' && notificationSession?.source !== 'workflow') {
-      this.nsp.to(`pending-interactions:${profile}`).emit('app.notification', { ...notification, profile })
+      this.nsp.to(`pending-interactions:${profile}`).emit('app.notification', { ...notification, ...foregroundNotificationPreview(notification.kind, notificationSession, payload || {}), profile })
     }
     if (event !== 'approval.requested' && event !== 'approval.resolved'
       && event !== 'clarify.requested' && event !== 'clarify.resolved'

--- a/packages/server/src/modules/studio/sockets/chat-run.ts
+++ b/packages/server/src/modules/studio/sockets/chat-run.ts
@@ -1,3 +1,4 @@
+import { foregroundNotification } from '../services/chat-run/foreground-notification'
 import { mobileDeviceRoom, mobileDeviceId, sameMobileDevice, mobileEventAllowed, type MobileDeviceTarget } from '../services/chat-run/mobile-device-target'
 /**
  * ChatRunSocket — Socket.IO namespace /chat-run.
@@ -2620,6 +2621,12 @@ export class ChatRunSocket {
 
   private emitPendingInteraction(profile: string, event: string, payload: any) {
     this.emitSessionActivity(profile, event, payload)
+    const notification = foregroundNotification(event, payload || {})
+    const notificationSession = notification ? getSession(notification.sessionId) : null
+    // Group/workflow navigation is a separate contract; do not misroute it as single chat.
+    if (notification && notificationSession?.source !== 'group_chat' && notificationSession?.source !== 'workflow') {
+      this.nsp.to(`pending-interactions:${profile}`).emit('app.notification', { ...notification, profile })
+    }
     if (event !== 'approval.requested' && event !== 'approval.resolved'
       && event !== 'clarify.requested' && event !== 'clarify.resolved'
       && event !== 'location.requested' && event !== 'location.resolved'

--- a/packages/server/src/modules/studio/sockets/chat-run.ts
+++ b/packages/server/src/modules/studio/sockets/chat-run.ts
@@ -13,7 +13,7 @@ import type { Server, Socket } from 'socket.io'
 import { randomUUID } from 'crypto'
 import { logger } from '../public/logging'
 import { getSystemPrompt } from '../public/runs/prompt'
-import { clearSessionMessages, deleteSession, getSession, getSessionMetadata, listSessions, updateMessageDisplayContent } from '../repositories/session-store'
+import { clearSessionMessages, deleteSession, getSessionNotificationPreview, getSession, getSessionMetadata, listSessions, updateMessageDisplayContent } from '../repositories/session-store'
 import { listWorkspaceRunChangesForAssistantMessages } from '../repositories/workspace-run-changes-store'
 import { getSessionCategory } from '../repositories/session-category-store'
 import { getActiveProfileName, getProfileDir, listProfileNamesFromDisk } from '../public/profile-config'
@@ -2625,7 +2625,7 @@ export class ChatRunSocket {
     const notificationSession = notification ? getSession(notification.sessionId) : null
     // Group/workflow navigation is a separate contract; do not misroute it as single chat.
     if (notification && notificationSession?.source !== 'group_chat' && notificationSession?.source !== 'workflow') {
-      this.nsp.to(`pending-interactions:${profile}`).emit('app.notification', { ...notification, ...foregroundNotificationPreview(notification.kind, notificationSession, payload || {}), profile })
+      this.nsp.to(`pending-interactions:${profile}`).emit('app.notification', { ...notification, ...foregroundNotificationPreview(notification.kind, getSessionNotificationPreview(notification.sessionId) || notificationSession, payload || {}), profile })
     }
     if (event !== 'approval.requested' && event !== 'approval.resolved'
       && event !== 'clarify.requested' && event !== 'clarify.resolved'

--- a/packages/server/src/modules/studio/sockets/chat-run.ts
+++ b/packages/server/src/modules/studio/sockets/chat-run.ts
@@ -1,4 +1,4 @@
-import { foregroundNotification, foregroundNotificationPreview } from '../services/chat-run/foreground-notification'
+import { foregroundNotification, foregroundNotificationPreview, foregroundNotificationAgent } from '../services/chat-run/foreground-notification'
 import { mobileDeviceRoom, mobileDeviceId, sameMobileDevice, mobileEventAllowed, type MobileDeviceTarget } from '../services/chat-run/mobile-device-target'
 /**
  * ChatRunSocket — Socket.IO namespace /chat-run.
@@ -2625,7 +2625,7 @@ export class ChatRunSocket {
     const notificationSession = notification ? getSession(notification.sessionId) : null
     // Group/workflow navigation is a separate contract; do not misroute it as single chat.
     if (notification && notificationSession?.source !== 'group_chat' && notificationSession?.source !== 'workflow') {
-      this.nsp.to(`pending-interactions:${profile}`).emit('app.notification', { ...notification, ...foregroundNotificationPreview(notification.kind, getSessionNotificationPreview(notification.sessionId) || notificationSession, payload || {}), profile })
+      this.nsp.to(`pending-interactions:${profile}`).emit('app.notification', { ...notification, agent: foregroundNotificationAgent(notificationSession?.agent), ...foregroundNotificationPreview(notification.kind, getSessionNotificationPreview(notification.sessionId) || notificationSession, payload || {}), profile })
     }
     if (event !== 'approval.requested' && event !== 'approval.resolved'
       && event !== 'clarify.requested' && event !== 'clarify.resolved'

--- a/tests/server/chat-run-bridge-readiness.test.ts
+++ b/tests/server/chat-run-bridge-readiness.test.ts
@@ -84,6 +84,7 @@ vi.mock('../../packages/server/src/modules/studio/public/runs/prompt', () => ({
 }))
 
 vi.mock('../../packages/server/src/modules/studio/repositories/session-store', () => ({
+  getSessionNotificationPreview: vi.fn(() => null),
   getSession: getSessionMock,
   getSessionMetadata: getSessionMock,
   getSessionDetail: vi.fn(() => null),

--- a/tests/server/foreground-notification.test.ts
+++ b/tests/server/foreground-notification.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { foregroundNotification as event, foregroundNotificationPreview } from '../../packages/server/src/modules/studio/services/chat-run/foreground-notification'
+import { foregroundNotification as event, foregroundNotificationPreview, foregroundNotificationAgent } from '../../packages/server/src/modules/studio/services/chat-run/foreground-notification'
 describe('foreground notification contract', () => {
   it('uses stable request and run identities without sensitive payload', () => {
     expect(event('approval.requested', { session_id:'s',approval_id:'a',command:'secret' },10)).toEqual({id:'s:approval:a',sessionId:'s',kind:'approval',resolved:false,timestamp:10})
@@ -19,3 +19,10 @@ describe('foreground notification contract', () => {
    expect(foregroundNotificationPreview('approval', {title:'Chat'}, {command:'secret',error:'secret'})).toEqual({title:'Chat',content:''})
    expect(foregroundNotificationPreview('completion', {title:'x'.repeat(500)}, {output:'y'.repeat(1000)}).content).toHaveLength(240)
  })
+
+it('normalizes stored agent identity without arbitrary avatar URLs', () => {
+ expect(foregroundNotificationAgent('codex')).toBe('codex')
+ expect(foregroundNotificationAgent('Claude')).toBe('claude-code')
+ expect(foregroundNotificationAgent('ekko')).toBe('ekko-agent')
+ expect(foregroundNotificationAgent('https://example/avatar.png')).toBe('')
+})

--- a/tests/server/foreground-notification.test.ts
+++ b/tests/server/foreground-notification.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { foregroundNotification as event } from '../../packages/server/src/modules/studio/services/chat-run/foreground-notification'
+import { foregroundNotification as event, foregroundNotificationPreview } from '../../packages/server/src/modules/studio/services/chat-run/foreground-notification'
 describe('foreground notification contract', () => {
   it('uses stable request and run identities without sensitive payload', () => {
     expect(event('approval.requested', { session_id:'s',approval_id:'a',command:'secret' },10)).toEqual({id:'s:approval:a',sessionId:'s',kind:'approval',resolved:false,timestamp:10})
@@ -13,3 +13,9 @@ describe('foreground notification contract', () => {
     expect(event('run.completed',{session_id:'s',run_id:'r',interrupted:true})).toBeNull()
   })
 })
+
+ it('ships bounded title and completion preview without command or error payloads', () => {
+   expect(foregroundNotificationPreview('completion', {title:'Chat',preview:'fallback'}, {output:'Done\nnow'})).toEqual({title:'Chat',content:'Done now'})
+   expect(foregroundNotificationPreview('approval', {title:'Chat'}, {command:'secret',error:'secret'})).toEqual({title:'Chat',content:''})
+   expect(foregroundNotificationPreview('completion', {title:'x'.repeat(500)}, {output:'y'.repeat(1000)}).content).toHaveLength(240)
+ })

--- a/tests/server/foreground-notification.test.ts
+++ b/tests/server/foreground-notification.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest'
+import { foregroundNotification as event } from '../../packages/server/src/modules/studio/services/chat-run/foreground-notification'
+describe('foreground notification contract', () => {
+  it('uses stable request and run identities without sensitive payload', () => {
+    expect(event('approval.requested', { session_id:'s',approval_id:'a',command:'secret' },10)).toEqual({id:'s:approval:a',sessionId:'s',kind:'approval',resolved:false,timestamp:10})
+    expect(event('approval.resolved',{session_id:'s',approval_id:'a'},11)?.id).toBe('s:approval:a')
+    expect(event('run.completed',{session_id:'s',run_id:'r'},10)?.kind).toBe('completion')
+  })
+  it('ignores progress, aborts, missing identity and queued/interrupted runs', () => {
+    for(const name of ['abort.completed','tool.completed','session.activity']) expect(event(name,{session_id:'s',run_id:'r'})).toBeNull()
+    expect(event('run.completed',{session_id:'s'})).toBeNull()
+    expect(event('run.completed',{session_id:'s',run_id:'r',queue_remaining:1})).toBeNull()
+    expect(event('run.completed',{session_id:'s',run_id:'r',interrupted:true})).toBeNull()
+  })
+})

--- a/tests/server/run-chat-clarify-respond.test.ts
+++ b/tests/server/run-chat-clarify-respond.test.ts
@@ -40,6 +40,7 @@ vi.mock('../../packages/server/src/modules/studio/public/logging', () => ({
 }))
 
 const sessionStoreMock = vi.hoisted(() => ({
+  getSessionNotificationPreview: vi.fn(() => null),
   getSession: vi.fn(() => ({ id: 'session-1', profile: 'default' })),
   getSessionMetadata: vi.fn(() => null),
   getSessionDetail: vi.fn(() => null),

--- a/tests/server/run-chat-mobile-location.test.ts
+++ b/tests/server/run-chat-mobile-location.test.ts
@@ -31,6 +31,7 @@ vi.mock('../../packages/server/src/modules/studio/public/logging', () => ({
 
 const sessionStoreMock = vi.hoisted(() => ({
   getSession: vi.fn(),
+  getSessionNotificationPreview: vi.fn(() => null),
   getSessionMetadata: vi.fn(() => null),
   getSessionDetail: vi.fn(() => null),
 }))

--- a/tests/server/run-chat-mobile-location.test.ts
+++ b/tests/server/run-chat-mobile-location.test.ts
@@ -315,3 +315,26 @@ describe('App notification room delivery', () => {
     expect(emitted.filter(item => item.event === 'app.notification')).toHaveLength(1)
   })
 })
+
+
+describe('external Coding Agent notifications', () => {
+  it('forwards terminal and approval events through the profile notification path', async () => {
+    const { ChatRunSocket } = await import('../../packages/server/src/modules/studio/sockets/chat-run')
+    const { io, emitted } = createHarness()
+    sessionStoreMock.getSession.mockReturnValue({ id:'external',profile:'default',source:'coding_agent',agent:'codex' })
+    const server = new ChatRunSocket(io as any)
+    server.emitExternalEvent('external','run.completed',{run_id:'run-1'})
+    server.emitExternalEvent('external','approval.requested',{approval_id:'approval-1'})
+    server.emitExternalEvent('external','approval.resolved',{approval_id:'approval-1',resolved:true})
+    const notices=emitted.filter(item=>item.event==='app.notification')
+    expect(notices.map(item=>[item.room,item.payload.id,item.payload.resolved])).toEqual([
+      ['pending-interactions:default','external:run:run-1',false],
+      ['pending-interactions:default','external:approval:approval-1',false],
+      ['pending-interactions:default','external:approval:approval-1',true],
+    ])
+    expect(emitted.filter(item=>item.event==='session.activity')).toHaveLength(1)
+    server.emitExternalEvent('external','run.completed',{run_id:'run-2',queue_remaining:1})
+    server.emitExternalEvent('external','abort.completed',{run_id:'run-3'})
+    expect(emitted.filter(item=>item.event==='app.notification')).toHaveLength(3)
+  })
+})

--- a/tests/server/run-chat-mobile-location.test.ts
+++ b/tests/server/run-chat-mobile-location.test.ts
@@ -297,3 +297,21 @@ describe('ChatRunSocket mobile location', () => {
     })).toThrow('Mobile location is available only in direct chats')
   })
 })
+
+
+describe('App notification room delivery', () => {
+  it('broadcasts only minimal stable identity to the authorized profile room', async () => {
+    const { ChatRunSocket } = await import('../../packages/server/src/modules/studio/sockets/chat-run')
+    const { io, emitted } = createHarness()
+    sessionStoreMock.getSession.mockReturnValue({ id:'s',profile:'default',source:'cli' })
+    const server = new ChatRunSocket(io as any)
+    ;(server as any).emitPendingInteraction('default','approval.requested',{session_id:'s',approval_id:'a',command:'secret'})
+    const event = emitted.find(item => item.event === 'app.notification')
+    expect(event?.room).toBe('pending-interactions:default')
+    expect(event?.payload).toMatchObject({id:'s:approval:a',sessionId:'s',profile:'default',kind:'approval',resolved:false})
+    expect(event?.payload).not.toHaveProperty('command')
+    sessionStoreMock.getSession.mockReturnValue({id:'g',profile:'default',source:'group_chat'})
+    ;(server as any).emitPendingInteraction('default','run.completed',{session_id:'g',run_id:'r'})
+    expect(emitted.filter(item => item.event === 'app.notification')).toHaveLength(1)
+  })
+})

--- a/tests/server/run-chat-mobile-location.test.ts
+++ b/tests/server/run-chat-mobile-location.test.ts
@@ -328,6 +328,7 @@ describe('external Coding Agent notifications', () => {
     server.emitExternalEvent('external','approval.requested',{approval_id:'approval-1'})
     server.emitExternalEvent('external','approval.resolved',{approval_id:'approval-1',resolved:true})
     const notices=emitted.filter(item=>item.event==='app.notification')
+    expect(notices.every(item => item.payload.agent === 'codex')).toBe(true)
     expect(notices.map(item=>[item.room,item.payload.id,item.payload.resolved])).toEqual([
       ['pending-interactions:default','external:run:run-1',false],
       ['pending-interactions:default','external:approval:approval-1',false],

--- a/tests/server/session-store-search.test.ts
+++ b/tests/server/session-store-search.test.ts
@@ -23,6 +23,16 @@ describe('session store filtering', () => {
     vi.resetModules()
   })
 
+  it('resolves notification title for untitled sessions and bounds assistant preview', async () => {
+    const { createSession, addMessage, getSessionNotificationPreview } = await import('../../packages/server/src/modules/studio/repositories/session-store')
+    createSession({ id: 'untitled-notice', profile: 'default', source: 'coding_agent' })
+    addMessage({ session_id: 'untitled-notice', role: 'user', content: 'First user question', timestamp: 1 })
+    addMessage({ session_id: 'untitled-notice', role: 'assistant', content: 'a'.repeat(1000), timestamp: 2 })
+    addMessage({ session_id: 'untitled-notice', role: 'tool', content: 'private tool output', timestamp: 3 })
+    expect(getSessionNotificationPreview('untitled-notice')).toEqual({ title: 'First user question', preview: 'a'.repeat(240) })
+    expect(getSessionNotificationPreview('missing')).toBeNull()
+  })
+
   it('finds rendered text when Markdown markers split the stored phrase', async () => {
     const { addMessage, createSession, searchSessions } = await import(
       '../../packages/server/src/modules/studio/repositories/session-store'


### PR DESCRIPTION
## Summary
- Add minimal app.notification broadcasts to authenticated profile pending-interaction rooms.
- Stable request/run identity, resolution state and emission time; no prompts, commands or credentials.
- Exclude progress, aborts, interrupted runs, queued continuations, replay/snapshot flags and stale resolutions.
- Initial navigation scope is single chat; group/workflow-specific routing is excluded.

## Validation
- 30 focused tests passed, including socket room delivery and payload sanitization.
- npm run harness:check passed.
- npm run build passed.
- git diff --check passed.

## Limits
Companion App PR required. No APNs/FCM or background guarantees. Run notifications require a stable run_id; missing identity fails closed. This is a PR, not a deployment.