### PR TITLE
feat: foreground group reply notifications

### DIFF
--- a/docs/chat-chain-changes/2026-09-06-group-foreground-notifications.md
+++ b/docs/chat-chain-changes/2026-09-06-group-foreground-notifications.md
@@ -1,0 +1,3 @@
+# Group foreground message notifications
+
+Broadcast bounded persisted Agent reply previews to authenticated sockets passing current room observation policy. No automatic room join, history replay, tool-token alerts or Workflow changes. Initial support is host-local room reply completion only; remote guest connections, approval/failure alerts and message-anchor navigation remain follow-up work. Companion App consumes app.group-notification.

--- a/packages/server/src/modules/studio/services/group-chat/foreground-notification.ts
+++ b/packages/server/src/modules/studio/services/group-chat/foreground-notification.ts
@@ -1,0 +1,10 @@
+export function groupReplyNotification(room: { id: string; name: string }, message: {
+  id: string; senderName: string; senderType?: string; role?: string; content: string; finish_reason?: string | null
+}, now = Date.now()) {
+  if (message.senderType !== 'agent' || message.role !== 'assistant' || !message.content.trim()
+    || ['tool_calls', 'cancelled', 'aborted', 'error'].includes(message.finish_reason || '')) return null
+  const text = (s: string, limit: number) => s.replace(/[\u0000-\u001f\u007f]/g, ' ').replace(/\s+/g,' ').trim().slice(0,limit)
+  return { id: `group:${room.id}:message:${message.id}`, target:'group', roomId:room.id, messageId:message.id,
+    title:text(room.name,120), content:`${text(message.senderName,60)}: ${text(message.content,180)}`,
+    kind:'completion', resolved:false, timestamp:now }
+}

--- a/packages/server/src/modules/studio/sockets/group-chat.ts
+++ b/packages/server/src/modules/studio/sockets/group-chat.ts
@@ -1,3 +1,4 @@
+import { groupReplyNotification } from '../services/group-chat/foreground-notification'
 import { Server, Socket, Namespace } from 'socket.io'
 import type { Server as HttpServer } from 'http'
 import { mkdirSync } from 'fs'
@@ -3322,6 +3323,21 @@ export class GroupChatServer {
             : []
     }
 
+    private readonly notifiedGroupMessages = new Set<string>()
+
+    private notifyGroupReply(roomId: string, message: ChatMessage): void {
+        const room = this.storage.getRoom(roomId)
+        if (!room) return
+        const notice = groupReplyNotification(room, message)
+        if (!notice || this.notifiedGroupMessages.has(notice.id)) return
+        this.notifiedGroupMessages.add(notice.id)
+        if (this.notifiedGroupMessages.size > 2000) this.notifiedGroupMessages.delete(this.notifiedGroupMessages.values().next().value!)
+        for (const socket of this.nsp.sockets.values()) {
+            // Recheck membership/permissions at emission time, not just on connect.
+            if (this.canSocketObserveRoom(socket, roomId)) socket.emit('app.group-notification', notice)
+        }
+    }
+
     private broadcastExecutionQueue(roomId: string): void {
         this.nsp.to(roomId).emit('execution_queue_updated', {
             roomId,
@@ -4609,6 +4625,7 @@ export class GroupChatServer {
         const totalTokens = saved.totalTokens
 
         this.nsp.to(roomId).emit('message', buildOutboundGroupMessage(savedMsg))
+        this.notifyGroupReply(roomId, savedMsg)
         this.nsp.to(roomId).emit('room_updated', { roomId, totalTokens })
         ack?.({ id: savedMsg.id })
 

--- a/packages/server/src/modules/studio/sockets/group-chat.ts
+++ b/packages/server/src/modules/studio/sockets/group-chat.ts
@@ -3334,7 +3334,13 @@ export class GroupChatServer {
         if (this.notifiedGroupMessages.size > 2000) this.notifiedGroupMessages.delete(this.notifiedGroupMessages.values().next().value!)
         for (const socket of this.nsp.sockets.values()) {
             // Recheck membership/permissions at emission time, not just on connect.
-            if (this.canSocketObserveRoom(socket, roomId)) socket.emit('app.group-notification', notice)
+            if (this.canSocketObserveRoom(socket, roomId)) {
+                const agents = this.storage.getRoomAgents(roomId)
+                const visible = agents.length > 4 ? agents.slice(0, 3) : agents.slice(0, 4)
+                socket.emit('app.group-notification', { ...notice, agentCount: agents.length,
+                    agents: visible.map(agent => ({ id: agent.id, name: agent.name.slice(0, 80), agent: agent.agent,
+                        avatar: typeof agent.avatar === 'string' && agent.avatar.length <= 65536 ? agent.avatar : '' })) })
+            }
         }
     }
 

--- a/tests/server/group-chat-approval.test.ts
+++ b/tests/server/group-chat-approval.test.ts
@@ -41,6 +41,25 @@ describe('group chat approval and context baseline', () => {
     vi.restoreAllMocks()
   })
 
+  it('group reply notifications recheck visibility, never replay duplicate messages', () => {
+    const allowed = { id: 'notice-allowed', emit: vi.fn() }
+    const denied = { id: 'notice-denied', emit: vi.fn() }
+    const server = groupServer as any
+    const old = server.nsp.sockets
+    server.nsp.sockets = new Map([[allowed.id, allowed], [denied.id, denied]])
+    const access = vi.spyOn(server, 'canSocketObserveRoom').mockImplementation((socket: any) => socket.id === allowed.id)
+    try {
+      const message = { id:'notice-message', roomId:'room-1', senderName:'Pi', senderType:'agent', role:'assistant', content:'Done' }
+      server.notifyGroupReply('room-1', message)
+      server.notifyGroupReply('room-1', message)
+      expect(allowed.emit).toHaveBeenCalledTimes(1)
+      expect(denied.emit).not.toHaveBeenCalled()
+      access.mockReturnValue(false)
+      server.notifyGroupReply('room-1', { ...message, id:'second-message' })
+      expect(allowed.emit).toHaveBeenCalledTimes(1)
+    } finally { server.nsp.sockets = old }
+  })
+
   async function joinPair() {
     const agentSessionId = groupRuntimeSessionId('room-1', 'default', 'Agent')
     const agent = await connectGroupChatClient(port, 'agent-1', 'Agent', {

--- a/tests/server/group-foreground-notification.test.ts
+++ b/tests/server/group-foreground-notification.test.ts
@@ -1,0 +1,10 @@
+import { it, expect } from 'vitest'
+import { groupReplyNotification } from '../../packages/server/src/modules/studio/services/group-chat/foreground-notification'
+it('builds a WeChat-style room title and sender-prefixed bounded preview',()=>{
+ const event=groupReplyNotification({id:'room',name:'Team'},{id:'m',senderName:'Pi',senderType:'agent',role:'assistant',content:'Done\nnow'},10)
+ expect(event).toMatchObject({id:'group:room:message:m',target:'group',title:'Team',content:'Pi: Done now',messageId:'m',timestamp:10})
+})
+it('does not alert for human posts, tools, empty output or interrupted output',()=>{
+ const base={id:'m',senderName:'Pi',senderType:'agent',role:'assistant',content:'done'}
+ for(const patch of [{senderType:'member'},{role:'tool'},{content:''},{finish_reason:'tool_calls'},{finish_reason:'aborted'}]) expect(groupReplyNotification({id:'r',name:'Room'},{...base,...patch})).toBeNull()
+})


### PR DESCRIPTION
## Summary
WeChat-style room name and Agent-prefixed bounded reply preview, emitted after persisted Agent assistant messages. Reuses canSocketObserveRoom at delivery time, excludes agent/guest sockets and duplicate message IDs. No room auto-join or history replay.

## Base
Stacked on #2929, keeping existing single-chat changes separate.

## Validation
35 focused tests pass, including delivery/permission revocation/deduplication. Production build passed; harness check run.

## Draft boundaries
Initial host-local group reply-completion scope only. Workflow, remote guest transport, approval/failure notifications, custom/composite room avatars and exact message positioning are NOT implemented. Real-device notification acceptance pending.