### PR TITLE
fix: restore skill enable switches by default

### DIFF
--- a/packages/client/src/components/hermes/skills/SkillList.vue
+++ b/packages/client/src/components/hermes/skills/SkillList.vue
@@ -11,7 +11,7 @@ const { t } = useI18n()
 const message = useMessage()
 const dialog = useDialog()
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
     categories: SkillCategory[]
     archived: SkillInfo[]
     selectedSkill: string | null
@@ -21,7 +21,9 @@ const props = defineProps<{
     toggleable?: boolean
     toggleHandler?: (category: string, skill: string, enabled: boolean) => Promise<void>
     deleteHandler?: (category: string, skill: string) => Promise<void>
-}>()
+}>(), {
+    toggleable: true,
+})
 
 const emit = defineEmits<{
     select: [category: string, skill: string]

--- a/tests/client/skill-list.test.ts
+++ b/tests/client/skill-list.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { defineComponent } from 'vue'
 import SkillList from '@/components/hermes/skills/SkillList.vue'
+import { toggleSkill } from '@/api/hermes/skills'
 
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({ t: (key: string) => key }),
@@ -25,6 +26,52 @@ vi.mock('naive-ui', () => ({
 }))
 
 describe('SkillList', () => {
+  describe.each([null, 'external'] as const)('toggle controls with source filter %s', sourceFilter => {
+    function mountList(options: { readonly?: boolean; toggleable?: boolean } = {}) {
+      return mount(SkillList, {
+        props: {
+          categories: [{
+            name: 'tools',
+            description: '',
+            skills: [{
+              name: 'test-skill',
+              description: '',
+              enabled: true,
+              source: 'external',
+              sourcePath: '~/shared/skills',
+            }],
+          }],
+          archived: [],
+          selectedSkill: null,
+          searchQuery: '',
+          sourceFilter,
+          ...options,
+        },
+      })
+    }
+
+    it('shows the switch by default and disables the skill', async () => {
+      vi.mocked(toggleSkill).mockClear().mockResolvedValue(undefined)
+      const wrapper = mountList()
+      const toggle = wrapper.getComponent({ name: 'NSwitch' })
+
+      expect(toggle.props('value')).toBe(true)
+      toggle.vm.$emit('update:value', false)
+      await vi.waitFor(() => {
+        expect(toggleSkill).toHaveBeenCalledWith('test-skill', false)
+        expect(toggle.props('value')).toBe(false)
+      })
+    })
+
+    it('hides the switch when toggling is explicitly disabled', () => {
+      expect(mountList({ toggleable: false }).findComponent({ name: 'NSwitch' }).exists()).toBe(false)
+    })
+
+    it('hides the switch for readonly skills even when toggling is requested', () => {
+      expect(mountList({ readonly: true, toggleable: true }).findComponent({ name: 'NSwitch' }).exists()).toBe(false)
+    })
+  })
+
   it('supports filtering skills from external sources', () => {
     const wrapper = mount(SkillList, {
       props: {

--- a/tests/e2e/skill-toggle.spec.ts
+++ b/tests/e2e/skill-toggle.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test } from '@playwright/test'
+import { authenticate, mockHermesApi, TEST_ACCESS_KEY } from './fixtures'
+
+test('disables and re-enables a skill with a long title from the skills list', async ({ page }) => {
+  await authenticate(page, TEST_ACCESS_KEY, 'research')
+  const skill = {
+    name: 'review-a-very-long-skill-name-that-overflows-the-sidebar',
+    description: 'A long title must leave the enable switch visible.',
+    enabled: true,
+    source: 'local',
+  }
+  const api = await mockHermesApi(page, {
+    skills: { categories: [{ name: 'tools', description: '', skills: [skill] }], archived: [] },
+  })
+  const updates: boolean[] = []
+  await page.route('**/api/hermes/write-gate/pending', route => route.fulfill({
+    json: { supported: false, records: [] },
+  }))
+  await page.route('**/api/hermes/skills/tools/**', route => route.fulfill({
+    json: route.request().url().endsWith('/files') ? { files: [] } : { content: '# Test skill' },
+  }))
+  await page.route('**/api/hermes/skills/toggle', async route => {
+    expect(route.request().method()).toBe('PUT')
+    const body = route.request().postDataJSON()
+    expect(body.name).toBe(skill.name)
+    skill.enabled = body.enabled
+    updates.push(body.enabled)
+    await route.fulfill({ json: { ok: true } })
+  })
+
+  await page.goto('/#/hermes/skills')
+  const toggle = page.locator('.skill-item').filter({ hasText: skill.name }).getByRole('switch')
+  await expect(toggle).toBeVisible()
+  await expect(toggle).toHaveAttribute('aria-checked', 'true')
+
+  await toggle.click()
+  await expect(toggle).toHaveAttribute('aria-checked', 'false')
+  await page.reload()
+  await expect(toggle).toHaveAttribute('aria-checked', 'false')
+
+  await toggle.click()
+  await expect(toggle).toHaveAttribute('aria-checked', 'true')
+  expect(updates).toEqual([false, true])
+  expect(api.unexpectedRequests).toEqual([])
+})


### PR DESCRIPTION
## Summary

Restore the enable/disable switches in the Hermes and Ekko skill lists by defaulting `toggleable` to `true`. Vue casts the omitted Boolean prop to `false`, so callers that did not specify it lost their switches. Explicit `toggleable=false` and read-only views still hide the controls.

Add regression coverage for both flat and external-directory lists, plus a browser test that disables a skill with a long title, reloads to verify the saved state, and re-enables it. The default-visibility tests reproduce the failure before the fix.

## Validation

- `NODE_ENV=test npm test -- tests/client/skill-list.test.ts tests/client/skills-view.test.ts tests/client/ekko-config-navigation.test.ts` — 13 passed
- `PLAYWRIGHT_PORT=14302 PLAYWRIGHT_CHANNEL=chrome npx playwright test tests/e2e/skill-toggle.spec.ts --workers=1` — 1 passed
- `npm run harness:check` — passed
- `npm run build` — passed
- `git diff --check` — passed
