### PR TITLE
feat: foreground workflow run result notifications

### DIFF
--- a/docs/chat-chain-changes/2026-09-06-workflow-foreground-notifications.md
+++ b/docs/chat-chain-changes/2026-09-06-workflow-foreground-notifications.md
@@ -1,0 +1,3 @@
+# Workflow foreground result notifications
+
+Emit app.workflow-notification for persisted completed/failed whole runs only, dedupe per run ID, and recheck authenticated profile access at send time. No node/status snapshot replay, cancel alerts or approval notifications. Companion App opens exact run details. No raw error text or output is included in the initial compact version.

--- a/packages/server/src/modules/studio/sockets/workflow.ts
+++ b/packages/server/src/modules/studio/sockets/workflow.ts
@@ -61,6 +61,7 @@ export class WorkflowSocketServer {
   private readonly nsp: ReturnType<Server['of']>
   private readonly manager: WorkflowManager
   private readonly removeStatusListener: () => void
+  private readonly notifiedRuns = new Set<string>()
 
   constructor(io: Server, manager: WorkflowManager = getWorkflowManager()) {
     this.manager = manager
@@ -191,7 +192,26 @@ export class WorkflowSocketServer {
 
   private emitRuntimeStatus(status: WorkflowRuntimeStatus): void {
     try {
-      this.nsp.to(this.workflowRoom(status.workflowId)).emit('workflow.status.updated', this.statusWithEvidence(status))
+      const snapshot = this.statusWithEvidence(status)
+      this.nsp.to(this.workflowRoom(status.workflowId)).emit('workflow.status.updated', snapshot)
+      if (!status.runId || !snapshot.run || !['completed', 'failed'].includes(status.status)
+        || snapshot.run.status !== status.status || this.notifiedRuns.has(status.runId)) return
+      const workflow = this.manager.get(status.workflowId)
+      if (!workflow) return
+      this.notifiedRuns.add(status.runId)
+      if (this.notifiedRuns.size > 2000) this.notifiedRuns.delete(this.notifiedRuns.values().next().value!)
+      const notice = {
+        id: `workflow:${status.workflowId}:run:${status.runId}`, target: 'workflow',
+        workflowId: status.workflowId, runId: status.runId, profile: workflow.profile || 'default',
+        title: workflow.name.slice(0, 120), kind: status.status === 'failed' ? 'failure' : 'completion',
+        resolved: false, timestamp: Date.now(),
+      }
+      for (const socket of this.nsp.sockets.values()) {
+        const user = socket.data.user as AuthenticatedUser | undefined
+        // Foreground notifications require authenticated profile access even
+        // when ordinary local workflow routes are configured without auth.
+        if (user && canAccessProfile(user, workflow.profile)) socket.emit('app.workflow-notification', notice)
+      }
     } catch (err: any) {
       logger.error(err, '[workflow-socket] failed to load persisted execution evidence for workflow %s', status.workflowId)
       this.nsp.to(this.workflowRoom(status.workflowId)).emit('workflow.status.error', {

--- a/tests/server/workflow-foreground-notification.test.ts
+++ b/tests/server/workflow-foreground-notification.test.ts
@@ -1,0 +1,20 @@
+import { expect, it, vi } from 'vitest'
+vi.mock('../../packages/server/src/modules/studio/public/auth',()=>({authenticateUserToken:vi.fn(),isAuthEnabled:vi.fn()}))
+vi.mock('../../packages/server/src/modules/studio/repositories/users-store',()=>({listUserProfiles:()=>[{profile_name:'allowed'}]}))
+const run=vi.hoisted(()=>({status:'completed'}))
+vi.mock('../../packages/server/src/modules/studio/repositories/workflow-run-store',()=>({getWorkflowRunWithEvidence:()=>run}))
+vi.mock('../../packages/server/src/modules/studio/services/workflow/manager',()=>({getWorkflowManager:vi.fn()}))
+vi.mock('../../packages/server/src/modules/studio/public/logging',()=>({logger:{error:vi.fn(),info:vi.fn()}}))
+import { WorkflowSocketServer } from '../../packages/server/src/modules/studio/sockets/workflow'
+it('notifies only terminal run once to currently authorized users, never canceled or node progress',()=>{
+ const ok={data:{user:{id:1}},emit:vi.fn()},guest={data:{},emit:vi.fn()}
+ const nsp={sockets:new Map([['ok',ok],['guest',guest]]),to:()=>({emit:vi.fn()})}
+ const manager={onRuntimeStatus:vi.fn(()=>()=>{}),get:()=>({id:'w',name:'Workflow',profile:'allowed'})}
+ const server=new WorkflowSocketServer({of:()=>nsp} as any,manager as any)
+ const send=(status:string,runId='r')=>(server as any).emitRuntimeStatus({workflowId:'w',runId,status})
+ send('running');send('canceled');expect(ok.emit).not.toHaveBeenCalled()
+ send('completed');send('completed');expect(ok.emit).toHaveBeenCalledTimes(1);expect(guest.emit).not.toHaveBeenCalled()
+ expect(ok.emit.mock.calls[0][1]).toMatchObject({target:'workflow',workflowId:'w',runId:'r',kind:'completion'})
+ run.status='failed';send('failed','r2');expect(ok.emit).toHaveBeenCalledTimes(2)
+ manager.get=()=>({id:'w',name:'Workflow',profile:'denied'});send('failed','r3');expect(ok.emit).toHaveBeenCalledTimes(2)
+})


### PR DESCRIPTION
## Summary
Compact first version: persisted whole-run completed/failed notifications only, stable workflow/run identity, per-run dedupe and delivery-time profile authorization. No node completion, retries, canceled runs, history replay or approvals. Generic status only; no raw errors/output.

## Dependency
Stacked on #2934 (existing accepted group notification code unchanged).

## Validation
Focused workflow event tests passed, production build passed, harness check run. Covers authorization, duplicate terminal events, cancellation/progress filtering and new run identity.

## Acceptance
Draft pending real-device run-detail navigation and notification acceptance. No deployment or merge.