### PR TITLE
[codex] fix MCP-triggered Desktop restart loops and orphaned Web UI startup

### DIFF
--- a/docs/harness/validation.md
+++ b/docs/harness/validation.md
@@ -47,6 +47,18 @@ and migration aware of the flag so previously injected entries are repaired;
 do not overwrite user-owned MCP definitions or globally enable Node mode for
 the desktop app. Validate changes with the MCP injection and launch tests.
 
+Long-running external Gateways may keep older MCP definitions in memory. The
+packaged entrypoint must route the exact bundled MCP script invocation before
+loading GUI or updater code, even when Node mode is absent. Test the real package:
+
+```bash
+node scripts/verify-desktop-mcp.mjs '<packaged executable>' '<resources directory>'
+```
+
+This checks all four toolsets with Node mode deliberately removed, validates the
+JSON-RPC initialize response, and checks clean exit on stdin EOF. It uses temporary
+state and does not require a running Gateway.
+
 ## CI Mapping
 
 - Build workflow: installs dependencies, runs coverage, and builds production

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -9,7 +9,7 @@
   },
   "license": "BSL-1.1",
   "private": true,
-  "main": "dist/main/index.js",
+  "main": "dist/main/entry.js",
   "scripts": {
     "build:main": "tsc -p tsconfig.json",
     "build": "npm run build:main",

--- a/packages/desktop/src/main/entry.ts
+++ b/packages/desktop/src/main/entry.ts
@@ -1,0 +1,15 @@
+import { app } from 'electron'
+import { parseBundledMcpArgs, runBundledMcpCli } from './mcp-cli'
+
+// Already-running Gateways can retain MCP definitions from before Node mode
+// was persisted. Route those invocations before loading any GUI or updater code.
+const mcpArgs = app.isPackaged ? parseBundledMcpArgs(process.argv, process.resourcesPath) : null
+if (mcpArgs) {
+  app.dock?.hide()
+  runBundledMcpCli(mcpArgs).then(code => app.exit(code)).catch(error => {
+    console.error(error)
+    app.exit(1)
+  })
+} else {
+  require('./index')
+}

--- a/packages/desktop/src/main/mcp-cli.ts
+++ b/packages/desktop/src/main/mcp-cli.ts
@@ -1,0 +1,41 @@
+import { spawn } from 'node:child_process'
+import { join, resolve } from 'node:path'
+
+export function parseBundledMcpArgs(argv: string[], resourcesPath: string): string[] | null {
+  const script = argv[1]
+  if (!script) return null
+  const bin = join(resourcesPath, 'webui', 'bin')
+  if (!['hermes-studio-mcp.mjs', 'hermes-web-ui-mcp.mjs'].some(name => resolve(script) === join(bin, name))) {
+    return null
+  }
+  return argv.slice(1)
+}
+
+export async function runBundledMcpCli(args: string[]): Promise<number> {
+  return await new Promise(resolveExit => {
+    const child = spawn(process.execPath, args, {
+      env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
+      stdio: 'inherit',
+      windowsHide: true,
+    })
+    const terminate = () => { child.kill('SIGTERM') }
+    const interrupt = () => { child.kill('SIGINT') }
+    process.on('SIGTERM', terminate)
+    process.on('SIGINT', interrupt)
+    process.once('exit', terminate)
+    const cleanup = () => {
+      process.removeListener('SIGTERM', terminate)
+      process.removeListener('SIGINT', interrupt)
+      process.removeListener('exit', terminate)
+    }
+    child.once('error', error => {
+      cleanup()
+      console.error(`Failed to start bundled MCP: ${error.message}`)
+      resolveExit(1)
+    })
+    child.once('exit', (code, signal) => {
+      cleanup()
+      resolveExit(code ?? (signal === 'SIGINT' ? 130 : 143))
+    })
+  })
+}

--- a/packages/desktop/src/main/webui-port.ts
+++ b/packages/desktop/src/main/webui-port.ts
@@ -1,0 +1,53 @@
+import { createServer } from 'node:net'
+
+const PORT_RELEASE_TIMEOUT_MS = 10_000
+const PORT_POLL_INTERVAL_MS = 100
+
+export async function canBindTcpPort(port: number): Promise<boolean> {
+  return await new Promise((resolve) => {
+    const server = createServer()
+    server.unref()
+    server.once('error', () => resolve(false))
+    server.listen(port, '127.0.0.1', () => {
+      server.close(() => resolve(true))
+    })
+  })
+}
+
+async function waitForTcpPort(port: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (await canBindTcpPort(port)) return true
+    await new Promise(resolve => setTimeout(resolve, PORT_POLL_INTERVAL_MS))
+  }
+  return canBindTcpPort(port)
+}
+
+/**
+ * Recover a Desktop Web UI orphaned after its Electron parent exited.
+ * Only the authenticated Desktop shutdown endpoint can authorize this action.
+ */
+export async function releaseOccupiedWebUiPort(
+  port: number,
+  token: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<boolean> {
+  if (await canBindTcpPort(port)) return false
+
+  let response: Response
+  try {
+    response = await fetchImpl(`http://127.0.0.1:${port}/api/desktop/shutdown`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(PORT_RELEASE_TIMEOUT_MS),
+    })
+  } catch {
+    return false
+  }
+
+  if (response.status !== 202) return false
+  if (!await waitForTcpPort(port, PORT_RELEASE_TIMEOUT_MS)) {
+    throw new Error(`Existing Web UI server did not release port ${port} after shutdown`)
+  }
+  return true
+}

--- a/packages/desktop/src/main/webui-port.ts
+++ b/packages/desktop/src/main/webui-port.ts
@@ -4,12 +4,18 @@ const DEFAULT_WEB_UI_SHUTDOWN_FORCE_EXIT_MS = 10_000
 const PORT_RELEASE_GRACE_MS = 1_000
 const PORT_POLL_INTERVAL_MS = 100
 
-function webUiShutdownWaitTimeoutMs(): number {
-  const configured = Number(process.env.HERMES_WEB_UI_SHUTDOWN_FORCE_EXIT_MS)
+export function getWebUiPortReleaseTimeoutMs(
+  env: Record<string, string | undefined> = process.env,
+): number {
+  const configured = Number(env.HERMES_WEB_UI_SHUTDOWN_FORCE_EXIT_MS)
   const forceExitMs = Number.isFinite(configured) && configured > 0
     ? configured
     : DEFAULT_WEB_UI_SHUTDOWN_FORCE_EXIT_MS
   return forceExitMs + PORT_RELEASE_GRACE_MS
+}
+
+function webUiBindHost(env: Record<string, string | undefined> = process.env): string {
+  return env.BIND_HOST?.trim() || '0.0.0.0'
 }
 
 export async function canBindTcpPort(port: number, host = '127.0.0.1'): Promise<boolean> {
@@ -41,7 +47,8 @@ export async function releaseOccupiedWebUiPort(
   token: string,
   fetchImpl: typeof fetch = fetch,
 ): Promise<boolean> {
-  const timeoutMs = webUiShutdownWaitTimeoutMs()
+  const timeoutMs = getWebUiPortReleaseTimeoutMs()
+  const bindHost = webUiBindHost()
   let response: Response
   try {
     response = await fetchImpl(`http://127.0.0.1:${port}/api/desktop/shutdown`, {
@@ -54,9 +61,10 @@ export async function releaseOccupiedWebUiPort(
   }
 
   if (response.status !== 202) return false
-  // The Web UI listens on 0.0.0.0. Probe the same IPv4 wildcard address so an
-  // IPv6 wildcard bind cannot report success while the real listener remains.
-  if (!await waitForTcpPort(port, '0.0.0.0', timeoutMs)) {
+  // Probe the same address family and bind host as the Web UI. In particular,
+  // do not let an IPv4 wildcard probe report success beside a loopback-bound
+  // listener configured with BIND_HOST=127.0.0.1.
+  if (!await waitForTcpPort(port, bindHost, timeoutMs)) {
     throw new Error(`Existing Web UI server did not release port ${port} after shutdown`)
   }
   return true

--- a/packages/desktop/src/main/webui-port.ts
+++ b/packages/desktop/src/main/webui-port.ts
@@ -1,28 +1,35 @@
 import { createServer } from 'node:net'
 
-const PORT_RELEASE_TIMEOUT_MS = 10_000
+const DEFAULT_WEB_UI_SHUTDOWN_FORCE_EXIT_MS = 10_000
+const PORT_RELEASE_GRACE_MS = 1_000
 const PORT_POLL_INTERVAL_MS = 100
 
-export async function canBindTcpPort(port: number): Promise<boolean> {
+function webUiShutdownWaitTimeoutMs(): number {
+  const configured = Number(process.env.HERMES_WEB_UI_SHUTDOWN_FORCE_EXIT_MS)
+  const forceExitMs = Number.isFinite(configured) && configured > 0
+    ? configured
+    : DEFAULT_WEB_UI_SHUTDOWN_FORCE_EXIT_MS
+  return forceExitMs + PORT_RELEASE_GRACE_MS
+}
+
+export async function canBindTcpPort(port: number, host = '127.0.0.1'): Promise<boolean> {
   return await new Promise((resolve) => {
     const server = createServer()
     server.unref()
     server.once('error', () => resolve(false))
-    // Match the Web UI server, which listens on all local interfaces. On macOS
-    // a loopback-only probe can incorrectly succeed beside a wildcard listener.
-    server.listen(port, () => {
+    server.listen(port, host, () => {
       server.close(() => resolve(true))
     })
   })
 }
 
-async function waitForTcpPort(port: number, timeoutMs: number): Promise<boolean> {
+async function waitForTcpPort(port: number, host: string, timeoutMs: number): Promise<boolean> {
   const deadline = Date.now() + timeoutMs
   while (Date.now() < deadline) {
-    if (await canBindTcpPort(port)) return true
+    if (await canBindTcpPort(port, host)) return true
     await new Promise(resolve => setTimeout(resolve, PORT_POLL_INTERVAL_MS))
   }
-  return canBindTcpPort(port)
+  return canBindTcpPort(port, host)
 }
 
 /**
@@ -34,19 +41,22 @@ export async function releaseOccupiedWebUiPort(
   token: string,
   fetchImpl: typeof fetch = fetch,
 ): Promise<boolean> {
+  const timeoutMs = webUiShutdownWaitTimeoutMs()
   let response: Response
   try {
     response = await fetchImpl(`http://127.0.0.1:${port}/api/desktop/shutdown`, {
       method: 'POST',
       headers: { Authorization: `Bearer ${token}` },
-      signal: AbortSignal.timeout(PORT_RELEASE_TIMEOUT_MS),
+      signal: AbortSignal.timeout(timeoutMs),
     })
   } catch {
     return false
   }
 
   if (response.status !== 202) return false
-  if (!await waitForTcpPort(port, PORT_RELEASE_TIMEOUT_MS)) {
+  // The Web UI listens on 0.0.0.0. Probe the same IPv4 wildcard address so an
+  // IPv6 wildcard bind cannot report success while the real listener remains.
+  if (!await waitForTcpPort(port, '0.0.0.0', timeoutMs)) {
     throw new Error(`Existing Web UI server did not release port ${port} after shutdown`)
   }
   return true

--- a/packages/desktop/src/main/webui-port.ts
+++ b/packages/desktop/src/main/webui-port.ts
@@ -8,7 +8,9 @@ export async function canBindTcpPort(port: number): Promise<boolean> {
     const server = createServer()
     server.unref()
     server.once('error', () => resolve(false))
-    server.listen(port, '127.0.0.1', () => {
+    // Match the Web UI server, which listens on all local interfaces. On macOS
+    // a loopback-only probe can incorrectly succeed beside a wildcard listener.
+    server.listen(port, () => {
       server.close(() => resolve(true))
     })
   })
@@ -32,8 +34,6 @@ export async function releaseOccupiedWebUiPort(
   token: string,
   fetchImpl: typeof fetch = fetch,
 ): Promise<boolean> {
-  if (await canBindTcpPort(port)) return false
-
   let response: Response
   try {
     response = await fetchImpl(`http://127.0.0.1:${port}/api/desktop/shutdown`, {

--- a/packages/desktop/src/main/webui-server.ts
+++ b/packages/desktop/src/main/webui-server.ts
@@ -33,6 +33,7 @@ import {
   withDesktopHermesSelection,
   type DesktopManagedHermesRuntime,
 } from './hermes-environment-selection'
+import { canBindTcpPort, releaseOccupiedWebUiPort } from './webui-port'
 
 const DEFAULT_PORT = 8748
 const DEFAULT_READY_TIMEOUT_MS = 120_000
@@ -549,17 +550,6 @@ async function getFreeTcpPort(): Promise<number> {
   })
 }
 
-async function canBindTcpPort(port: number): Promise<boolean> {
-  return await new Promise((resolveCanBind) => {
-    const server = createServer()
-    server.unref()
-    server.once('error', () => resolveCanBind(false))
-    server.listen(port, '127.0.0.1', () => {
-      server.close(() => resolveCanBind(true))
-    })
-  })
-}
-
 async function getFreeTcpPortInRange(min: number, max: number): Promise<number> {
   for (let attempt = 0; attempt < 100; attempt += 1) {
     const port = min + (randomBytes(2).readUInt16BE(0) % (max - min + 1))
@@ -735,6 +725,11 @@ export async function startWebUiServer(port = DEFAULT_PORT): Promise<string> {
     // available after selection without influencing which Hermes wins.
     PATH: runtimePath,
   }, hermesSelection)
+
+  const released = await releaseOccupiedWebUiPort(port, token)
+  if (released) {
+    console.warn(`[webui] released an orphaned Desktop Web UI on port ${port}`)
+  }
 
   const fallbackWebUiDir = defaultWebuiDir()
   try {

--- a/packages/desktop/src/main/webui-server.ts
+++ b/packages/desktop/src/main/webui-server.ts
@@ -553,7 +553,9 @@ async function getFreeTcpPort(): Promise<number> {
 async function getFreeTcpPortInRange(min: number, max: number): Promise<number> {
   for (let attempt = 0; attempt < 100; attempt += 1) {
     const port = min + (randomBytes(2).readUInt16BE(0) % (max - min + 1))
-    if (await canBindTcpPort(port)) return port
+    // Bridge workers use tcp://127.0.0.1, so keep the probe on the same
+    // loopback address instead of reserving an IPv4 wildcard port.
+    if (await canBindTcpPort(port, '127.0.0.1')) return port
   }
   return getFreeTcpPort()
 }

--- a/scripts/verify-desktop-mcp.mjs
+++ b/scripts/verify-desktop-mcp.mjs
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+const executable = resolve(process.argv[2] || '')
+const resources = process.argv[3] && resolve(process.argv[3])
+if (!process.argv[2] || !resources) {
+  throw new Error('Usage: node scripts/verify-desktop-mcp.mjs <packaged executable> <resources directory>')
+}
+const state = await mkdtemp(join(tmpdir(), 'hermes-desktop-mcp-'))
+try {
+  for (const toolset of ['api', 'browser', 'devices', 'use']) {
+    const env = {
+      ...process.env,
+      HERMES_WEB_UI_HOME: state,
+      HERMES_WEBUI_STATE_DIR: state,
+      HERMES_HOME: state,
+    }
+    delete env.ELECTRON_RUN_AS_NODE
+    const child = spawn(executable, [join(resources, 'webui', 'bin', 'hermes-studio-mcp.mjs'), toolset], {
+      env, stdio: ['pipe', 'pipe', 'pipe'],
+    })
+    let output = ''
+    let stderr = ''
+    child.stdout.on('data', chunk => { output += chunk })
+    child.stderr.on('data', chunk => { stderr += chunk })
+    const timer = setTimeout(() => child.kill('SIGKILL'), 15_000)
+    try {
+      const closed = new Promise((resolveClose, reject) => {
+        child.once('error', reject)
+        child.once('close', (code, signal) => resolveClose({ code, signal }))
+      })
+      child.stdin.end(JSON.stringify({
+        jsonrpc: '2.0', id: 1, method: 'initialize',
+        params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'desktop-regression', version: '1' } },
+      }) + '\n')
+      const result = await closed
+      assert.equal(result.code, 0, `${toolset} exit: ${JSON.stringify(result)} ${stderr}`)
+      const messages = output.trim().split('\n').map(line => JSON.parse(line))
+      assert.equal(messages.length, 1, `Unexpected GUI or updater output: ${output}`)
+      assert.equal(messages[0].id, 1)
+      assert.ok(messages[0].result?.serverInfo)
+      console.log(`PASS ${toolset}: packaged MCP initializes without ELECTRON_RUN_AS_NODE and exits on stdin EOF`)
+    } finally {
+      clearTimeout(timer)
+    }
+  }
+} finally {
+  await rm(state, { recursive: true, force: true })
+}

--- a/tests/desktop/mcp-cli.test.ts
+++ b/tests/desktop/mcp-cli.test.ts
@@ -1,0 +1,18 @@
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { parseBundledMcpArgs } from '../../packages/desktop/src/main/mcp-cli'
+
+describe('legacy packaged MCP invocation', () => {
+  const resources = join(process.cwd(), 'test-app', 'Resources')
+
+  it.each(['hermes-studio-mcp.mjs', 'hermes-web-ui-mcp.mjs'])('preserves the arguments for %s', name => {
+    const script = join(resources, 'webui', 'bin', name)
+    expect(parseBundledMcpArgs(['Hermes Studio', script, 'devices'], resources)).toEqual([script, 'devices'])
+  })
+
+  it('leaves ordinary desktop, CLI, and arbitrary script invocations alone', () => {
+    for (const args of [[], ['--hidden'], ['--quit'], ['--hermes-cli', 'status'], ['/tmp/hermes-studio-mcp.mjs']]) {
+      expect(parseBundledMcpArgs(['Hermes Studio', ...args], resources)).toBeNull()
+    }
+  })
+})

--- a/tests/desktop/webui-port.test.ts
+++ b/tests/desktop/webui-port.test.ts
@@ -1,0 +1,67 @@
+import { createServer, type Server } from 'node:http'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { releaseOccupiedWebUiPort } from '../../packages/desktop/src/main/webui-port'
+
+const servers: Server[] = []
+
+async function listen(server: Server): Promise<number> {
+  servers.push(server)
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => resolve())
+  })
+  const address = server.address()
+  if (!address || typeof address === 'string') throw new Error('Test server did not expose a TCP port')
+  return address.port
+}
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map(server => new Promise<void>(resolve => {
+    if (!server.listening) {
+      resolve()
+      return
+    }
+    server.close(() => resolve())
+  })))
+})
+
+describe('Desktop Web UI port recovery', () => {
+  it('asks an orphaned Desktop server to shut down and waits for the port', async () => {
+    let server!: Server
+    server = createServer((request, response) => {
+      if (request.url === '/api/desktop/shutdown' && request.method === 'POST') {
+        response.statusCode = request.headers.authorization === 'Bearer desktop-token' ? 202 : 401
+        response.end()
+        if (response.statusCode === 202) setImmediate(() => server.close())
+        return
+      }
+      response.statusCode = 404
+      response.end()
+    })
+    const port = await listen(server)
+
+    await expect(releaseOccupiedWebUiPort(port, 'desktop-token')).resolves.toBe(true)
+    expect(server.listening).toBe(false)
+  })
+
+  it('does not stop a non-Desktop service on the requested port', async () => {
+    const server = createServer((_request, response) => {
+      response.statusCode = 404
+      response.end()
+    })
+    const port = await listen(server)
+
+    await expect(releaseOccupiedWebUiPort(port, 'desktop-token')).resolves.toBe(false)
+    expect(server.listening).toBe(true)
+  })
+
+  it('does not probe an available port', async () => {
+    const fetchImpl = vi.fn<typeof fetch>()
+    const server = createServer()
+    const port = await listen(server)
+    await new Promise<void>(resolve => server.close(() => resolve()))
+
+    await expect(releaseOccupiedWebUiPort(port, 'desktop-token', fetchImpl)).resolves.toBe(false)
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+})

--- a/tests/desktop/webui-port.test.ts
+++ b/tests/desktop/webui-port.test.ts
@@ -4,11 +4,11 @@ import { releaseOccupiedWebUiPort } from '../../packages/desktop/src/main/webui-
 
 const servers: Server[] = []
 
-async function listen(server: Server): Promise<number> {
+async function listen(server: Server, host = '127.0.0.1'): Promise<number> {
   servers.push(server)
   await new Promise<void>((resolve, reject) => {
     server.once('error', reject)
-    server.listen(0, '127.0.0.1', () => resolve())
+    server.listen(0, host, () => resolve())
   })
   const address = server.address()
   if (!address || typeof address === 'string') throw new Error('Test server did not expose a TCP port')
@@ -44,6 +44,24 @@ describe('Desktop Web UI port recovery', () => {
     expect(server.listening).toBe(false)
   })
 
+  it('recovers a Desktop server bound to all local interfaces', async () => {
+    let server!: Server
+    server = createServer((request, response) => {
+      if (request.url === '/api/desktop/shutdown' && request.method === 'POST') {
+        response.statusCode = request.headers.authorization === 'Bearer desktop-token' ? 202 : 401
+        response.end()
+        if (response.statusCode === 202) setImmediate(() => server.close())
+        return
+      }
+      response.statusCode = 404
+      response.end()
+    })
+    const port = await listen(server, '0.0.0.0')
+
+    await expect(releaseOccupiedWebUiPort(port, 'desktop-token')).resolves.toBe(true)
+    expect(server.listening).toBe(false)
+  })
+
   it('does not stop a non-Desktop service on the requested port', async () => {
     const server = createServer((_request, response) => {
       response.statusCode = 404
@@ -55,13 +73,13 @@ describe('Desktop Web UI port recovery', () => {
     expect(server.listening).toBe(true)
   })
 
-  it('does not probe an available port', async () => {
-    const fetchImpl = vi.fn<typeof fetch>()
+  it('does not affect an available port', async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockRejectedValue(new Error('ECONNREFUSED'))
     const server = createServer()
     const port = await listen(server)
     await new Promise<void>(resolve => server.close(() => resolve()))
 
     await expect(releaseOccupiedWebUiPort(port, 'desktop-token', fetchImpl)).resolves.toBe(false)
-    expect(fetchImpl).not.toHaveBeenCalled()
+    expect(fetchImpl).toHaveBeenCalledOnce()
   })
 })

--- a/tests/desktop/webui-port.test.ts
+++ b/tests/desktop/webui-port.test.ts
@@ -1,6 +1,10 @@
 import { createServer, type Server } from 'node:http'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { canBindTcpPort, releaseOccupiedWebUiPort } from '../../packages/desktop/src/main/webui-port'
+import {
+  canBindTcpPort,
+  getWebUiPortReleaseTimeoutMs,
+  releaseOccupiedWebUiPort,
+} from '../../packages/desktop/src/main/webui-port'
 
 const servers: Server[] = []
 
@@ -64,6 +68,7 @@ describe('Desktop Web UI port recovery', () => {
   })
 
   it('waits for a delayed IPv4 wildcard shutdown before reporting success', async () => {
+    vi.stubEnv('BIND_HOST', '0.0.0.0')
     vi.stubEnv('HERMES_WEB_UI_SHUTDOWN_FORCE_EXIT_MS', '100')
     let server!: Server
     server = createServer((request, response) => {
@@ -82,6 +87,26 @@ describe('Desktop Web UI port recovery', () => {
     expect(server.listening).toBe(false)
   })
 
+  it('uses the configured loopback bind host for delayed shutdown recovery', async () => {
+    vi.stubEnv('BIND_HOST', '127.0.0.1')
+    vi.stubEnv('HERMES_WEB_UI_SHUTDOWN_FORCE_EXIT_MS', '100')
+    let server!: Server
+    server = createServer((request, response) => {
+      if (request.url === '/api/desktop/shutdown' && request.method === 'POST') {
+        response.statusCode = request.headers.authorization === 'Bearer desktop-token' ? 202 : 401
+        response.end()
+        if (response.statusCode === 202) setTimeout(() => server.close(), 150)
+        return
+      }
+      response.statusCode = 404
+      response.end()
+    })
+    const port = await listen(server, '127.0.0.1')
+
+    await expect(releaseOccupiedWebUiPort(port, 'desktop-token')).resolves.toBe(true)
+    expect(server.listening).toBe(false)
+  })
+
   it('reports an occupied IPv4 wildcard port as unavailable to a matching probe', async () => {
     const server = createServer()
     const port = await listen(server, '0.0.0.0')
@@ -91,6 +116,7 @@ describe('Desktop Web UI port recovery', () => {
   })
 
   it('waits through the configured shutdown budget plus cleanup grace', async () => {
+    vi.stubEnv('BIND_HOST', '0.0.0.0')
     vi.stubEnv('HERMES_WEB_UI_SHUTDOWN_FORCE_EXIT_MS', '100')
     let server!: Server
     server = createServer((request, response) => {
@@ -110,6 +136,7 @@ describe('Desktop Web UI port recovery', () => {
   })
 
   it('throws when the server misses the shutdown budget and cleanup grace', async () => {
+    vi.stubEnv('BIND_HOST', '0.0.0.0')
     vi.stubEnv('HERMES_WEB_UI_SHUTDOWN_FORCE_EXIT_MS', '100')
     const server = createServer((request, response) => {
       if (request.url === '/api/desktop/shutdown' && request.method === 'POST') {
@@ -122,9 +149,18 @@ describe('Desktop Web UI port recovery', () => {
     })
     const port = await listen(server, '0.0.0.0')
 
+    const startedAt = Date.now()
     await expect(releaseOccupiedWebUiPort(port, 'desktop-token'))
       .rejects.toThrow(`Existing Web UI server did not release port ${port} after shutdown`)
+    const elapsedMs = Date.now() - startedAt
+    expect(elapsedMs).toBeGreaterThanOrEqual(1_000)
+    expect(elapsedMs).toBeLessThan(1_500)
     expect(server.listening).toBe(true)
+  })
+
+  it('derives the release timeout from the shutdown budget plus grace', () => {
+    expect(getWebUiPortReleaseTimeoutMs({ HERMES_WEB_UI_SHUTDOWN_FORCE_EXIT_MS: '100' })).toBe(1_100)
+    expect(getWebUiPortReleaseTimeoutMs({ HERMES_WEB_UI_SHUTDOWN_FORCE_EXIT_MS: 'not-a-number' })).toBe(11_000)
   })
 
   it('does not stop a non-Desktop service on the requested port', async () => {

--- a/tests/desktop/webui-port.test.ts
+++ b/tests/desktop/webui-port.test.ts
@@ -1,6 +1,6 @@
 import { createServer, type Server } from 'node:http'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { releaseOccupiedWebUiPort } from '../../packages/desktop/src/main/webui-port'
+import { canBindTcpPort, releaseOccupiedWebUiPort } from '../../packages/desktop/src/main/webui-port'
 
 const servers: Server[] = []
 
@@ -16,6 +16,7 @@ async function listen(server: Server, host = '127.0.0.1'): Promise<number> {
 }
 
 afterEach(async () => {
+  vi.unstubAllEnvs()
   await Promise.all(servers.splice(0).map(server => new Promise<void>(resolve => {
     if (!server.listening) {
       resolve()
@@ -60,6 +61,70 @@ describe('Desktop Web UI port recovery', () => {
 
     await expect(releaseOccupiedWebUiPort(port, 'desktop-token')).resolves.toBe(true)
     expect(server.listening).toBe(false)
+  })
+
+  it('waits for a delayed IPv4 wildcard shutdown before reporting success', async () => {
+    vi.stubEnv('HERMES_WEB_UI_SHUTDOWN_FORCE_EXIT_MS', '100')
+    let server!: Server
+    server = createServer((request, response) => {
+      if (request.url === '/api/desktop/shutdown' && request.method === 'POST') {
+        response.statusCode = request.headers.authorization === 'Bearer desktop-token' ? 202 : 401
+        response.end()
+        if (response.statusCode === 202) setTimeout(() => server.close(), 150)
+        return
+      }
+      response.statusCode = 404
+      response.end()
+    })
+    const port = await listen(server, '0.0.0.0')
+
+    await expect(releaseOccupiedWebUiPort(port, 'desktop-token')).resolves.toBe(true)
+    expect(server.listening).toBe(false)
+  })
+
+  it('reports an occupied IPv4 wildcard port as unavailable to a matching probe', async () => {
+    const server = createServer()
+    const port = await listen(server, '0.0.0.0')
+
+    await expect(canBindTcpPort(port, '0.0.0.0')).resolves.toBe(false)
+    expect(server.listening).toBe(true)
+  })
+
+  it('waits through the configured shutdown budget plus cleanup grace', async () => {
+    vi.stubEnv('HERMES_WEB_UI_SHUTDOWN_FORCE_EXIT_MS', '100')
+    let server!: Server
+    server = createServer((request, response) => {
+      if (request.url === '/api/desktop/shutdown' && request.method === 'POST') {
+        response.statusCode = request.headers.authorization === 'Bearer desktop-token' ? 202 : 401
+        response.end()
+        if (response.statusCode === 202) setTimeout(() => server.close(), 900)
+        return
+      }
+      response.statusCode = 404
+      response.end()
+    })
+    const port = await listen(server, '0.0.0.0')
+
+    await expect(releaseOccupiedWebUiPort(port, 'desktop-token')).resolves.toBe(true)
+    expect(server.listening).toBe(false)
+  })
+
+  it('throws when the server misses the shutdown budget and cleanup grace', async () => {
+    vi.stubEnv('HERMES_WEB_UI_SHUTDOWN_FORCE_EXIT_MS', '100')
+    const server = createServer((request, response) => {
+      if (request.url === '/api/desktop/shutdown' && request.method === 'POST') {
+        response.statusCode = request.headers.authorization === 'Bearer desktop-token' ? 202 : 401
+        response.end()
+        return
+      }
+      response.statusCode = 404
+      response.end()
+    })
+    const port = await listen(server, '0.0.0.0')
+
+    await expect(releaseOccupiedWebUiPort(port, 'desktop-token'))
+      .rejects.toThrow(`Existing Web UI server did not release port ${port} after shutdown`)
+    expect(server.listening).toBe(true)
   })
 
   it('does not stop a non-Desktop service on the requested port', async () => {


### PR DESCRIPTION
## Summary

Fix a Desktop startup failure and a related loop in which Hermes Studio keeps reopening and an update download never finishes. Recover an authenticated orphaned Web UI server before starting its replacement, and route legacy MCP invocations before loading any Desktop GUI or updater code.

## What the user experienced

The user opens Hermes Studio 0.7.17, sees the 0.7.18 update prompt, and clicks **Download**. The window disappears or returns to **Starting local services...**, then another window offers the same update. After several attempts the installed version is still 0.7.17. Sometimes startup instead fails with a generic Web UI `code=1` error, and **Retry** fails again.

In plain language, a background agent was trying to start a small tool, but the old tool configuration accidentally opened the entire desktop app. The agent waited for a tool response, received desktop startup output instead, timed out, and retried. The desktop window that the user interacted with belonged to that short-lived tool attempt. Clicking Download started a real download, but the app could be terminated before it finished. Reopening the old version was not evidence of a successful update.

中文用户场景：打开软件后提示有新版本，点击 Download，等了一会儿窗口又重新打开，仍然提示同一个更新，让人以为“已经更新但没生效”。实际上后台 Agent 把本应无界面运行的工具启动成了桌面软件，等不到工具回复就结束它并重试。用户看到的软件因此反复重开，下载也在中途被打断。另一个启动问题是旧的本地服务没有退出，继续占着端口，让新窗口启动失败。

<img width="1075" height="685" alt="image" src="https://github.com/user-attachments/assets/f00ed53c-547d-43ab-8ae5-c82e7b9759d5" />


## Evidence and cause

- The GUI-owning process was a child of a long-running Hermes Gateway, invoked as the packaged Electron executable followed by `Resources/webui/bin/hermes-studio-mcp.mjs` and a toolset argument.
- MCP stderr contained Desktop startup errors and updater failures (`net::ERR_FAILED`). Gateway logs repeatedly reported invalid JSON-RPC responses and retried the tool launch. Partial download files disappeared without a complete update package.
- Upstream commit `7905706f` already adds `ELECTRON_RUN_AS_NODE=1` to newly persisted managed MCP configurations. An existing Gateway can still retain an older configuration in memory, so fixing the saved file alone does not protect that running process.
- Separately, a local startup log reported `EADDRINUSE` on port 8748. A Web UI child left behind by an exited parent prevents its replacement from binding that port.

## Changes

- Add a small packaged entrypoint that recognizes only the two exact bundled MCP script paths. Re-execute them in Node mode with inherited stdio, arguments, exit status, and signal forwarding before loading GUI modules. Normal Desktop and Hermes CLI launches retain their existing route.
- Keep the Node-mode override local to the MCP child. Legacy Gateway calls can now return JSON-RPC without opening a window, acquiring the GUI instance lock, or checking for updates.
- Before launching the Web UI, ask an existing loopback server to shut down using the current Desktop token and wait for the port to be released. Unauthenticated or unrelated services are left running.
- Add a packaged regression script covering all four MCP toolsets with Node mode deliberately absent, plus focused parser and port-recovery tests.

## Validation

- `npm --prefix packages/desktop run build:main`
- `npm test -- tests/desktop`: 154 passed, 1 skipped
- `npm run harness:check`
- `npm run build`
- Local macOS arm64 package build, including packaged Web UI resource validation
- `node scripts/verify-desktop-mcp.mjs <executable> <resources>` against both the built package and the installed application: all four toolsets return an initialize response and exit cleanly on stdin EOF without `ELECTRON_RUN_AS_NODE`
- Installed the rebuilt 0.7.18 application locally with the old bundle retained as a backup. Observed the real chat UI and existing sessions, then performed a normal quit/reopen. Web UI shutdown exited with code 0, port 8748 was rebound, and the update check reported up to date. The existing Gateway was not restarted.
- Local recovery also corrected an existing CLI wrapper to explicitly select its existing virtualenv Python. The final launch detects the user's Hermes CLI, reports Agent inventory available, and starts the Agent bridge successfully. This machine-specific wrapper adjustment is outside the PR diff.

## Limits

The local recovery used a locally built, unsigned 0.7.18 package. This verifies the installed startup/MCP repair and normal restart, but does not establish the signed Squirrel.Mac download-and-replacement flow. The updater implementation itself is unchanged. Windows and Linux packaged runs were not performed.
