### PR TITLE
Add OpenCode Free provider and keyless Coding Agent proxy

### DIFF
--- a/docs/opencode-free.md
+++ b/docs/opencode-free.md
@@ -1,0 +1,54 @@
+# OpenCode Free
+
+Studio includes the native Hermes `opencode-free` provider without credentials
+or a custom-provider entry. It is listed on startup, including on installations
+that already have other provider catalog caches. The free catalog is public and
+shared across profiles; model visibility and aliases continue to use the existing
+Studio settings.
+
+Startup does not modify Hermes `config.yaml`, `.env`, or the default model. Only
+an explicit default-model selection writes `model.provider: opencode-free` and
+the selected model ID. Chat requests retain the native provider ID, allowing
+Hermes to choose the transport and anonymous authentication behavior.
+
+Initialization runs in the background:
+
+- Probe the selected Hermes Python's provider registry with a 5-second timeout.
+  Command lookup also runs asynchronously with a 2-second timeout.
+- Fetch the public OpenCode catalog without an Authorization header and with an
+  8-second timeout. Match Hermes' `-free` catalog filter, excluding the known
+  Go-only `ox-alpha-free` model.
+- Use the existing Studio catalog cache immediately. With no cache, show a
+  loading entry instead of blocking other providers or guessing model IDs.
+- Keep a last-good catalog after failures or empty responses. Retry after one
+  minute; refresh successful initialization after five minutes. Deduplicate
+  initialization and unref retry timers so they cannot keep the server alive.
+- If the runtime does not support this provider, keep its entry visible with an
+  update message and no selectable models. No automatic Hermes upgrade occurs.
+
+The model settings page and new-chat drawer poll initialization in the background while it is
+loading or retrying and stops polling when the page is unmounted. This does not
+show a page-wide loading overlay or change the selected model.
+
+These are remote free-tier models. A model appearing in the catalog does not
+guarantee successful inference: rate limits and provider outages still apply.
+
+Focused checks:
+
+```sh
+npx vitest run tests/server/opencode-free*.test.ts tests/server/provider-create-controller.test.ts tests/server/provider-model-refresh.test.ts
+npx playwright test tests/e2e/provider-models.spec.ts
+```
+
+Scoped Coding Agents (Claude Code, Codex, Pi, Grok, and OpenCode) also support
+this provider without an upstream key. Their generated configurations retain
+Studio's local proxy token; the proxy strips stale supplied credentials, fixes
+the upstream to OpenCode Zen, and omits upstream Authorization / x-api-key
+headers. Existing Codex and Pi proxy restoration supports empty upstream
+credentials. Other providers retain credential requirements. Ekko resolves the
+same anonymous runtime directly. Global Coding Agent mode continues to use the
+agent's own configuration.
+
+API mode follows Hermes' Zen routing: GPT/Grok/Muse Spark use Responses,
+Claude/Qwen use Messages, and other free models use Chat Completions. The
+new-chat form selects this mode automatically and does not ask for an API key.

--- a/packages/client/src/api/hermes/system.ts
+++ b/packages/client/src/api/hermes/system.ts
@@ -25,6 +25,7 @@ export interface ModelVisibilityRule {
 export type ModelVisibility = Record<string, ModelVisibilityRule>
 export type CustomModels = Record<string, string[]>
 export interface AvailableModelGroup {
+  catalog_status?: 'loading' | 'ready' | 'error' | 'unsupported'
   provider: string   // credential pool key (e.g. "zai", "custom:subrouter.ai")
   label: string      // display name (e.g. "zai", "subrouter.ai")
   base_url: string

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -57,7 +57,7 @@ import PageSidebarNav from "@/components/layout/PageSidebarNav.vue";
 import { isStoredSuperAdmin } from "@/api/client";
 import { useDefaultWorkspace } from "@/composables/useDefaultWorkspace";
 import { useCollapsedProviderGroups } from "@/composables/useCollapsedProviderGroups";
-import { canScopedCodingAgentUseProvider, usesServerManagedProviderAuth } from "@/utils/codingAgentProviders";
+import { canScopedCodingAgentUseProvider, usesServerManagedProviderAuth, isKeylessModelProvider, openCodeFreeApiMode } from "@/utils/codingAgentProviders";
 import { OPEN_SUBAGENT_STREAM_EVENT, type OpenSubagentStreamDetail } from "@/utils/hermes/subagent-stream";
 import { desktopBridge, hasDesktopBrowserBridge } from "@/utils/desktop-bridge";
 import { OPEN_DESKTOP_BROWSER_PANEL_EVENT } from "@/utils/desktop-browser";
@@ -1123,10 +1123,12 @@ const newChatNeedsBaseUrl = computed(() =>
 const newChatUsesServerAuth = computed(() =>
   usesServerManagedProviderAuth(newChatAgent.value as ChatCodingAgentId, selectedNewChatProviderGroup.value?.provider),
 );
+const newChatUsesKeylessProvider = computed(() => isKeylessModelProvider(newChatProvider.value));
 const newChatNeedsApiKey = computed(() =>
   isNewChatCodingAgent.value &&
   effectiveNewChatAgentMode.value === "scoped" &&
   !newChatUsesServerAuth.value &&
+  !newChatUsesKeylessProvider.value &&
   !selectedNewChatProviderGroup.value?.api_key,
 );
 const canConfirmNewChat = computed(() => {
@@ -1142,6 +1144,7 @@ const canConfirmNewChat = computed(() => {
 });
 
 function defaultNewChatApiMode(group?: AvailableModelGroup): CodingAgentApiMode {
+  if (newChatUsesKeylessProvider.value) return openCodeFreeApiMode(newChatModel.value);
   const providerKey = String(group?.provider || newChatProvider.value || "").toLowerCase();
   const baseUrl = String(group?.base_url || newChatBaseUrl.value || "").toLowerCase();
   return normalizeCodingAgentApiMode(
@@ -1153,6 +1156,10 @@ function defaultNewChatApiMode(group?: AvailableModelGroup): CodingAgentApiMode 
 function syncNewChatApiMode() {
   newChatApiMode.value = defaultNewChatApiMode(selectedNewChatProviderGroup.value);
 }
+
+watch(newChatModel, () => {
+  if (newChatUsesKeylessProvider.value) syncNewChatApiMode();
+});
 
 function syncNewChatModelSelection() {
   const defaults = getDefaultModelForProfile(newChatProfile.value);
@@ -1212,6 +1219,33 @@ watch(
     }
   },
 );
+
+let newChatCatalogPoll: ReturnType<typeof setInterval> | undefined;
+let refreshingNewChatCatalog = false;
+watch(showNewChatModal, (visible) => {
+  if (newChatCatalogPoll) clearInterval(newChatCatalogPoll);
+  newChatCatalogPoll = undefined;
+  if (!visible) return;
+  newChatCatalogPoll = setInterval(async () => {
+    const free = newChatModelGroups.value.find(group => group.provider === "opencode-free");
+    if (refreshingNewChatCatalog || !free || !["loading", "error"].includes(free.catalog_status || "")) return;
+    refreshingNewChatCatalog = true;
+    try {
+      await appStore.reloadModels({ preserveSelection: true });
+      if (!showNewChatModal.value) return;
+      const current = selectedNewChatProviderGroup.value;
+      if (current && !newChatModel.value) {
+        newChatModel.value = current.models[0] || "";
+        syncNewChatApiMode();
+      } else if (!newChatProvider.value) {
+        ensureNewChatProviderSelection();
+      }
+    } finally {
+      refreshingNewChatCatalog = false;
+    }
+  }, 3000);
+});
+onUnmounted(() => { if (newChatCatalogPoll) clearInterval(newChatCatalogPoll); });
 
 async function openNewChatModal() {
   isBatchMode.value = false;
@@ -1331,7 +1365,7 @@ async function confirmNewChat() {
     workspace: newChatWorkspace.value || null,
     categoryId: newChatCategoryId.value,
     baseUrl: source === "coding_agent" && !isGlobalCodingAgent ? group?.base_url || newChatBaseUrl.value.trim() || undefined : undefined,
-    apiKey: source === "coding_agent" && !isGlobalCodingAgent ? group?.api_key || newChatApiKey.value.trim() || undefined : undefined,
+    apiKey: source === "coding_agent" && !isGlobalCodingAgent && !newChatUsesKeylessProvider.value ? group?.api_key || newChatApiKey.value.trim() || undefined : undefined,
     apiMode: isNewChatCodingAgent.value && !isGlobalCodingAgent ? newChatApiMode.value : undefined,
   });
   // Record workspace to recent list
@@ -3006,7 +3040,7 @@ async function handleSessionModelCustomSubmit() {
             <NSelect
               v-model:value="newChatApiMode"
               :options="newChatApiModeOptions"
-              :disabled="newChatLoading"
+              :disabled="newChatLoading || newChatUsesKeylessProvider"
             />
           </label>
           <label v-if="newChatNeedsBaseUrl" class="new-chat-field">
@@ -3016,6 +3050,9 @@ async function handleSessionModelCustomSubmit() {
               :placeholder="t('models.baseUrlPlaceholder')"
             />
           </label>
+          <div v-if="newChatUsesProviderModel && newChatUsesKeylessProvider" class="new-chat-field">
+            {{ t("models.opencodeFreeHint") }}
+          </div>
           <label v-if="newChatNeedsApiKey" class="new-chat-field">
             <span class="new-chat-label">{{ t("models.apiKey") }}</span>
             <NInput

--- a/packages/client/src/components/hermes/models/ProviderCard.vue
+++ b/packages/client/src/components/hermes/models/ProviderCard.vue
@@ -23,6 +23,7 @@ const isCustomProviderKey = computed(() => props.provider.provider.startsWith('c
 const isCustom = computed(() => !props.provider.builtin && isCustomProviderKey.value)
 const isConfigBackedProvider = computed(() => isCustomProviderKey.value || (!props.provider.builtin && !!props.provider.provider_source))
 const isCopilot = computed(() => props.provider.provider === 'copilot')
+const isOpenCodeFree = computed(() => props.provider.provider === 'opencode-free')
 const displayName = computed(() => props.provider.label)
 const userRole = getStoredUserRole()
 const canEditProvider = computed(() => (
@@ -305,6 +306,12 @@ async function handleRestoreModels() {
     </div>
 
     <div class="card-body">
+      <template v-if="isOpenCodeFree">
+        <p>{{ t('models.opencodeFreeHint') }}</p>
+        <p v-if="provider.catalog_status === 'loading'">{{ t('models.opencodeFreeLoading') }}</p>
+        <p v-else-if="provider.catalog_status === 'error'">{{ t('models.opencodeFreeRetry') }}</p>
+        <p v-else-if="provider.catalog_status === 'unsupported'">{{ t('models.opencodeFreeUpgrade') }}</p>
+      </template>
       <div class="info-row">
         <span class="info-label">{{ t('models.provider') }}</span>
         <code class="info-value mono">{{ provider.provider }}</code>
@@ -357,7 +364,7 @@ async function handleRestoreModels() {
       <NButton
         size="tiny"
         quaternary
-        :disabled="isDefaultProvider"
+        :disabled="isDefaultProvider || provider.models.length === 0"
         :loading="defaultingProvider"
         @click="handleSetDefaultProvider"
       >
@@ -385,7 +392,7 @@ async function handleRestoreModels() {
         {{ t('models.restoreModels') }}
       </NButton>
       <NButton v-if="canEditProvider" size="tiny" quaternary @click="showEditorModal = true">{{ t('common.edit') }}</NButton>
-      <NButton size="tiny" quaternary type="error" :loading="deleting" @click="handleDelete">{{ destructiveActionLabel }}</NButton>
+      <NButton v-if="!isOpenCodeFree" size="tiny" quaternary type="error" :loading="deleting" @click="handleDelete">{{ destructiveActionLabel }}</NButton>
     </div>
 
     <ProviderEditorModal

--- a/packages/client/src/components/hermes/models/ProviderFormModal.vue
+++ b/packages/client/src/components/hermes/models/ProviderFormModal.vue
@@ -105,6 +105,7 @@ const isCliproxyApi = computed(() => selectedPreset.value === CLIPROXYAPI_KEY)
 const isXaiOAuth = computed(() => selectedPreset.value === XAI_OAUTH_KEY)
 const isClaudeOAuth = computed(() => selectedPreset.value === CLAUDE_OAUTH_KEY)
 const isMiniMaxOAuth = computed(() => selectedPreset.value === MINIMAX_OAUTH_KEY)
+const isOpenCodeFree = computed(() => selectedPreset.value === 'opencode-free')
 const isAlibabaCoding = computed(() => selectedPreset.value === ALIBABA_CODING_KEY)
 const alibabaCodingRegion = ref<'intl' | 'cn'>('intl')
 
@@ -175,6 +176,7 @@ function customProviderKey(name: string): string {
 
 watch(selectedPreset, (val) => {
   formData.value.model = ''
+  if (val === 'opencode-free') formData.value.api_key = ''
   alibabaCodingRegion.value = 'intl'
   if (val) {
     const group = selectedPresetProvider.value
@@ -249,7 +251,7 @@ async function fetchModels() {
       : formData.value.name.trim() || provider
     const data = await fetchProviderModels({
       base_url: base_url.trim(),
-      api_key: formData.value.api_key.trim(),
+      api_key: isOpenCodeFree.value ? '' : formData.value.api_key.trim(),
       provider,
       label,
       update_cache: !!provider,
@@ -309,7 +311,7 @@ async function handleSave() {
     message.warning(t('models.baseUrlRequired'))
     return
   }
-  if (!formData.value.api_key.trim() && !isCliproxyApi.value && !isXaiOAuth.value && !isClaudeOAuth.value && !isMiniMaxOAuth.value) {
+  if (!formData.value.api_key.trim() && !isCliproxyApi.value && !isXaiOAuth.value && !isClaudeOAuth.value && !isMiniMaxOAuth.value && !isOpenCodeFree.value) {
     message.warning(t('models.apiKeyRequired'))
     return
   }
@@ -336,7 +338,7 @@ async function handleSave() {
     await modelsStore.addProvider({
       name: providerName,
       base_url: baseUrl,
-      api_key: formData.value.api_key.trim(),
+      api_key: isOpenCodeFree.value ? '' : formData.value.api_key.trim(),
       model: formData.value.model,
       context_length: contextLength,
       api_mode: formData.value.api_mode,
@@ -532,7 +534,11 @@ function handleClose() {
         />
       </NFormItem>
 
-      <NFormItem v-if="!isCodex && !isNous && !isClaudeOAuth && !isMiniMaxOAuth" :label="t('models.apiKey')" :required="!isCliproxyApi && !isXaiOAuth">
+      <template v-if="isOpenCodeFree">
+        <p>{{ t('models.opencodeFreeHint') }}</p>
+        <p v-if="selectedPresetProvider?.catalog_status === 'unsupported'">{{ t('models.opencodeFreeUpgrade') }}</p>
+      </template>
+      <NFormItem v-if="!isCodex && !isNous && !isClaudeOAuth && !isMiniMaxOAuth && !isOpenCodeFree" :label="t('models.apiKey')" :required="!isCliproxyApi && !isXaiOAuth">
         <NInput
           v-model:value="formData.api_key"
           type="password"
@@ -584,7 +590,7 @@ function handleClose() {
     <template #footer>
       <div class="modal-footer">
         <NButton @click="handleClose">{{ t('common.cancel') }}</NButton>
-        <NButton type="primary" :loading="loading" @click="handleSave">
+        <NButton type="primary" :loading="loading" :disabled="isOpenCodeFree && selectedPresetProvider?.catalog_status === 'unsupported'" @click="handleSave">
           {{ t('common.add') }}
         </NButton>
       </div>

--- a/packages/client/src/i18n/locales/ar.ts
+++ b/packages/client/src/i18n/locales/ar.ts
@@ -1875,6 +1875,10 @@ export default {
 
   // Models
   models: {
+    opencodeFreeHint: "لا يلزم حساب أو مفتاح API. قد تخضع النماذج المجانية لحدود الاستخدام.",
+    opencodeFreeLoading: "جارٍ تحميل النماذج المجانية في الخلفية…",
+    opencodeFreeRetry: "فشل التحقق من المزود أو تحديث القائمة. ستتم إعادة المحاولة تلقائيًا مع الاحتفاظ بالنماذج المخزنة مؤقتًا.",
+    opencodeFreeUpgrade: "حدّث Hermes Agent لاستخدام OpenCode Free.",
     title: 'النماذج',
     searchPlaceholder: 'البحث في النماذج...',
     noResults: 'لا توجد نتائج',

--- a/packages/client/src/i18n/locales/de.ts
+++ b/packages/client/src/i18n/locales/de.ts
@@ -1429,6 +1429,10 @@ jobTriggered: 'Job ausgelost',
 
   // Models
   models: {
+    opencodeFreeHint: "Kein Konto oder API-Schlüssel erforderlich. Für kostenlose Modelle können Nutzungslimits gelten.",
+    opencodeFreeLoading: "Kostenlose Modelle werden im Hintergrund geladen…",
+    opencodeFreeRetry: "Anbieterprüfung oder Katalogaktualisierung fehlgeschlagen. Automatischer neuer Versuch; der Cache bleibt erhalten.",
+    opencodeFreeUpgrade: "Aktualisieren Sie Hermes Agent, um OpenCode Free zu nutzen.",
     title: 'Modelle',
     addProvider: 'Anbieter hinzufugen',
     noProviderPromptTitle: 'Kein Modellanbieter konfiguriert',

--- a/packages/client/src/i18n/locales/en.ts
+++ b/packages/client/src/i18n/locales/en.ts
@@ -1836,6 +1836,10 @@ export default {
 
   // Models
   models: {
+    opencodeFreeHint: "No account or API key required. Free models may be rate limited.",
+    opencodeFreeLoading: "Loading free models in the background…",
+    opencodeFreeRetry: "Free provider check or catalog refresh failed. Retrying automatically; cached models are retained.",
+    opencodeFreeUpgrade: "Update Hermes Agent to use OpenCode Free.",
     title: 'Models',
     searchPlaceholder: 'Search models...',
     noResults: 'No results',

--- a/packages/client/src/i18n/locales/es.ts
+++ b/packages/client/src/i18n/locales/es.ts
@@ -1429,6 +1429,10 @@ jobTriggered: 'Job ejecutado',
 
   // Models
   models: {
+    opencodeFreeHint: "No se necesita cuenta ni clave API. Los modelos gratuitos pueden tener límites de uso.",
+    opencodeFreeLoading: "Cargando modelos gratuitos en segundo plano…",
+    opencodeFreeRetry: "Falló la comprobación o actualización del catálogo. Se reintentará automáticamente y se conservará la caché.",
+    opencodeFreeUpgrade: "Actualiza Hermes Agent para usar OpenCode Free.",
     title: 'Modelos',
     addProvider: 'Anadir proveedor',
     noProviderPromptTitle: 'No hay proveedor de modelos configurado',

--- a/packages/client/src/i18n/locales/fr.ts
+++ b/packages/client/src/i18n/locales/fr.ts
@@ -1429,6 +1429,10 @@ jobTriggered: 'Job declenche',
 
   // Models
   models: {
+    opencodeFreeHint: "Aucun compte ni clé API requis. Les modèles gratuits peuvent être limités.",
+    opencodeFreeLoading: "Chargement des modèles gratuits en arrière-plan…",
+    opencodeFreeRetry: "Échec de la vérification ou de la mise à jour du catalogue. Nouvelle tentative automatique ; le cache est conservé.",
+    opencodeFreeUpgrade: "Mettez Hermes Agent à jour pour utiliser OpenCode Free.",
     title: 'Modeles',
     addProvider: 'Ajouter un fournisseur',
     noProviderPromptTitle: 'Aucun fournisseur de modeles configure',

--- a/packages/client/src/i18n/locales/ja.ts
+++ b/packages/client/src/i18n/locales/ja.ts
@@ -1429,6 +1429,10 @@ export default {
 
   // モデル
   models: {
+    opencodeFreeHint: "アカウントや API キーは不要です。無料モデルには利用制限があります。",
+    opencodeFreeLoading: "無料モデルをバックグラウンドで読み込み中…",
+    opencodeFreeRetry: "プロバイダーの確認または一覧の更新に失敗しました。キャッシュを保持して自動で再試行します。",
+    opencodeFreeUpgrade: "OpenCode Free を使うには Hermes Agent を更新してください。",
     title: 'モデル',
     addProvider: 'プロバイダーを追加',
     noProviderPromptTitle: 'モデルプロバイダーが設定されていません',

--- a/packages/client/src/i18n/locales/ko.ts
+++ b/packages/client/src/i18n/locales/ko.ts
@@ -1429,6 +1429,10 @@ export default {
 
   // 모델
   models: {
+    opencodeFreeHint: "계정이나 API 키가 필요하지 않습니다. 무료 모델은 사용량이 제한될 수 있습니다.",
+    opencodeFreeLoading: "백그라운드에서 무료 모델을 불러오는 중…",
+    opencodeFreeRetry: "제공자 확인 또는 목록 갱신에 실패했습니다. 캐시를 유지하고 자동으로 다시 시도합니다.",
+    opencodeFreeUpgrade: "OpenCode Free를 사용하려면 Hermes Agent를 업데이트하세요.",
     title: '모델',
     addProvider: 'Provider 추가',
     noProviderPromptTitle: '모델 Provider가 설정되지 않음',

--- a/packages/client/src/i18n/locales/pt.ts
+++ b/packages/client/src/i18n/locales/pt.ts
@@ -1429,6 +1429,10 @@ jobTriggered: 'Job acionado',
 
   // Models
   models: {
+    opencodeFreeHint: "Não é necessária conta nem chave API. Os modelos gratuitos podem ter limites de uso.",
+    opencodeFreeLoading: "Carregando modelos gratuitos em segundo plano…",
+    opencodeFreeRetry: "Falha na verificação ou atualização do catálogo. Nova tentativa automática; o cache será mantido.",
+    opencodeFreeUpgrade: "Atualize o Hermes Agent para usar o OpenCode Free.",
     title: 'Modelos',
     addProvider: 'Adicionar provedor',
     noProviderPromptTitle: 'Nenhum provedor de modelos configurado',

--- a/packages/client/src/i18n/locales/ru.ts
+++ b/packages/client/src/i18n/locales/ru.ts
@@ -1685,6 +1685,10 @@ export default {
 
 
   models: {
+    opencodeFreeHint: "Аккаунт и API-ключ не нужны. Для бесплатных моделей возможны ограничения запросов.",
+    opencodeFreeLoading: "Бесплатные модели загружаются в фоновом режиме…",
+    opencodeFreeRetry: "Ошибка проверки провайдера или обновления каталога. Повторим автоматически; кеш сохранён.",
+    opencodeFreeUpgrade: "Обновите Hermes Agent, чтобы использовать OpenCode Free.",
     title: 'Модели',
     searchPlaceholder: 'Поиск моделей...',
     noResults: 'Нет результатов',

--- a/packages/client/src/i18n/locales/zh-TW.ts
+++ b/packages/client/src/i18n/locales/zh-TW.ts
@@ -1870,6 +1870,10 @@ export default {
 
   // 模型
   models: {
+    opencodeFreeHint: "無需帳號或 API key，免費模型可能受到限流。",
+    opencodeFreeLoading: "正在背景載入免費模型…",
+    opencodeFreeRetry: "免費提供商檢查或目錄更新失敗，將自動重試並保留快取模型。",
+    opencodeFreeUpgrade: "請更新 Hermes Agent 以使用 OpenCode Free。",
     title: '模型',
     searchPlaceholder: '搜尋模型...',
     noResults: '無結果',

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -1882,6 +1882,10 @@ export default {
 
   // 模型
   models: {
+    opencodeFreeHint: "无需账号或 API key，免费模型可能受到限流。",
+    opencodeFreeLoading: "正在后台加载免费模型…",
+    opencodeFreeRetry: "免费提供商检测或目录刷新失败，将自动重试并保留缓存模型。",
+    opencodeFreeUpgrade: "请更新 Hermes Agent 以使用 OpenCode Free。",
     title: '模型',
     searchPlaceholder: '搜索模型...',
     noResults: '无结果',

--- a/packages/client/src/stores/hermes/models.ts
+++ b/packages/client/src/stores/hermes/models.ts
@@ -34,12 +34,13 @@ export const useModelsStore = defineStore('models', () => {
     ),
   )
 
-  async function fetchProviders() {
+  async function fetchProviders(options: { background?: boolean } = {}) {
     if (!hasApiKey()) return
-    loading.value = true
+    if (!options.background) loading.value = true
     try {
       const profile = useProfilesStore().activeProfileName || 'default'
       const res = await systemApi.fetchAvailableModelsForProfile(profile)
+      if (profile !== (useProfilesStore().activeProfileName || 'default')) return
       // MoA is a virtual Hermes runtime provider used by chat model pickers,
       // not a credential-backed provider that belongs in model settings or
       // auxiliary-model configuration.
@@ -50,7 +51,7 @@ export const useModelsStore = defineStore('models', () => {
     } catch (err) {
       console.error('Failed to fetch providers:', err)
     } finally {
-      loading.value = false
+      if (!options.background) loading.value = false
     }
   }
 

--- a/packages/client/src/utils/codingAgentProviders.ts
+++ b/packages/client/src/utils/codingAgentProviders.ts
@@ -27,3 +27,14 @@ export function usesServerManagedProviderAuth(
 ): boolean {
   return agentId === 'ekko-agent' && isAuthModelProvider(provider)
 }
+
+export function isKeylessModelProvider(provider?: string): boolean {
+  return provider === 'opencode-free'
+}
+
+export function openCodeFreeApiMode(model: string): 'chat_completions' | 'anthropic_messages' | 'codex_responses' {
+  const normalized = model.toLowerCase()
+  if (/^(claude-|qwen)/.test(normalized)) return 'anthropic_messages'
+  if (/^(gpt-|grok-|muse-spark)/.test(normalized)) return 'codex_responses'
+  return 'chat_completions'
+}

--- a/packages/client/src/views/hermes/ModelsView.vue
+++ b/packages/client/src/views/hermes/ModelsView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, watch } from 'vue'
+import { ref, onMounted, onUnmounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { NButton, NSpin, NTabPane, NTabs, useMessage } from 'naive-ui'
 import { useI18n } from 'vue-i18n'
@@ -57,6 +57,25 @@ async function loadProvidersForProfile() {
 onMounted(async () => {
   await loadProvidersForProfile()
 })
+
+let catalogPoll: ReturnType<typeof setInterval> | undefined
+let pollingCatalog = false
+onMounted(() => {
+  catalogPoll = setInterval(async () => {
+    const freeProvider = modelsStore.providers.find(group => group.provider === 'opencode-free')
+    if (pollingCatalog || !freeProvider || !['loading', 'error'].includes(freeProvider.catalog_status || '')) return
+    pollingCatalog = true
+    try {
+      await modelsStore.fetchProviders({ background: true })
+      if (modelsStore.providers.find(group => group.provider === 'opencode-free')?.catalog_status === 'ready') {
+        await appStore.reloadModels({ preserveSelection: true })
+      }
+    } finally {
+      pollingCatalog = false
+    }
+  }, 3000)
+})
+onUnmounted(() => { if (catalogPoll) clearInterval(catalogPoll) })
 
 function openCreateModal() {
   showModal.value = true

--- a/packages/server/src/bootstrap/http.ts
+++ b/packages/server/src/bootstrap/http.ts
@@ -28,6 +28,7 @@ import { HermesSkillInjector } from '../modules/hermes/services/skills/injector'
 import { injectBundledMcpServer } from '../modules/hermes/services/mcp/studio-autoinject'
 import { ensureProfileGatewaysRunning } from '../modules/hermes/services/gateway/autostart'
 import { refreshConfiguredProviderModelCatalogsInBackground } from '../modules/hermes/services/providers/model-catalog-cache'
+import { initializeOpenCodeFreeInBackground } from '../modules/hermes/services/providers/opencode-free'
 import {
   scanLanDevices,
   selectLanIPv4Address,
@@ -663,6 +664,7 @@ export async function bootstrap() {
     close: stopLanDiscoveryResponder,
   })
   refreshConfiguredProviderModelCatalogsInBackground('bootstrap')
+  initializeOpenCodeFreeInBackground()
 
   if (isDesktopRuntime()) {
     await startRuntimeServicesAfterListen(hermesAgentAvailable)

--- a/packages/server/src/modules/coding-agents/protocol/gateway.ts
+++ b/packages/server/src/modules/coding-agents/protocol/gateway.ts
@@ -46,7 +46,7 @@ export class AgentRunGateway {
     return fetch(request.url, {
       method: 'POST',
       headers: {
-        Authorization: `Bearer ${request.apiKey}`,
+        ...(request.apiKey ? { Authorization: `Bearer ${request.apiKey}` } : {}),
         'Content-Type': 'application/json',
         ...request.headers,
       },

--- a/packages/server/src/modules/coding-agents/protocol/target-registry.ts
+++ b/packages/server/src/modules/coding-agents/protocol/target-registry.ts
@@ -1,3 +1,4 @@
+import { OPENCODE_FREE_PROVIDER, openCodeFreeRuntime } from '../../studio/contracts/opencode-free'
 import { randomBytes } from 'crypto'
 import type { AgentApiMode } from './types'
 
@@ -40,6 +41,7 @@ export class AgentTargetRegistry<T extends AgentTargetInput> {
       model: input.model.trim(),
       baseUrl: input.baseUrl.trim().replace(/\/+$/, ''),
       apiMode: input.apiMode || 'chat_completions',
+      ...(input.provider.trim() === OPENCODE_FREE_PROVIDER ? openCodeFreeRuntime(input.model.trim()) : {}),
     } as NormalizedAgentTargetInput<T>
     const key = JSON.stringify(this.keyParts(normalized))
     const existing = this.targets.get(key)

--- a/packages/server/src/modules/coding-agents/services/claude-code/proxy.ts
+++ b/packages/server/src/modules/coding-agents/services/claude-code/proxy.ts
@@ -299,7 +299,7 @@ async function callAnthropicMessages(target: ClaudeCodeProxyTarget, body: any): 
     url: anthropicMessagesUrl(target),
     apiKey: target.apiKey,
     headers: {
-      'x-api-key': target.apiKey,
+      ...(target.apiKey ? { 'x-api-key': target.apiKey } : {}),
       'anthropic-version': '2023-06-01',
     },
     body: anthropicRequestBody(nextBody, target),
@@ -387,7 +387,7 @@ async function anthropicMessagesSseStream(target: ClaudeCodeProxyTarget, body: a
     url: anthropicMessagesUrl(target),
     apiKey: target.apiKey,
     headers: {
-      'x-api-key': target.apiKey,
+      ...(target.apiKey ? { 'x-api-key': target.apiKey } : {}),
       'anthropic-version': '2023-06-01',
     },
     body: anthropicRequestBody(nextBody, target),

--- a/packages/server/src/modules/coding-agents/services/codex/proxy.ts
+++ b/packages/server/src/modules/coding-agents/services/codex/proxy.ts
@@ -171,7 +171,7 @@ async function callAnthropicMessages(target: CodexProxyTarget, body: any): Promi
     url: anthropicMessagesUrl(target),
     apiKey: target.apiKey,
     headers: {
-      'x-api-key': target.apiKey,
+      ...(target.apiKey ? { 'x-api-key': target.apiKey } : {}),
       'anthropic-version': '2023-06-01',
     },
     body: anthropicBody,
@@ -286,7 +286,7 @@ async function anthropicMessagesToResponsesSseStream(target: CodexProxyTarget, b
     url: anthropicMessagesUrl(target),
     apiKey: target.apiKey,
     headers: {
-      'x-api-key': target.apiKey,
+      ...(target.apiKey ? { 'x-api-key': target.apiKey } : {}),
       'anthropic-version': '2023-06-01',
     },
     body: anthropicBody,

--- a/packages/server/src/modules/coding-agents/services/index.ts
+++ b/packages/server/src/modules/coding-agents/services/index.ts
@@ -1,3 +1,4 @@
+import { OPENCODE_FREE_PROVIDER, openCodeFreeRuntime } from '../../studio/contracts/opencode-free'
 import { execFile } from 'child_process'
 import { createCipheriv, createDecipheriv, createHash, randomBytes, randomUUID } from 'crypto'
 import { existsSync, readdirSync, realpathSync } from 'fs'
@@ -202,10 +203,10 @@ async function decryptPiProxyApiKey(
   value: unknown,
   input: Record<string, unknown>,
   token: string,
-): Promise<string> {
+): Promise<string | null> {
   const encrypted = value as Partial<EncryptedPiProxyApiKey> | null
-  if ((encrypted?.v !== 1 && encrypted?.v !== 2) || encrypted.algorithm !== 'aes-256-gcm') return ''
-  if (!encrypted.iv || !encrypted.tag || !encrypted.ciphertext) return ''
+  if ((encrypted?.v !== 1 && encrypted?.v !== 2) || encrypted.algorithm !== 'aes-256-gcm') return null
+  if (!encrypted.iv || !encrypted.tag || typeof encrypted.ciphertext !== 'string') return null
   const key = await readOrCreatePiProxyTargetKey()
   const decipher = createDecipheriv('aes-256-gcm', key, Buffer.from(encrypted.iv, 'base64'))
   decipher.setAAD(encrypted.v === 1 ? PI_PROXY_TARGET_LEGACY_AAD : piProxyTargetAad(input, token))
@@ -742,6 +743,9 @@ async function resolveStoredProviderLaunchInput(
     ? normalizeStoredLaunchApiMode(existingSession?.api_mode)
     : undefined
   let apiMode = input.apiMode || storedApiMode
+  if (provider === OPENCODE_FREE_PROVIDER) {
+    return { ...input, profile, provider, model, workspace, ...openCodeFreeRuntime(model) }
+  }
   let canonicalProvider = provider
   const ignoredStaleProviderRuntime = belongsToDifferentBuiltinProvider(provider, baseUrl)
   if (ignoredStaleProviderRuntime) {
@@ -1861,7 +1865,7 @@ export async function restorePersistedPiProxyTargets(): Promise<number> {
           sessionId: chatSessionId,
         }, null)
         const apiKey = String(resolved.apiKey || '').trim()
-        if (!apiKey) continue
+        if (!apiKey && provider !== OPENCODE_FREE_PROVIDER) continue
         content = await serializePiProxyTarget({
           profile,
           provider,
@@ -1884,12 +1888,14 @@ export async function restorePersistedPiProxyTargets(): Promise<number> {
       const legacyApiKey = String(input?.apiKey || '').trim()
       if (!input || typeof input !== 'object' || !token) continue
       const encryptedVersion = Number(persisted?.apiKeyEncrypted?.v || 0)
-      const apiKey = legacyApiKey || String(await decryptPiProxyApiKey(persisted?.apiKeyEncrypted, input, token) || '').trim()
+      const decrypted = legacyApiKey || await decryptPiProxyApiKey(persisted?.apiKeyEncrypted, input, token)
+      if (decrypted === null) continue
+      const apiKey = decrypted.trim()
       if (!String(input.profile || '').trim()
         || !String(input.provider || '').trim()
         || !String(input.model || '').trim()
         || !String(input.baseUrl || '').trim()
-        || !apiKey) continue
+        || (!apiKey && input.provider !== OPENCODE_FREE_PROVIDER)) continue
       const restoredInput = { ...input, apiKey }
       delete restoredInput.apiKeyEncrypted
       restoreCodexProxyTarget(restoredInput, token)
@@ -1990,7 +1996,7 @@ export async function restorePersistedCodexProxyTargets(): Promise<number> {
         sessionId: chatSessionId,
       }, null)
       const apiKey = String(resolved.apiKey || '').trim()
-      if (!profile || !provider || !model || !baseUrl || !apiKey) continue
+      if (!profile || !provider || !model || !baseUrl || (!apiKey && provider !== OPENCODE_FREE_PROVIDER)) continue
       restoreCodexProxyTarget({
         profile,
         provider,
@@ -3142,7 +3148,8 @@ export async function prepareCodingAgentLaunch(id: string, input: CodingAgentLau
   const provider = normalizeProviderIdentity(input.provider)
   const scope = normalizeConfigScope({ profile: input.profile, provider })
   const model = String(input.model || '').trim()
-  const apiKey = String(input.apiKey || '').trim()
+  const freeRuntime = provider === OPENCODE_FREE_PROVIDER ? openCodeFreeRuntime(model) : undefined
+  const apiKey = freeRuntime ? '' : String(input.apiKey || '').trim()
   assertScopedCodingAgentProviderAllowed(mode, provider)
   if (!model) {
     const err = new Error('Model is required')
@@ -3150,9 +3157,9 @@ export async function prepareCodingAgentLaunch(id: string, input: CodingAgentLau
     throw err
   }
 
-  const baseUrl = String(input.baseUrl || '').trim()
+  const baseUrl = freeRuntime?.baseUrl || String(input.baseUrl || '').trim()
   const preset = PROVIDER_PRESETS.find(item => item.value === provider)
-  const apiMode = normalizeLaunchApiMode(input.apiMode, preset?.api_mode || 'chat_completions')
+  const apiMode = freeRuntime?.apiMode || normalizeLaunchApiMode(input.apiMode, preset?.api_mode || 'chat_completions')
   const reasoningEffort = String(input.reasoningEffort || '').trim()
   const groupSystemPrompt = String(input.groupSystemPrompt || '').trim()
   const scopedSystemPrompt = tool.id === 'pi' && groupSystemPrompt ? getSystemPrompt() : groupSystemPrompt || getSystemPrompt()
@@ -3188,7 +3195,7 @@ export async function prepareCodingAgentLaunch(id: string, input: CodingAgentLau
 
   if (tool.id === 'claude-code') {
     const contextWindow = getModelContextLength({ profile: scope.profile, provider, model })
-    const proxyTarget = baseUrl && apiKey
+    const proxyTarget = baseUrl && (apiKey || freeRuntime)
       ? registerClaudeCodeProxyTarget({
           provider,
           model,
@@ -3258,7 +3265,7 @@ export async function prepareCodingAgentLaunch(id: string, input: CodingAgentLau
       ;(err as any).status = 400
       throw err
     }
-    const proxyTarget = baseUrl && apiKey
+    const proxyTarget = baseUrl && (apiKey || freeRuntime)
       ? registerCodexProxyTarget({
           profile: scope.profile,
           provider,
@@ -3350,7 +3357,7 @@ export async function prepareCodingAgentLaunch(id: string, input: CodingAgentLau
     // Claude Code and Codex homes. Each conversation still gets an isolated
     // runs/<hash> directory containing its provider credentials and sessions.
     await ensurePiScopedBaseConfigFiles(scope)
-    const proxyTarget = baseUrl && apiKey
+    const proxyTarget = baseUrl && (apiKey || freeRuntime)
       ? registerCodexProxyTarget({
           profile: scope.profile,
           provider,
@@ -3428,7 +3435,7 @@ export async function prepareCodingAgentLaunch(id: string, input: CodingAgentLau
         : []),
     ]
   } else if (tool.id === 'grok') {
-    const proxyTarget = baseUrl && apiKey
+    const proxyTarget = baseUrl && (apiKey || freeRuntime)
       ? registerCodexProxyTarget({
           profile: scope.profile,
           provider,
@@ -3483,7 +3490,7 @@ export async function prepareCodingAgentLaunch(id: string, input: CodingAgentLau
       ...(reasoningEffort ? ['--reasoning-effort', reasoningEffort] : []),
     ]
   } else {
-    const proxyTarget = baseUrl && apiKey
+    const proxyTarget = baseUrl && (apiKey || freeRuntime)
       ? registerCodexProxyTarget({
           profile: scope.profile,
           provider,
@@ -3592,7 +3599,7 @@ export async function startCodingAgentRun(
   const requestedMode = resolvedInput.mode === 'global' ? 'global' : 'scoped'
   const requestedProvider = String(resolvedInput.provider || '').trim().toLowerCase()
   assertScopedCodingAgentProviderAllowed(requestedMode, requestedProvider)
-  if (requestedMode !== 'global' && (!String(resolvedInput.baseUrl || '').trim() || !String(resolvedInput.apiKey || '').trim())) {
+  if (requestedMode !== 'global' && (!String(resolvedInput.baseUrl || '').trim() || (!String(resolvedInput.apiKey || '').trim() && requestedProvider !== OPENCODE_FREE_PROVIDER))) {
     const err = new Error('Coding agent provider credentials are missing. Re-select the provider/model or update the provider API key before continuing this session.')
     ;(err as any).status = 400
     throw err

--- a/packages/server/src/modules/ekko/services/provider-runtime.ts
+++ b/packages/server/src/modules/ekko/services/provider-runtime.ts
@@ -1,3 +1,4 @@
+import { OPENCODE_FREE_PROVIDER, openCodeFreeRuntime } from '../../studio/contracts/opencode-free'
 import { join } from 'path'
 import { getCompatibleCustomProviders } from '../../studio/contracts/provider-compat'
 import { PROVIDER_PRESETS } from '../../studio/contracts/providers'
@@ -31,6 +32,10 @@ export async function resolveEkkoProviderRuntimeConfig(input: {
 }): Promise<EkkoProviderRuntimeConfig> {
   const provider = String(input.provider || '').trim()
   if (!provider) throw new Error('Ekko model provider is required')
+
+  if (provider === OPENCODE_FREE_PROVIDER) {
+    return { provider, ...openCodeFreeRuntime(String(input.model || '').trim()) }
+  }
 
   const profile = String(input.profile || '').trim() || 'default'
   const providerKey = providerKeyWithoutCustomPrefix(provider.toLowerCase())

--- a/packages/server/src/modules/hermes/controllers/models.ts
+++ b/packages/server/src/modules/hermes/controllers/models.ts
@@ -19,12 +19,14 @@ import { readProviderModelCatalogCache,
 } from '../services/providers/model-catalog-cache'
 import { providerEditorCapabilities, type ProviderEditableField } from '../services/providers/provider-editor'
 import { providerModelRefreshCapabilities } from '../services/providers/provider-model-refresh'
+import { getOpenCodeFreeStatus, type OpenCodeFreeStatus } from '../services/providers/opencode-free'
+import { OPENCODE_FREE_PROVIDER, OPENCODE_FREE_BASE_URL, isOpenCodeFreeModel } from '../../studio/contracts/opencode-free'
 
 const PROVIDER_MODEL_CATALOG = buildProviderModelMap()
 
 type ModelMeta = { preview?: boolean; disabled?: boolean; alias?: string }
 type ProviderApiMode = 'chat_completions' | 'codex_responses' | 'anthropic_messages' | 'bedrock_converse' | 'codex_app_server'
-type AvailableGroup = { provider: string; label: string; base_url: string; models: string[]; api_key: string; api_mode?: ProviderApiMode; builtin?: boolean; model_meta?: Record<string, ModelMeta>; available_models?: string[]; base_url_env?: string; provider_source?: 'custom_providers' | 'providers'; provider_key?: string; provider_editable?: boolean; editable_fields?: ProviderEditableField[]; model_refreshable?: boolean; model_refresh_reason?: string; model_restore_available?: boolean }
+type AvailableGroup = { catalog_status?: OpenCodeFreeStatus; provider: string; label: string; base_url: string; models: string[]; api_key: string; api_mode?: ProviderApiMode; builtin?: boolean; model_meta?: Record<string, ModelMeta>; available_models?: string[]; base_url_env?: string; provider_source?: 'custom_providers' | 'providers'; provider_key?: string; provider_editable?: boolean; editable_fields?: ProviderEditableField[]; model_refreshable?: boolean; model_refresh_reason?: string; model_restore_available?: boolean }
 type ModelVisibility = Record<string, ModelVisibilityRule>
 type CustomModels = Record<string, string[]>
 
@@ -110,6 +112,7 @@ function normalizeCustomModels(input: unknown): CustomModels {
 
 function applyCustomModels(groups: AvailableGroup[], customModels: CustomModels): AvailableGroup[] {
   return groups.map(group => {
+    if (group.provider === OPENCODE_FREE_PROVIDER) return group
     const extra = customModels[group.provider] || []
     if (!extra.length) return group
     const models = [...new Set([...group.models, ...extra])]
@@ -126,7 +129,10 @@ function providerPresetToGroup(p: any, models?: string[]): AvailableGroup {
     provider: p.value,
     label: p.label,
     base_url: p.base_url,
-    models: models || p.models,
+    models: p.value === OPENCODE_FREE_PROVIDER
+      ? getOpenCodeFreeStatus() === 'unsupported' ? [] : (models || p.models).filter(isOpenCodeFreeModel)
+      : models || p.models,
+    ...(p.value === OPENCODE_FREE_PROVIDER ? { catalog_status: getOpenCodeFreeStatus() } : {}),
     api_key: '',
     ...(apiMode ? { api_mode: apiMode } : {}),
     ...(p.builtin ? { builtin: true } : {}),
@@ -174,7 +180,7 @@ function applyModelVisibility(groups: AvailableGroup[], visibility: ModelVisibil
         models: filterModelsForProvider(group.provider, availableModels, visibility),
       }
     })
-    .filter(group => group.models.length > 0)
+    .filter(group => group.models.length > 0 || group.provider === OPENCODE_FREE_PROVIDER)
 }
 
 function resolveVisibleDefault(defaultModel: string, defaultProvider: string, groups: AvailableGroup[]) {
@@ -457,6 +463,16 @@ async function buildAvailableForProfile(
   }
 
   for (const [providerKey, envMapping] of Object.entries(PROVIDER_ENV_MAP)) {
+    if (providerKey === OPENCODE_FREE_PROVIDER) {
+      const freeStatus = getOpenCodeFreeStatus()
+      const models = freeStatus === 'unsupported' ? [] : resolveProviderCatalogModels(
+        modelCatalogCache, providerKey, OPENCODE_FREE_BASE_URL, [],
+      ).filter(isOpenCodeFreeModel)
+      addGroup(providerKey, 'OpenCode Free', OPENCODE_FREE_BASE_URL, models, '', true)
+      const group = groups.find(item => item.provider === providerKey)
+      if (group) group.catalog_status = freeStatus
+      continue
+    }
     const oauthAuthorized = providerSupportsStoredOAuth(providerKey) ? isOAuthAuthorized(providerKey) : false
     if (envMapping.api_key_env && !envHasValue(envMapping.api_key_env) && !oauthAuthorized) continue
     if (!envMapping.api_key_env) {
@@ -923,10 +939,10 @@ export async function removeCustomModel(ctx: any) {
 export async function fetchProviderModelList(ctx: any) {
   try {
     const body = ctx.request.body as { base_url?: string; api_key?: string; freeOnly?: boolean; provider?: string; label?: string; update_cache?: boolean }
-    const baseUrl = String(body?.base_url || '').trim()
+    const provider = String(body?.provider || '').trim()
+    const baseUrl = provider === OPENCODE_FREE_PROVIDER ? OPENCODE_FREE_BASE_URL : String(body?.base_url || '').trim()
     const apiKey = String(body?.api_key || '').trim()
     const freeOnly = body?.freeOnly === true
-    const provider = String(body?.provider || '').trim()
     const label = String(body?.label || provider).trim()
 
     if (!baseUrl) {
@@ -952,7 +968,7 @@ export async function fetchProviderModelList(ctx: any) {
     const base = baseUrl.replace(/\/+$/, '')
     const modelsUrl = /\/v\d+\/?$/.test(base) ? `${base}/models` : `${base}/v1/models`
     const headers: Record<string, string> = {}
-    if (apiKey) headers.Authorization = `Bearer ${apiKey}`
+    if (apiKey && provider !== OPENCODE_FREE_PROVIDER) headers.Authorization = `Bearer ${apiKey}`
 
     const res = await fetch(modelsUrl, {
       headers,
@@ -975,7 +991,13 @@ export async function fetchProviderModelList(ctx: any) {
       .map(m => String(m?.id || '').trim())
       .filter(Boolean)
     if (freeOnly) models = models.filter(m => m.endsWith(':free'))
+    if (provider === OPENCODE_FREE_PROVIDER) models = models.filter(isOpenCodeFreeModel)
     const uniqueModels = Array.from(new Set(models)).sort()
+    if (provider === OPENCODE_FREE_PROVIDER && !uniqueModels.length) {
+      ctx.status = 502
+      ctx.body = { error: 'OpenCode returned no free models; the cached catalog was retained' }
+      return
+    }
     if (body?.update_cache === true && provider) {
       await writeProviderModelCatalogEntry({
         provider,
@@ -1067,6 +1089,11 @@ export async function setConfigModel(ctx: any) {
   if (!defaultModel) {
     ctx.status = 400
     ctx.body = { error: 'Missing default model' }
+    return
+  }
+  if (reqProvider === OPENCODE_FREE_PROVIDER && !isOpenCodeFreeModel(defaultModel)) {
+    ctx.status = 400
+    ctx.body = { error: 'Select an OpenCode Free model' }
     return
   }
   try {

--- a/packages/server/src/modules/hermes/controllers/providers.ts
+++ b/packages/server/src/modules/hermes/controllers/providers.ts
@@ -17,9 +17,10 @@ import {
 import { refreshProviderModels, restoreProviderModels } from '../services/providers/provider-model-refresh'
 import { appendProviderAuditEvent } from '../../studio/public/provider-audit'
 import { invalidateProviderRuntime } from '../../studio/public/provider-runtime'
+import { OPENCODE_FREE_PROVIDER, OPENCODE_FREE_BASE_URL, isOpenCodeFreeModel } from '../../studio/contracts/opencode-free'
 
-const OPTIONAL_API_KEY_PROVIDERS = new Set(['cliproxyapi', 'xai-oauth', 'openai-codex', 'claude-oauth', 'minimax-oauth'])
-const DIRECT_CONFIG_PROVIDERS = new Set(['xai-oauth', 'openai-codex', 'claude-oauth', 'minimax-oauth'])
+const OPTIONAL_API_KEY_PROVIDERS = new Set(['cliproxyapi', 'xai-oauth', 'openai-codex', 'claude-oauth', 'minimax-oauth', OPENCODE_FREE_PROVIDER])
+const DIRECT_CONFIG_PROVIDERS = new Set(['xai-oauth', 'openai-codex', 'claude-oauth', 'minimax-oauth', OPENCODE_FREE_PROVIDER])
 type ProviderApiMode = 'chat_completions' | 'codex_responses' | 'anthropic_messages' | 'bedrock_converse' | 'codex_app_server'
 
 function requestedProfile(ctx: any): string {
@@ -294,13 +295,16 @@ export async function create(ctx: any) {
   const normalizedName = String(name || '').trim()
   const poolKey = providerKey || `custom:${normalizedName.toLowerCase().replace(/ /g, '-')}`
   const isBuiltin = poolKey in PROVIDER_ENV_MAP
-  const effectiveBaseUrl = isBuiltin ? builtinBaseUrl(poolKey, base_url) : base_url
+  const effectiveBaseUrl = poolKey === OPENCODE_FREE_PROVIDER ? OPENCODE_FREE_BASE_URL : isBuiltin ? builtinBaseUrl(poolKey, base_url) : base_url
   const customApiMode = normalizeApiMode(api_mode)
   if (!normalizedName || !effectiveBaseUrl || !model) {
     ctx.status = 400; ctx.body = { error: 'Missing name, base_url, or model' }; return
   }
   if (!api_key && !OPTIONAL_API_KEY_PROVIDERS.has(String(providerKey || ''))) {
     ctx.status = 400; ctx.body = { error: 'Missing API key' }; return
+  }
+  if (poolKey === OPENCODE_FREE_PROVIDER && !isOpenCodeFreeModel(model)) {
+    ctx.status = 400; ctx.body = { error: 'Select an OpenCode Free model' }; return
   }
   try {
     const profile = requestedProfile(ctx)

--- a/packages/server/src/modules/hermes/services/profiles/config.ts
+++ b/packages/server/src/modules/hermes/services/profiles/config.ts
@@ -35,6 +35,7 @@ export const PROVIDER_ENV_MAP: Record<string, { api_key_env: string; base_url_en
   'ai-gateway': { api_key_env: 'AI_GATEWAY_API_KEY', base_url_env: 'AI_GATEWAY_BASE_URL' },
   cliproxyapi: { api_key_env: '', base_url_env: '' },
   'opencode-zen': { api_key_env: 'OPENCODE_ZEN_API_KEY', base_url_env: 'OPENCODE_ZEN_BASE_URL' },
+  'opencode-free': { api_key_env: '', base_url_env: '' },
   'opencode-go': { api_key_env: 'OPENCODE_GO_API_KEY', base_url_env: 'OPENCODE_GO_BASE_URL' },
   huggingface: { api_key_env: 'HF_TOKEN', base_url_env: 'HF_BASE_URL' },
   nvidia: { api_key_env: 'NVIDIA_API_KEY', base_url_env: 'NVIDIA_BASE_URL' },

--- a/packages/server/src/modules/hermes/services/providers/model-catalog-cache.ts
+++ b/packages/server/src/modules/hermes/services/providers/model-catalog-cache.ts
@@ -5,7 +5,8 @@ import { PROVIDER_PRESETS } from '../../../studio/contracts/providers'
 import { readAppConfig } from '../../../studio/public/app-config'
 import { config } from '../../../studio/public/config'
 import { logger } from '../../../studio/public/logging'
-import { fetchProviderModels } from '../../../studio/public/provider-catalog'
+import { fetchProviderModels, fetchOpenCodeFreeModels } from '../../../studio/public/provider-catalog'
+import { OPENCODE_FREE_PROVIDER, OPENCODE_FREE_BASE_URL } from '../../../studio/contracts/opencode-free'
 import { PROVIDER_ENV_MAP, readConfigYamlForProfile } from '../../../studio/public/profile-config'
 import { safeFileStore } from '../../../studio/public/safe-file-store'
 import { fetchCopilotModelsWithOAuthToken, resolveCopilotOAuthToken } from './copilot-models'
@@ -156,7 +157,7 @@ export function resolveProviderCatalogEntry(
   options: { freeOnly?: boolean; profile?: string } = {},
 ): ProviderModelCatalogEntry | undefined {
   const freeOnly = options.freeOnly === true
-  const profile = String(options.profile || '').trim()
+  const profile = provider === OPENCODE_FREE_PROVIDER ? '' : String(options.profile || '').trim()
   if (profile) {
     const scoped = cache.providers[providerModelCatalogKey(provider, baseUrl, freeOnly, profile)]
     if (scoped) return scoped
@@ -198,7 +199,7 @@ export async function writeProviderModelCatalogEntry(input: {
   const provider = input.provider.trim()
   const baseUrl = normalizeCatalogBaseUrl(input.base_url)
   const models = uniqueModels(input.models)
-  const profile = String(input.profile || '').trim()
+  const profile = provider === OPENCODE_FREE_PROVIDER ? '' : String(input.profile || '').trim()
   const key = providerModelCatalogKey(provider, baseUrl, input.free_only === true, profile || undefined)
   const now = new Date().toISOString()
   const entry: ProviderModelCatalogEntry = {
@@ -405,6 +406,7 @@ export async function fetchProviderCatalogRefreshTargetModels(
   target: ProviderCatalogRefreshTarget,
 ): Promise<string[]> {
   if (target.skip_live_fetch) return []
+  if (target.provider === OPENCODE_FREE_PROVIDER) return fetchOpenCodeFreeModels()
   if (target.provider === 'openai-codex') return fetchCodexOAuthModels(target.api_key)
   if (target.provider === 'copilot') {
     try {
@@ -588,6 +590,10 @@ export async function resolveProviderCatalogRefreshTarget(
   profile: string,
   provider: string,
 ): Promise<ProviderCatalogRefreshTarget | null> {
+  if (provider === OPENCODE_FREE_PROVIDER) {
+    return { provider, label: 'OpenCode Free', base_url: OPENCODE_FREE_BASE_URL,
+      api_key: '', fallback_models: [], profile, credential_kind: 'none' }
+  }
   const candidates = await collectRefreshCandidates([profile])
   return candidates.find(candidate => candidate.provider === provider) || null
 }

--- a/packages/server/src/modules/hermes/services/providers/opencode-free.ts
+++ b/packages/server/src/modules/hermes/services/providers/opencode-free.ts
@@ -1,0 +1,78 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { isAbsolute } from 'node:path'
+import { resolveHermesInstallationEnvironment } from '../runtime/installation'
+import { resolveHermesBin } from '../runtime/process'
+import { getProfileDir } from '../profiles/profile'
+import { logger } from '../../../studio/public/logging'
+import { fetchOpenCodeFreeModels } from '../../../studio/public/provider-catalog'
+import { OPENCODE_FREE_PROVIDER, OPENCODE_FREE_BASE_URL } from '../../../studio/contracts/opencode-free'
+import { writeProviderModelCatalogEntry } from './model-catalog-cache'
+
+const execFileAsync = promisify(execFile)
+const PROBE = "from hermes_cli.auth import PROVIDER_REGISTRY; print('supported' if 'opencode-free' in PROVIDER_REGISTRY else 'unsupported')"
+const REFRESH_MS = 5 * 60_000
+const RETRY_MS = 60_000
+
+export type OpenCodeFreeStatus = 'loading' | 'ready' | 'error' | 'unsupported'
+let status: OpenCodeFreeStatus = 'loading'
+let inflight: Promise<void> | undefined
+let retryTimer: ReturnType<typeof setTimeout> | undefined
+
+export function getOpenCodeFreeStatus(): OpenCodeFreeStatus {
+  return status
+}
+
+async function probeSupport(): Promise<boolean> {
+  const hermesHome = getProfileDir('default')
+  let bin = resolveHermesBin()
+  if (!process.env.HERMES_AGENT_BRIDGE_PYTHON && !isAbsolute(bin) && !bin.includes('/') && !bin.includes('\\')) {
+    const result = await execFileAsync(process.platform === 'win32' ? 'where.exe' : 'which', [bin], {
+      timeout: 2000, windowsHide: true, maxBuffer: 64 * 1024,
+    })
+    bin = result.stdout.trim().split(/\r?\n/)[0] || bin
+  }
+  const installation = resolveHermesInstallationEnvironment(bin, hermesHome)
+  const python = process.env.HERMES_AGENT_BRIDGE_PYTHON || installation.python
+  if (!python) throw new Error('Hermes Python could not be resolved')
+  const { stdout } = await execFileAsync(python, ['-c', PROBE], {
+    cwd: process.env.HERMES_AGENT_ROOT || installation.agentRoot,
+    env: { ...process.env, HERMES_HOME: hermesHome },
+    timeout: 5000,
+    maxBuffer: 64 * 1024,
+    windowsHide: true,
+  })
+  return stdout.trim().split(/\r?\n/).at(-1) === 'supported'
+}
+
+/** No caller awaits startup network IO. Retries are bounded and single-flight. */
+export function initializeOpenCodeFreeInBackground(): void {
+  if (inflight || retryTimer) return
+  inflight = Promise.resolve().then(async () => {
+    const [support, catalog] = await Promise.allSettled([probeSupport(), fetchOpenCodeFreeModels()])
+    if (catalog.status === 'fulfilled' && catalog.value.length) {
+      await writeProviderModelCatalogEntry({
+        provider: OPENCODE_FREE_PROVIDER,
+        label: 'OpenCode Free',
+        base_url: OPENCODE_FREE_BASE_URL,
+        models: catalog.value,
+        source: 'live',
+      })
+    }
+    status = support.status === 'fulfilled' && !support.value
+      ? 'unsupported'
+      : support.status === 'fulfilled' && catalog.status === 'fulfilled' && catalog.value.length
+        ? 'ready'
+        : 'error'
+  }).catch(error => {
+    status = 'error'
+    logger.warn(error, '[opencode-free] background initialization failed')
+  }).finally(() => {
+    inflight = undefined
+    retryTimer = setTimeout(() => {
+      retryTimer = undefined
+      initializeOpenCodeFreeInBackground()
+    }, status === 'ready' ? REFRESH_MS : RETRY_MS)
+    retryTimer.unref()
+  })
+}

--- a/packages/server/src/modules/hermes/services/providers/provider-model-refresh.ts
+++ b/packages/server/src/modules/hermes/services/providers/provider-model-refresh.ts
@@ -16,6 +16,7 @@ import {
 } from './provider-editor'
 import { getCompatibleCustomProviders } from '../../../studio/contracts/provider-compat'
 import { PROVIDER_PRESETS } from '../../../studio/contracts/providers'
+import { OPENCODE_FREE_PROVIDER } from '../../../studio/contracts/opencode-free'
 import { readConfigYamlForProfile } from '../../../studio/public/profile-config'
 
 export interface ProviderModelRefreshDiff {
@@ -111,6 +112,7 @@ async function protectedModels(profile: string, providerId: string, preferredMod
 }
 
 async function preferredModelForProvider(profile: string, providerId: string): Promise<string> {
+  if (providerId === OPENCODE_FREE_PROVIDER) return ''
   try {
     return (await getProviderEditorDetail(profile, providerId)).preferred_model
   } catch (error) {
@@ -251,6 +253,7 @@ async function fetchFullRemoteModels(
   target: ProviderCatalogRefreshTarget,
   apiMode: ProviderApiMode | undefined,
 ): Promise<string[]> {
+  if (target.provider === OPENCODE_FREE_PROVIDER) return fetchProviderCatalogRefreshTargetModels(target)
   if (target.credential_kind === 'api_key' || target.credential_kind === 'none') {
     return fetchProviderCatalogForTest(target.base_url, target.api_key, apiMode)
   }

--- a/packages/server/src/modules/studio/contracts/opencode-free.ts
+++ b/packages/server/src/modules/studio/contracts/opencode-free.ts
@@ -1,0 +1,25 @@
+export const OPENCODE_FREE_PROVIDER = 'opencode-free'
+export const OPENCODE_FREE_BASE_URL = 'https://opencode.ai/zen/v1'
+
+// Match Hermes' anonymous catalog, excluding the Go-only twin despite its suffix.
+export function isOpenCodeFreeModel(model: string): boolean {
+  return model.endsWith('-free') && model !== 'ox-alpha-free'
+}
+
+/** OpenCode Free shares Zen's per-model API surfaces, as resolved by Hermes. */
+export function openCodeFreeRuntime(model: string): {
+  baseUrl: string
+  apiKey: string
+  apiMode: 'chat_completions' | 'anthropic_messages' | 'codex_responses'
+} {
+  if (!isOpenCodeFreeModel(model)) {
+    throw Object.assign(new Error('OpenCode Free requires a free model'), { status: 400 })
+  }
+  const normalized = model.toLowerCase()
+  const apiMode = /^(claude-|qwen)/.test(normalized)
+    ? 'anthropic_messages'
+    : /^(gpt-|grok-|muse-spark)/.test(normalized)
+      ? 'codex_responses'
+      : 'chat_completions'
+  return { baseUrl: OPENCODE_FREE_BASE_URL, apiKey: '', apiMode }
+}

--- a/packages/server/src/modules/studio/contracts/providers.ts
+++ b/packages/server/src/modules/studio/contracts/providers.ts
@@ -3,6 +3,8 @@
  * Synced from hermes-agent hermes_cli/models.py _PROVIDER_MODELS.
  */
 
+import { OPENCODE_FREE_PROVIDER, OPENCODE_FREE_BASE_URL } from './opencode-free'
+
 export interface ProviderPreset {
   label: string
   value: string
@@ -409,6 +411,13 @@ export const PROVIDER_PRESETS: ProviderPreset[] = [
       'gemini-3.1-pro-preview',
       'gemini-2.5-pro',
     ],
+  },
+  {
+    label: 'OpenCode Free',
+    value: OPENCODE_FREE_PROVIDER,
+    builtin: true,
+    base_url: OPENCODE_FREE_BASE_URL,
+    models: [],
   },
   {
     label: 'OpenCode Zen',

--- a/packages/server/src/modules/studio/public/provider-catalog.ts
+++ b/packages/server/src/modules/studio/public/provider-catalog.ts
@@ -1,11 +1,16 @@
 import { logger } from './logging'
+import { OPENCODE_FREE_BASE_URL, isOpenCodeFreeModel } from '../contracts/opencode-free'
+
+export async function fetchOpenCodeFreeModels(): Promise<string[]> {
+  return (await fetchProviderModels(OPENCODE_FREE_BASE_URL, '')).filter(isOpenCodeFreeModel)
+}
 
 export async function fetchProviderModels(baseUrl: string, apiKey: string, freeOnly = false): Promise<string[]> {
   const base = baseUrl.replace(/\/+$/, '')
   const modelsUrl = /\/v\d+\/?$/.test(base) ? `${base}/models` : `${base}/v1/models`
   try {
     const response = await fetch(modelsUrl, {
-      headers: { Authorization: `Bearer ${apiKey}` },
+      headers: apiKey ? { Authorization: `Bearer ${apiKey}` } : {},
       signal: AbortSignal.timeout(8000),
     })
     if (!response.ok) {

--- a/tests/client/coding-agent-providers.test.ts
+++ b/tests/client/coding-agent-providers.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  isKeylessModelProvider,
   canScopedCodingAgentUseProvider,
   isAuthModelProvider,
   usesServerManagedProviderAuth,
@@ -24,4 +25,12 @@ describe('coding agent provider visibility', () => {
       expect(canScopedCodingAgentUseProvider(agentId, 'deepseek')).toBe(true)
     },
   )
+})
+
+
+it('requires no key only for the native OpenCode Free provider', () => {
+  expect(isKeylessModelProvider('opencode-free')).toBe(true)
+  for (const provider of ['opencode-zen', 'custom:opencode-free', 'openai-api', undefined]) {
+    expect(isKeylessModelProvider(provider)).toBe(false)
+  }
 })

--- a/tests/e2e/provider-models.spec.ts
+++ b/tests/e2e/provider-models.spec.ts
@@ -1,5 +1,42 @@
 import { expect, test } from '@playwright/test'
-import { authenticate, mockHermesApi, TEST_ACCESS_KEY } from './fixtures'
+import { authenticate, mockChatSocket, mockHermesApi, TEST_ACCESS_KEY, TEST_MODEL_GROUP } from './fixtures'
+
+test('shows OpenCode Free loading without blocking other providers, then updates in the background', async ({ page }) => {
+  await authenticate(page, TEST_ACCESS_KEY)
+  const freeGroup = { provider: 'opencode-free', label: 'OpenCode Free', base_url: 'https://opencode.ai/zen/v1', api_key: '', builtin: true, models: [] as string[], catalog_status: 'loading' }
+  const api = await mockHermesApi(page, { modelGroups: [TEST_MODEL_GROUP, freeGroup] })
+  await page.goto('/#/hermes/models')
+  const freeCard = page.locator('.provider-card').filter({ has: page.getByRole('heading', { name: 'OpenCode Free', exact: true }) })
+  await expect(freeCard.getByText('Loading free models in the background…')).toBeVisible()
+  await expect(page.locator('.provider-card').filter({ hasText: 'test-provider' }).getByText('test-model', { exact: true }).first()).toBeVisible()
+  await expect(freeCard.getByRole('button', { name: 'Set default provider' })).toBeDisabled()
+  freeGroup.models = ['mimo-v2.5-free']
+  freeGroup.catalog_status = 'ready'
+  await expect(freeCard.getByText('mimo-v2.5-free', { exact: true })).toBeVisible({ timeout: 10_000 })
+  await expect(freeCard.getByText('Loading free models in the background…')).toHaveCount(0)
+  expect(api.requests.filter(request => request.method === 'PUT' && request.pathname === '/api/hermes/config/model')).toHaveLength(0)
+  expect(api.unexpectedRequests).toEqual([])
+})
+
+test('adds OpenCode Free without a key and preserves the native provider ID', async ({ page }) => {
+  await authenticate(page, TEST_ACCESS_KEY)
+  const freeGroup = { provider: 'opencode-free', label: 'OpenCode Free', base_url: 'https://opencode.ai/zen/v1', api_key: '', builtin: true, models: ['mimo-v2.5-free'], catalog_status: 'ready' }
+  await mockHermesApi(page, { modelGroups: [TEST_MODEL_GROUP, freeGroup] })
+  let saved: Record<string, unknown> | undefined
+  await page.route('**/api/hermes/config/providers', async route => {
+    saved = route.request().postDataJSON()
+    await route.fulfill({ json: { success: true } })
+  })
+  await page.goto('/#/hermes/models?addProvider=1')
+  const form = page.getByRole('dialog')
+  await form.locator('.n-base-selection').first().click()
+  await page.locator('.n-base-select-option').filter({ hasText: 'OpenCode Free' }).click()
+  await expect(form.locator('input[type="password"]')).toHaveCount(0)
+  await expect(form.getByText('No account or API key required. Free models may be rate limited.')).toBeVisible()
+  await form.getByRole('button', { name: 'Add', exact: true }).click()
+  await expect(form).toHaveCount(0)
+  expect(saved).toMatchObject({ providerKey: 'opencode-free', api_key: '', model: 'mimo-v2.5-free' })
+})
 
 test('opens the provider form when model settings are entered from setup guidance', async ({ page }) => {
   await authenticate(page, TEST_ACCESS_KEY)
@@ -92,4 +129,42 @@ test('edits a provider without rendering its existing credential', async ({ page
   expect(testRequest?.method).toBe('POST')
   expect(testRequest?.headers['x-hermes-profile']).toBe('research')
   expect(api.unexpectedRequests).toEqual([])
+})
+
+
+for (const agent of ['Hermes', 'Ekko', 'Claude', 'Codex', 'Pi', 'Grok', 'OpenCode']) {
+  test(`creates an OpenCode Free ${agent} chat without asking for a key`, async ({ page }) => {
+    await authenticate(page, TEST_ACCESS_KEY)
+    await mockHermesApi(page, { modelGroups: [{ provider: 'opencode-free', label: 'OpenCode Free', base_url: 'https://opencode.ai/zen/v1', api_key: '', builtin: true, models: ['mimo-v2.5-free'], catalog_status: 'ready' }] })
+    await mockChatSocket(page)
+    await page.route('**/api/coding-agents', route => route.fulfill({ json: {
+      tools: ['claude-code', 'codex', 'pi', 'grok', 'opencode'].map(id => ({ id, name: id, installed: true })),
+    } }))
+    await page.goto('/#/hermes/chat')
+    await page.getByRole('button', { name: 'New Chat' }).click()
+    const form = page.locator('.new-chat-drawer')
+    if (agent !== 'Hermes') {
+      await form.locator('.new-chat-field').filter({ hasText: /^Agent/ }).locator('.n-base-selection').click()
+      await page.locator('.n-base-select-option:visible').filter({ hasText: new RegExp(`^${agent}$`) }).click()
+    }
+    await expect(form.locator('input[type="password"]')).toHaveCount(0)
+    await expect(form.getByText('No account or API key required. Free models may be rate limited.')).toBeVisible()
+    await expect(form.getByRole('button', { name: 'Create', exact: true })).toBeEnabled()
+    await form.getByRole('button', { name: 'Create', exact: true }).click()
+    await expect(page).toHaveURL(/#\/hermes\/session\//)
+  })
+}
+
+test('updates a pending free catalog inside the new chat drawer', async ({ page }) => {
+  await authenticate(page, TEST_ACCESS_KEY)
+  const freeGroup = { provider: 'opencode-free', label: 'OpenCode Free', base_url: 'https://opencode.ai/zen/v1', api_key: '', models: [] as string[], catalog_status: 'loading' }
+  await mockHermesApi(page, { modelGroups: [freeGroup] })
+  await mockChatSocket(page)
+  await page.goto('/#/hermes/chat')
+  await page.getByRole('button', { name: 'New Chat' }).click()
+  const create = page.locator('.new-chat-drawer').getByRole('button', { name: 'Create', exact: true })
+  await expect(create).toBeDisabled()
+  freeGroup.models = ['mimo-v2.5-free']
+  freeGroup.catalog_status = 'ready'
+  await expect(create).toBeEnabled({ timeout: 10_000 })
 })

--- a/tests/server/agent-runner-gateway.test.ts
+++ b/tests/server/agent-runner-gateway.test.ts
@@ -32,6 +32,21 @@ describe('agent run gateway', () => {
     }))
   })
 
+  it.each([false, true])('omits upstream authorization for keyless requests (stream=%s)', async (stream) => {
+    const fetchMock = vi.fn(async () => new Response(stream ? 'data: [DONE]\n\n' : '{}', {
+      headers: { 'Content-Type': stream ? 'text/event-stream' : 'application/json' },
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+    const gateway = new AgentRunGateway()
+    const request = { url: 'https://opencode.ai/zen/v1/chat/completions', apiKey: '', body: { stream } }
+    if (stream) {
+      for await (const _chunk of await gateway.streamBytes(request)) { /* drain */ }
+    } else await gateway.completeJson(request)
+    const headers = new Headers((fetchMock.mock.calls[0] as any)[1].headers)
+    expect(headers.has('authorization')).toBe(false)
+    expect(headers.has('x-api-key')).toBe(false)
+  })
+
   it('throws structured provider errors', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
       error: { message: 'bad key' },

--- a/tests/server/coding-agent-resume-config.test.ts
+++ b/tests/server/coding-agent-resume-config.test.ts
@@ -443,6 +443,30 @@ describe('coding agent resumed session config', () => {
     expect(startRunMock).not.toHaveBeenCalled()
   })
 
+  it('starts and resumes OpenCode Free without reading upstream credentials', async () => {
+    makeHome()
+    getSessionMock.mockReturnValue({
+      id: 'session-free', profile: 'default', source: 'coding_agent', agent: 'codex',
+      agent_session_id: 'agent-session-1', provider: 'opencode-free', model: 'muse-spark-free',
+    })
+    safeReadFileMock.mockResolvedValue('')
+    const { startCodingAgentRun } = await import('../../packages/server/src/bootstrap/coding-agents')
+    await startCodingAgentRun('codex', { sessionId: 'session-free' })
+    const resumed = startRunMock.mock.calls[0][0]
+    expect(resumed.provider).toBe('opencode-free')
+    expect(resumed.model).toBe('muse-spark-free')
+    expect(readConfigYamlForProfileMock).not.toHaveBeenCalled()
+    getSessionMock.mockReturnValue(null)
+    await startCodingAgentRun('codex', {
+      sessionId: 'session-new-free', provider: 'opencode-free', model: 'mimo-v2.5-free',
+      apiKey: 'stale-key', baseUrl: 'https://stale.example/v1',
+    })
+    expect(startRunMock).toHaveBeenCalledTimes(2)
+    const started = startRunMock.mock.calls[1][0]
+    expect(started.provider).toBe('opencode-free')
+    expect(started.model).toBe('mimo-v2.5-free')
+  })
+
   it('fails clearly instead of launching Claude without scoped credentials', async () => {
     makeHome()
     getSessionMock.mockReturnValue({

--- a/tests/server/coding-agents-launch.test.ts
+++ b/tests/server/coding-agents-launch.test.ts
@@ -5,6 +5,7 @@ import { dirname, join } from 'path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { claudeProxyMessages, claudeProxyModels, registerClaudeCodeProxyTarget } from '../../packages/server/src/modules/coding-agents/services/claude-code/proxy'
 import {
+  revokeCodexProxyTargets,
   codexProxyModels,
   codexProxyResponses,
   isAuthorizedCodexProxyRequest,
@@ -3098,5 +3099,66 @@ describe('coding agent launch preparation', () => {
     expect(ids).toContain('claude-sonnet-4-6')
     expect(ids).toContain('claude-opus-4-7')
     expect(ids).toContain('cognitivecomputations/dolphin-mistral-24b-venice-edition:free')
+  })
+})
+
+
+describe('OpenCode Free coding agents', () => {
+  it.each(['claude-code', 'codex', 'pi', 'grok', 'opencode'])('prepares %s with a protected local proxy and no upstream key', async (id) => {
+    const home = makeHome()
+    if (id === 'pi') {
+      const adapter = join(home, 'coding-agent', 'pi-mcp-adapter', 'node_modules', 'pi-mcp-adapter', 'index.ts')
+      mkdirSync(dirname(adapter), { recursive: true })
+      writeFileSync(adapter, 'export default {}')
+    }
+    const launch = await prepareCodingAgentLaunch(id as any, {
+      profile: 'default', provider: 'opencode-free', model: 'mimo-v2.5-free', mode: 'scoped',
+    })
+    const contents = launch.files.map(file => readFileSync(file.absolutePath, 'utf8')).join('\n')
+    expect(contents).toMatch(/api\/(codex-proxy|claude-code-proxy)\//)
+    expect(contents + JSON.stringify(launch.env)).toContain('hwui_')
+    if (id === 'codex' || id === 'pi') {
+      revokeCodexProxyTargets('default', 'opencode-free')
+      const restored = id === 'pi' ? await restorePersistedPiProxyTargets() : await restorePersistedCodexProxyTargets()
+      expect(restored).toBeGreaterThan(0)
+    }
+  })
+
+  it.each([
+    ['mimo-v2.5-free', 'chat/completions'],
+    ['muse-spark-free', 'responses'],
+    ['qwen3-free', 'messages'],
+  ])('routes %s anonymously through both proxy protocols', async (model, endpoint) => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      id: 'test', type: 'message', role: 'assistant', content: [{ type: 'text', text: 'ok' }],
+      output: [], choices: [{ finish_reason: 'stop', message: { role: 'assistant', content: 'ok' } }],
+    }), { headers: { 'Content-Type': 'application/json' } }))
+    vi.stubGlobal('fetch', fetchMock)
+    for (const claude of [false, true]) {
+      const input = { profile: 'default', provider: 'opencode-free', model, baseUrl: 'https://stale.example', apiKey: 'stale-key' }
+      const target = claude ? registerClaudeCodeProxyTarget(input) : registerCodexProxyTarget(input)
+      const handler = claude ? claudeProxyMessages : codexProxyResponses
+      const body = { model, max_tokens: 16, messages: [{ role: 'user', content: 'hello' }], input: 'hello' }
+      const denied = makeProxyContext(target.routeKey, '', body)
+      await handler(denied)
+      expect(denied.status).toBe(401)
+      fetchMock.mockClear()
+      const ctx = makeProxyContext(target.routeKey, target.token, body)
+      await handler(ctx)
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      const [url, init] = fetchMock.mock.calls[0] as any
+      expect(url).toBe(`https://opencode.ai/zen/v1/${endpoint}`)
+      const headers = new Headers(init.headers)
+      expect(headers.has('authorization')).toBe(false)
+      expect(headers.has('x-api-key')).toBe(false)
+      expect(JSON.parse(init.body).model).toBe(model)
+    }
+  })
+
+  it('rejects paid model IDs for the native anonymous provider', async () => {
+    makeHome()
+    await expect(prepareCodingAgentLaunch('codex', {
+      provider: 'opencode-free', model: 'gpt-5', mode: 'scoped',
+    })).rejects.toMatchObject({ status: 400 })
   })
 })

--- a/tests/server/ekko-agent-provider-runtime.test.ts
+++ b/tests/server/ekko-agent-provider-runtime.test.ts
@@ -33,6 +33,16 @@ describe('resolveEkkoProviderRuntimeConfig', () => {
     mocks.resolveAuthorized.mockResolvedValue({})
   })
 
+  it('resolves OpenCode Free anonymously without reading or borrowing profile credentials', async () => {
+    const { resolveEkkoProviderRuntimeConfig } = await import('../../packages/server/src/modules/ekko/services/provider-runtime')
+    await expect(resolveEkkoProviderRuntimeConfig({
+      profile: 'default', provider: 'opencode-free', model: 'muse-spark-free',
+      apiKey: 'stale-key', baseUrl: 'https://stale.example/v1', apiMode: 'chat_completions',
+    })).resolves.toEqual({ provider: 'opencode-free', apiKey: '', baseUrl: 'https://opencode.ai/zen/v1', apiMode: 'codex_responses' })
+    expect(mocks.readConfigYamlForProfile).not.toHaveBeenCalled()
+    expect(mocks.resolveAuthorized).not.toHaveBeenCalled()
+  })
+
   it('resolves a built-in provider from the profile env and preset', async () => {
     mocks.safeReadFile.mockResolvedValue([
       'OPENAI_API_KEY="profile-openai-key"',

--- a/tests/server/opencode-free-catalog.test.ts
+++ b/tests/server/opencode-free-catalog.test.ts
@@ -1,0 +1,14 @@
+import { afterEach, expect, it, vi } from 'vitest'
+import { fetchOpenCodeFreeModels } from '../../packages/server/src/modules/studio/public/provider-catalog'
+
+afterEach(() => vi.unstubAllGlobals())
+
+it('fetches anonymously and excludes paid models and the Go-only free-named twin', async () => {
+  const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({ data: [
+    { id: 'mimo-v2.5-free' }, { id: 'deepseek-v4-flash-free' },
+    { id: 'claude-opus-4-8' }, { id: 'ox-alpha-free' }, { id: 'openrouter/free' },
+  ] })))
+  vi.stubGlobal('fetch', fetchMock)
+  expect(await fetchOpenCodeFreeModels()).toEqual(['deepseek-v4-flash-free', 'mimo-v2.5-free'])
+  expect(fetchMock).toHaveBeenCalledWith('https://opencode.ai/zen/v1/models', expect.objectContaining({ headers: {}, signal: expect.any(AbortSignal) }))
+})

--- a/tests/server/opencode-free-models.test.ts
+++ b/tests/server/opencode-free-models.test.ts
@@ -1,0 +1,72 @@
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { status } = vi.hoisted(() => ({ status: vi.fn(() => 'loading') }))
+vi.mock('../../packages/server/src/modules/hermes/services/providers/opencode-free', () => ({ getOpenCodeFreeStatus: status }))
+let home = ''
+let appHome = ''
+const originalHome = process.env.HERMES_HOME
+const originalAppHome = process.env.HERMES_WEB_UI_HOME
+const initialConfig = 'model:\n  provider: deepseek\n  default: deepseek-chat\n'
+beforeEach(() => {
+  vi.resetModules()
+  home = mkdtempSync(join(tmpdir(), 'opencode-free-profile-'))
+  appHome = mkdtempSync(join(tmpdir(), 'opencode-free-studio-'))
+  process.env.HERMES_HOME = home
+  process.env.HERMES_WEB_UI_HOME = appHome
+  writeFileSync(join(home, 'config.yaml'), initialConfig)
+  writeFileSync(join(home, '.env'), 'DEEPSEEK_API_KEY=test-key\n')
+  status.mockReturnValue('loading')
+  vi.stubGlobal('fetch', vi.fn(() => new Promise(() => {})))
+})
+afterEach(() => {
+  vi.unstubAllGlobals()
+  if (originalHome === undefined) delete process.env.HERMES_HOME
+  else process.env.HERMES_HOME = originalHome
+  if (originalAppHome === undefined) delete process.env.HERMES_WEB_UI_HOME
+  else process.env.HERMES_WEB_UI_HOME = originalAppHome
+  rmSync(home, { recursive: true, force: true })
+  rmSync(appHome, { recursive: true, force: true })
+})
+
+async function load() {
+  await import('../../packages/server/src/bootstrap/agent-profile-adapter')
+  const models = await import('../../packages/server/src/modules/hermes/controllers/models')
+  const cache = await import('../../packages/server/src/modules/hermes/services/providers/model-catalog-cache')
+  return { ...models, ...cache }
+}
+const ctx = () => ({ query: { profile: 'default' }, body: undefined as any })
+
+describe('OpenCode Free provider discovery', () => {
+  it('shows the loading entry immediately without waiting for network or modifying the default', async () => {
+    const { getAvailable } = await load()
+    const request = ctx()
+    await getAvailable(request)
+    expect(request.body.groups).toContainEqual(expect.objectContaining({ provider: 'opencode-free', api_key: '', models: [], catalog_status: 'loading' }))
+    expect(request.body.default_provider).toBe('deepseek')
+    expect(request.body.default).toBe('deepseek-chat')
+    expect(fetch).not.toHaveBeenCalled()
+    expect(readFileSync(join(home, 'config.yaml'), 'utf8')).toBe(initialConfig)
+  })
+
+  it('uses the public cache during a failed refresh and filters out paid models', async () => {
+    const { getAvailable, writeProviderModelCatalogEntry } = await load()
+    await writeProviderModelCatalogEntry({ provider: 'opencode-free', label: 'OpenCode Free', base_url: 'https://opencode.ai/zen/v1', models: ['mimo-v2.5-free', 'paid-model'], source: 'live' })
+    status.mockReturnValue('error')
+    const request = ctx()
+    await getAvailable(request)
+    expect(request.body.groups).toContainEqual(expect.objectContaining({ provider: 'opencode-free', models: ['mimo-v2.5-free'], catalog_status: 'error' }))
+    expect(request.body.default_provider).toBe('deepseek')
+  })
+
+  it('keeps the entry but disables models when Hermes lacks the provider', async () => {
+    const { getAvailable, writeProviderModelCatalogEntry } = await load()
+    await writeProviderModelCatalogEntry({ provider: 'opencode-free', label: 'OpenCode Free', base_url: 'https://opencode.ai/zen/v1', models: ['mimo-v2.5-free'], source: 'live' })
+    status.mockReturnValue('unsupported')
+    const request = ctx()
+    await getAvailable(request)
+    expect(request.body.groups).toContainEqual(expect.objectContaining({ provider: 'opencode-free', models: [], catalog_status: 'unsupported' }))
+  })
+})

--- a/tests/server/opencode-free.test.ts
+++ b/tests/server/opencode-free.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { probe, catalog, write } = vi.hoisted(() => ({
+  probe: vi.fn(), catalog: vi.fn(), write: vi.fn(),
+}))
+vi.mock('node:util', () => ({ promisify: () => probe }))
+vi.mock('../../packages/server/src/modules/hermes/services/runtime/installation', () => ({ resolveHermesInstallationEnvironment: () => ({ python: '/runtime/python', agentRoot: '/runtime' }) }))
+vi.mock('../../packages/server/src/modules/hermes/services/runtime/process', () => ({ resolveHermesBin: () => '/runtime/hermes' }))
+vi.mock('../../packages/server/src/modules/hermes/services/profiles/profile', () => ({ getProfileDir: () => '/profiles' }))
+vi.mock('../../packages/server/src/modules/studio/public/provider-catalog', () => ({ fetchOpenCodeFreeModels: catalog }))
+vi.mock('../../packages/server/src/modules/hermes/services/providers/model-catalog-cache', () => ({ writeProviderModelCatalogEntry: write }))
+vi.mock('../../packages/server/src/modules/studio/public/logging', () => ({ logger: { warn: vi.fn() } }))
+
+beforeEach(() => {
+  vi.stubEnv('HERMES_AGENT_BRIDGE_PYTHON', '/runtime/python')
+  vi.stubEnv('HERMES_AGENT_ROOT', '/runtime')
+  vi.resetModules()
+  vi.useFakeTimers()
+  vi.clearAllMocks()
+  probe.mockResolvedValue({ stdout: 'supported\n' })
+  catalog.mockResolvedValue(['mimo-v2.5-free'])
+  write.mockResolvedValue({})
+})
+afterEach(() => { vi.clearAllTimers(); vi.useRealTimers(); vi.unstubAllEnvs() })
+
+describe('OpenCode Free background initialization', () => {
+  it('returns immediately, deduplicates slow requests and persists only the public catalog', async () => {
+    let finish!: (models: string[]) => void
+    catalog.mockImplementation(() => new Promise<string[]>(resolve => { finish = resolve }))
+    const service = await import('../../packages/server/src/modules/hermes/services/providers/opencode-free')
+    expect(service.initializeOpenCodeFreeInBackground()).toBeUndefined()
+    service.initializeOpenCodeFreeInBackground()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(catalog).toHaveBeenCalledTimes(1)
+    expect(service.getOpenCodeFreeStatus()).toBe('loading')
+    expect(write).not.toHaveBeenCalled()
+    expect(probe.mock.calls[0][0]).toBe('/runtime/python')
+    expect(probe.mock.calls[0][2].timeout).toBe(5000)
+    expect(probe.mock.calls[0][2].cwd).toBe('/runtime')
+    finish(['mimo-v2.5-free'])
+    await vi.advanceTimersByTimeAsync(0)
+    expect(service.getOpenCodeFreeStatus()).toBe('ready')
+    expect(write).toHaveBeenCalledWith({ provider: 'opencode-free', label: 'OpenCode Free', base_url: 'https://opencode.ai/zen/v1', models: ['mimo-v2.5-free'], source: 'live' })
+    service.initializeOpenCodeFreeInBackground()
+    expect(catalog).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps the last-good cache on timeout and retries later without a busy loop', async () => {
+    catalog.mockRejectedValueOnce(new Error('timeout'))
+    const service = await import('../../packages/server/src/modules/hermes/services/providers/opencode-free')
+    service.initializeOpenCodeFreeInBackground()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(service.getOpenCodeFreeStatus()).toBe('error')
+    expect(write).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(59_999)
+    expect(catalog).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(catalog).toHaveBeenCalledTimes(2)
+    expect(service.getOpenCodeFreeStatus()).toBe('ready')
+  })
+
+  it('reports older Hermes installations without changing their model config', async () => {
+    probe.mockResolvedValue({ stdout: 'unsupported\n' })
+    const service = await import('../../packages/server/src/modules/hermes/services/providers/opencode-free')
+    service.initializeOpenCodeFreeInBackground()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(service.getOpenCodeFreeStatus()).toBe('unsupported')
+  })
+
+  it('does not replace a good catalog with an empty response', async () => {
+    catalog.mockResolvedValue([])
+    const service = await import('../../packages/server/src/modules/hermes/services/providers/opencode-free')
+    service.initializeOpenCodeFreeInBackground()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(write).not.toHaveBeenCalled()
+    expect(service.getOpenCodeFreeStatus()).toBe('error')
+  })
+})

--- a/tests/server/provider-create-controller.test.ts
+++ b/tests/server/provider-create-controller.test.ts
@@ -64,6 +64,24 @@ describe('providers controller create', () => {
     expect(envAfter).not.toContain('DEEPSEEK_BASE_URL')
   })
 
+  it('selects native OpenCode Free without writing credentials or a custom provider', async () => {
+    const { create } = await loadProvidersController()
+    const ctx = makeCtx({ name: 'OpenCode Free', providerKey: 'opencode-free', model: 'mimo-v2.5-free', api_key: '' })
+    await create(ctx)
+    expect(ctx.body).toEqual({ success: true })
+    expect(readYaml(join(hermesHome, 'config.yaml'))).toEqual({ model: { provider: 'opencode-free', default: 'mimo-v2.5-free' } })
+    expect(readFileSync(join(hermesHome, '.env'), 'utf-8')).toBe('')
+  })
+
+  it('rejects a paid model under OpenCode Free without changing the current config', async () => {
+    const { create } = await loadProvidersController()
+    const before = readFileSync(join(hermesHome, 'config.yaml'), 'utf-8')
+    const ctx = makeCtx({ name: 'OpenCode Free', providerKey: 'opencode-free', model: 'claude-opus-4-8', api_key: '' })
+    await create(ctx)
+    expect(ctx.status).toBe(400)
+    expect(readFileSync(join(hermesHome, 'config.yaml'), 'utf-8')).toBe(before)
+  })
+
   it('persists a built-in provider base URL when it differs from the preset default', async () => {
     const { create } = await loadProvidersController()
     const ctx = makeCtx({


### PR DESCRIPTION
## Summary

- Add native `opencode-free` discovery to Studio. Probe Hermes support and fetch the anonymous model catalog asynchronously with timeouts, retries, single-flight initialization, and a shared last-good cache. Startup preserves Hermes config, credentials, and the default model; explicit selection stores the native provider ID.
- Remove key prompts for this provider in setup and new-chat flows. Model settings and the new-chat drawer pick up background catalog results. Include translations in all 11 locales.
- Support anonymous upstream requests for scoped Claude Code, Codex, Pi, Grok, and OpenCode launches, plus Ekko runtime resolution. Retain local proxy token authentication, discard stale upstream credentials, and select Chat Completions, Responses, or Messages according to the model. Support keyless Codex and Pi proxy restoration.

## Validation

- `npm run harness:check` — passed.
- `npm run build` — passed.
- Focused Vitest checks with the expected fixture port (`PORT=8648`) — 142 passed, covering discovery, provider creation, refresh, first launch/resume, proxy authentication/routing, keyless persistence, Ekko runtime resolution, and native bridge credentials.
- `PLAYWRIGHT_CHANNEL=chrome npx playwright test --workers=4` — all 169 test cases passed, including seven Agent new-chat variants and background catalog updates. The runner stalled during worker teardown after all cases completed; test-owned processes were terminated.
- `npm run test:coverage -- --reporter=json` — 5,010 passed / 57 failed. Compared against an unmodified HEAD worktree (4,978 passed / 66 failed): 51 failures also occur on the baseline; the remaining six belong to Windows runner, group-history, and speech-route tests and passed when rerun (134 tests passed). Existing launch tests also assume port 8648, unlike the active development environment; the focused run sets that fixture port explicitly.
- `git diff --check` — passed.

## Limitations

The public upstream catalog was reachable anonymously. Live inference probes encountered upstream unavailability/free-tier rate limits, so this does not claim successful live model inference. Free model availability is controlled by OpenCode. Older Hermes runtimes show an upgrade hint. Global Coding Agent mode continues to use the agent’s own configuration.
