### PR TITLE
feat: consolidated chat, group and workflow App notification events

### DIFF
--- a/docs/app-business-events.md
+++ b/docs/app-business-events.md
@@ -1,0 +1,50 @@
+# Foreground App business-event subscriptions
+
+The in-process hub in `services/webhooks/business-events.ts` is shared by HTTP
+webhooks, existing social-message push and the App adapter. `observeChatRunWebhookEvent`
+is the backwards-compatible producer entry; it normalizes before publishing. Group
+Agent reply persistence publishes `group.message.created`; workflow socket's manager
+terminal callback verifies persisted run status before publishing
+`workflow.run.completed` / `workflow.run.failed`. A workflow node's chat event cannot
+become a workflow-terminal or ordinary single-chat App notification.
+
+## Wire contract v1
+
+On the existing authenticated `/chat-run` namespace, send `app.events.subscribe`
+with `{schema_version:1, profile:"default", types:[...]}`. Optional `session_ids`,
+`room_ids`, `workflow_ids` narrow the subscription. Empty/omitted profile resolves
+to `default` before authorization; omitted types select the supported App set.
+Unknown types and malformed filters are rejected. Ack is `{ok:true,schema_version:1}`.
+`app.events.unsubscribe` removes the selection. Disconnect removes the hub listener.
+Reconnect must explicitly resubscribe; there is no backlog or offline delivery.
+
+`app.event` carries `schema_version`, stable `id`, `type`, ISO `occurred_at`, `profile`,
+`source`, `subject` identifiers and bounded `display` title/preview/Agent/roster fields.
+Types: chat.run.completed/failed, chat.approval.requested/resolved,
+chat.clarification.requested/resolved, group.message.created,
+workflow.run.completed/failed. Interaction IDs remain in subject so requested and
+resolved update the same UI item even though their event IDs differ.
+
+JWT/account and current profile assignments are checked for every delivery. Group
+membership/visibility is also rechecked using the existing group access policy.
+Filters only narrow this authorization. Internal payloads are never sent verbatim.
+
+## Compatibility and channels
+
+New App sends `auth.appEventVersion=1`, subscribes on this single namespace and does
+not open legacy group/workflow notification listeners. Old clients retain the three
+legacy event names through a hub consumer. Version-1 clients never get both channels.
+An old server rejects the new command: new App records unsupported/denied and does
+not silently enable competing legacy channels. Deploy server before the App.
+
+LAN and manual-address connections use LocalAppRelayServer; cloud uses AppRelayClient.
+Both whitelist the two commands and forward the same namespace/auth/query/envelope.
+No new cloud binding, endpoint, APNs, OS push, or relay event-specific transport exists.
+
+HTTP consumers receive only the existing ChatRunWebhookEvent projection; assistant/
+user body switches and schemas remain unchanged. New group/workflow event types are
+not exposed as HTTP endpoint subscriptions in this change. Social push retains its
+original three event types, session push flag, recipient binding and generic message
+format; the new domains do not automatically expand social delivery. Consumers catch
+sync/async failures independently. App ignores snapshots, old events, canceled,
+interrupted and queued-continuation completions; UI preferences stay on the device.

--- a/docs/chat-chain-changes/2026-09-06-app-foreground-notifications.md
+++ b/docs/chat-chain-changes/2026-09-06-app-foreground-notifications.md
@@ -1,0 +1,3 @@
+# App foreground notifications
+
+Add profile-scoped `app.notification` events with stable request/run identities, generic kinds, resolution and emission timestamps. Exclude progress, aborts and queued continuations. No prompts or command content. Existing socket authentication and profile room isolation remain unchanged. Mobile clients must ignore snapshots/background replay and deduplicate per account/device.

--- a/docs/chat-chain-changes/2026-09-06-app-foreground-notifications.md
+++ b/docs/chat-chain-changes/2026-09-06-app-foreground-notifications.md
@@ -1,3 +1,11 @@
 # App foreground notifications
 
 Add profile-scoped `app.notification` events with stable request/run identities, generic kinds, resolution and emission timestamps. Exclude progress, aborts and queued continuations. No prompts or command content. Existing socket authentication and profile room isolation remain unchanged. Mobile clients must ignore snapshots/background replay and deduplicate per account/device.
+
+## Unified transport revision
+
+The new App companion negotiates schema 1 on the existing `/chat-run` namespace,
+receives only `app.event`, and delegates presentation to the existing local settings.
+See `docs/app-business-events.md` for event types, filters, compatibility and channel
+isolation. Legacy output is now a consumer of the same source, not assembled by the
+three business sockets. HTTP and social projection/scope are intentionally unchanged.

--- a/docs/chat-chain-changes/2026-09-06-group-foreground-notifications.md
+++ b/docs/chat-chain-changes/2026-09-06-group-foreground-notifications.md
@@ -1,0 +1,3 @@
+# Group foreground message notifications
+
+Broadcast bounded persisted Agent reply previews to authenticated sockets passing current room observation policy. No automatic room join, history replay, tool-token alerts or Workflow changes. Initial support is host-local room reply completion only; remote guest connections, approval/failure alerts and message-anchor navigation remain follow-up work. Companion App consumes app.group-notification.

--- a/docs/chat-chain-changes/2026-09-06-workflow-foreground-notifications.md
+++ b/docs/chat-chain-changes/2026-09-06-workflow-foreground-notifications.md
@@ -1,0 +1,3 @@
+# Workflow foreground result notifications
+
+Emit app.workflow-notification for persisted completed/failed whole runs only, dedupe per run ID, and recheck authenticated profile access at send time. No node/status snapshot replay, cancel alerts or approval notifications. Companion App opens exact run details. No raw error text or output is included in the initial compact version.

--- a/packages/server/src/modules/coding-agents/services/runtime/run-manager.ts
+++ b/packages/server/src/modules/coding-agents/services/runtime/run-manager.ts
@@ -3248,6 +3248,7 @@ export class CodingAgentRunManager {
     const workspaceRunChange = this.completeWorkspaceRunDiff(run)
     this.emitToChat(run.launch.sessionId, event, {
       ...(payload || { event }),
+      run_id: typeof payload?.run_id === 'string' && payload.run_id ? payload.run_id : run.id,
       ...(run.assistantMessageId ? { message_id: run.assistantMessageId } : {}),
       ...(queueRemaining > 0 ? { queue_remaining: queueRemaining } : {}),
       workspace_run_change: workspaceRunChange,

--- a/packages/server/src/modules/studio/repositories/session-store.ts
+++ b/packages/server/src/modules/studio/repositories/session-store.ts
@@ -374,6 +374,22 @@ export function getSession(id: string): HermesSessionRow | null {
   return row ? mapSessionRow(row) : null
 }
 
+/** Bounded notification text; never materialize full chat history or tool output. */
+export function getSessionNotificationPreview(id: string): { title: string; preview: string } | null {
+  if (!isSqliteAvailable()) return null
+  const row = getDb()!.prepare(`
+    SELECT SUBSTR(COALESCE(NULLIF(s.title, ''), NULLIF(s.preview, ''),
+      (SELECT SUBSTR(m.content, 1, 63) FROM ${MESSAGES_TABLE} m
+       WHERE m.session_id = s.id AND m.role = 'user' AND m.content != ''
+       ORDER BY m.timestamp, m.id LIMIT 1), ''), 1, 120) AS title,
+      COALESCE((SELECT SUBSTR(COALESCE(NULLIF(m.display_content, ''), m.content), 1, 240)
+       FROM ${MESSAGES_TABLE} m WHERE m.session_id = s.id AND m.role = 'assistant' AND m.content != ''
+       ORDER BY m.timestamp DESC, m.id DESC LIMIT 1), '') AS preview
+    FROM ${SESSIONS_TABLE} s WHERE s.id = ?
+  `).get(id) as { title: string; preview: string } | undefined
+  return row || null
+}
+
 /** Session and branch metadata without loading this session's message bodies. */
 export function getSessionMetadata(id: string): HermesSessionRow | null {
   if (!isSqliteAvailable()) return null

--- a/packages/server/src/modules/studio/services/app-relay/client.ts
+++ b/packages/server/src/modules/studio/services/app-relay/client.ts
@@ -44,6 +44,8 @@ const ALLOWED_GROUP_AGENT_CLIENT_EVENTS = new Set([
   'run.accepted', 'run.completed', 'run.failed', 'agent.event', 'agent.events', 'agent.config.update', 'attachment.read', 'connector.revoke',
 ])
 const ALLOWED_CHAT_RUN_CLIENT_EVENTS = new Set([
+  'app.events.subscribe',
+  'app.events.unsubscribe',
   'run',
   'resume',
   'app.resume',

--- a/packages/server/src/modules/studio/services/app-relay/server.ts
+++ b/packages/server/src/modules/studio/services/app-relay/server.ts
@@ -47,6 +47,8 @@ const ALLOWED_REQUEST_HEADERS = new Set([
   'x-request-id',
 ])
 const ALLOWED_CHAT_RUN_CLIENT_EVENTS = new Set([
+  'app.events.subscribe',
+  'app.events.unsubscribe',
   'run',
   'resume',
   'app.resume',

--- a/packages/server/src/modules/studio/services/chat-run/foreground-notification.ts
+++ b/packages/server/src/modules/studio/services/chat-run/foreground-notification.ts
@@ -1,0 +1,38 @@
+/** Payload deliberately excludes prompts, commands, credentials and message text. */
+export function foregroundNotification(event: string, value: Record<string, unknown>, now = Date.now()) {
+  const sessionId = typeof value.session_id === 'string' ? value.session_id : ''
+  if (!sessionId || value.replayed === true || value.restored === true || value.background_snapshot === true) return null
+  if (event.endsWith('.resolved') && (value.resolved === false || value.stale === true)) return null
+  const requestKind = event.startsWith('approval.') ? 'approval' : event.startsWith('clarify.') ? 'clarify' : ''
+  const id = requestKind ? value[`${requestKind}_id`] : value.run_id
+  if (typeof id !== 'string' || !id) return null
+  if (requestKind && (event.endsWith('.requested') || event.endsWith('.resolved'))) {
+    return { id: `${sessionId}:${requestKind}:${id}`, sessionId, kind: 'approval', resolved: event.endsWith('.resolved'), timestamp: now }
+  }
+  if (!['run.completed', 'run.failed'].includes(event) || Number(value.queue_remaining || 0) > 0
+    || value.interrupted === true || value.stop_reason === 'queue_insertion' || value.stop_reason === 'aborted') return null
+  return { id: `${sessionId}:run:${id}`, sessionId, kind: event === 'run.failed' ? 'failure' : 'completion', resolved: false, timestamp: now }
+}
+
+/** Only short user-visible text; never serialize commands, tool results or raw errors. */
+export function foregroundNotificationPreview(
+  kind: string,
+  session: { title?: string | null; preview?: string | null } | null,
+  payload: Record<string, unknown>,
+) {
+  const plain = (value: unknown, limit: number) => typeof value === 'string'
+    ? value.replace(/[\u0000-\u001f\u007f]/g, ' ').replace(/\s+/g, ' ').trim().slice(0, limit) : ''
+  return {
+    title: plain(session?.title, 120),
+    content: kind === 'completion' ? plain(payload.output || session?.preview, 240) : '',
+  }
+}
+
+/** Stable identity only, never accept an image URL from a notification payload. */
+export function foregroundNotificationAgent(value: unknown): string {
+  if (typeof value !== 'string') return ''
+  const agent = value.toLowerCase().trim()
+  if (agent === 'claude' || agent === 'claude-code') return 'claude-code'
+  if (agent === 'ekko' || agent === 'ekko-agent') return 'ekko-agent'
+  return ['hermes', 'codex', 'pi', 'grok', 'opencode'].includes(agent) ? agent : ''
+}

--- a/packages/server/src/modules/studio/services/group-chat/foreground-notification.ts
+++ b/packages/server/src/modules/studio/services/group-chat/foreground-notification.ts
@@ -1,0 +1,10 @@
+export function groupReplyNotification(room: { id: string; name: string }, message: {
+  id: string; senderName: string; senderType?: string; role?: string; content: string; finish_reason?: string | null
+}, now = Date.now()) {
+  if (message.senderType !== 'agent' || message.role !== 'assistant' || !message.content.trim()
+    || ['tool_calls', 'cancelled', 'aborted', 'error'].includes(message.finish_reason || '')) return null
+  const text = (s: string, limit: number) => s.replace(/[\u0000-\u001f\u007f]/g, ' ').replace(/\s+/g,' ').trim().slice(0,limit)
+  return { id: `group:${room.id}:message:${message.id}`, target:'group', roomId:room.id, messageId:message.id,
+    title:text(room.name,120), content:`${text(message.senderName,60)}: ${text(message.content,180)}`,
+    kind:'completion', resolved:false, timestamp:now }
+}

--- a/packages/server/src/modules/studio/services/webhooks/app-events.ts
+++ b/packages/server/src/modules/studio/services/webhooks/app-events.ts
@@ -1,0 +1,120 @@
+import type { Socket } from 'socket.io'
+import { randomUUID } from 'crypto'
+import { businessEvents, APP_BUSINESS_TYPES, type BusinessEvent } from './business-events'
+import { stableChatWebhookEventId } from './envelope'
+import { authenticateUserToken, type AuthenticatedUser } from '../../public/auth'
+import { listUserProfiles } from '../../repositories/users-store'
+import { getSession, getSessionNotificationPreview } from '../../repositories/session-store'
+import { groupReplyNotification } from '../group-chat/foreground-notification'
+import { foregroundNotification, foregroundNotificationAgent, foregroundNotificationPreview } from '../chat-run/foreground-notification'
+
+interface Subscription { profile: string; types: string[]; sessionIds: string[]; roomIds: string[]; workflowIds: string[] }
+interface GroupAccess { canReceive(user: AuthenticatedUser, roomId: string): boolean }
+let groupAccess: GroupAccess | null = null
+export function registerGroupEventAccess(access: GroupAccess): () => void {
+  groupAccess = access
+  return () => { if (groupAccess === access) groupAccess = null }
+}
+function allowed(user: AuthenticatedUser, profile: string): boolean {
+  return user.role === 'super_admin' || listUserProfiles(user.id).some(item => item.profile_name === profile)
+}
+function ids(value: unknown): string[] {
+  if (value === undefined) return []
+  if (!Array.isArray(value) || value.length > 100 || value.some(v => typeof v !== 'string' || !v || v.length > 512)) throw new Error('invalid subscription filter')
+  return value
+}
+export function parseAppSubscription(value: unknown): Subscription {
+  const p = value && typeof value === 'object' ? value as Record<string, unknown> : {}
+  if (p.schema_version !== 1) throw new Error('unsupported event schema')
+  const profile = typeof p.profile === 'string' ? p.profile.trim() || 'default' : 'default'
+  const types = p.types === undefined ? [...APP_BUSINESS_TYPES] : ids(p.types)
+  if (types.some(t => !(APP_BUSINESS_TYPES as readonly string[]).includes(t))) throw new Error('unsupported event type')
+  return { profile, types, sessionIds: ids(p.session_ids), roomIds: ids(p.room_ids), workflowIds: ids(p.workflow_ids) }
+}
+export function appEventEnvelope(event: BusinessEvent) {
+  if (event.type.startsWith('chat.')) {
+    if (event.source === 'group_chat' || event.source === 'workflow') return null
+    const name = event.type.replace('chat.clarification.', 'clarify.').replace(/^chat\./, '')
+    const payload = { ...event.payload, session_id: event.subject.session_id }
+    const notice = foregroundNotification(name, payload)
+    if (!notice) return null
+    const session = getSession(notice.sessionId)
+    if (!session || (session.profile || 'default') !== event.profile || session.source === 'group_chat' || session.source === 'workflow') return null
+    return { schema_version: 1, id: event.id, type: event.type, occurred_at: event.occurred_at,
+      profile: event.profile, source: event.source, subject: event.subject,
+      display: { ...foregroundNotificationPreview(notice.kind, getSessionNotificationPreview(notice.sessionId) || session, payload), agent: foregroundNotificationAgent(session.agent) } }
+  }
+  if (event.type === 'group.message.created') {
+    const room = event.payload.room as {id:string;name:string}
+    const message = event.payload.message as Parameters<typeof groupReplyNotification>[1]
+    if (!room || !message) return null
+    const notice = groupReplyNotification(room, message, Date.parse(event.occurred_at))
+    if (!notice) return null
+    const agents = Array.isArray(event.payload.agents) ? event.payload.agents as Array<Record<string, unknown>> : []
+    const visible = agents.length > 4 ? agents.slice(0,3) : agents.slice(0,4)
+    return { schema_version: 1, id:event.id,type:event.type,occurred_at:event.occurred_at,profile:event.profile,source:event.source,subject:event.subject,
+      display: { title:notice.title,preview:notice.content,agentCount:agents.length,
+        agents:visible.map(agent=>({id:String(agent.id || ''),name:String(agent.name || '').slice(0,80),agent:String(agent.agent || ''),avatar:typeof agent.avatar === 'string' && agent.avatar.length <= 65536 ? agent.avatar : ''})) } }
+  }
+  if (!(APP_BUSINESS_TYPES as readonly string[]).includes(event.type)) return null
+  return { schema_version: 1, id: event.id, type: event.type, occurred_at: event.occurred_at,
+    profile: event.profile, source: event.source, subject: event.subject, display: event.payload.display }
+}
+/** One subscription per authenticated socket; local/manual/cloud use the same command. */
+export function bindAppEventSubscription(socket: Socket): void {
+  let subscription: Subscription | null = null
+  let revision = 0
+  let closed = false
+  let pending = 0
+  let chain = Promise.resolve()
+  const seen = new Set<string>()
+  const token = String(socket.handshake.auth?.token || '')
+  socket.on('app.events.subscribe', async (input: unknown, ack?: (result: unknown) => void) => {
+    const ticket = ++revision
+    subscription = null
+    try {
+      const request = parseAppSubscription(input)
+      const user = await authenticateUserToken(token)
+      if (!user || !allowed(user, request.profile)) throw new Error('Profile access denied')
+      if (closed || ticket !== revision) return
+      subscription = request
+      socket.data.appEventVersion = 1
+      ack?.({ ok: true, schema_version: 1 })
+    } catch { if (!closed && ticket === revision) ack?.({ ok: false, error: 'event_subscription_denied' }) }
+  })
+  socket.on('app.events.unsubscribe', (_input: unknown, ack?: (result: unknown) => void) => {
+    revision++; subscription = null; ack?.({ ok: true })
+  })
+  const stop = businessEvents.subscribe(`app:${socket.id}:${randomUUID()}`, event => {
+    const request = subscription, ticket = revision
+    if (closed || !request || !request.types.includes(event.type) || pending >= 100) return
+    if (event.source !== 'group_chat' && request.profile !== event.profile) return
+    const selected = event.subject.room_id ? request.roomIds : event.subject.workflow_id ? request.workflowIds : request.sessionIds
+    const subjectId = event.subject.room_id || event.subject.workflow_id || event.subject.session_id || ''
+    if (selected.length && !selected.includes(subjectId)) return
+    pending++
+    chain = chain.then(async () => {
+      if (closed || revision !== ticket || subscription !== request || seen.has(event.id)) return
+      // Revalidate JWT/account and current profile/membership on every delivery.
+      const user = await authenticateUserToken(token)
+      if (!user || !allowed(user, request.profile)) return
+      if (event.source === 'group_chat' && (!event.subject.room_id || !groupAccess?.canReceive(user, event.subject.room_id))) return
+      if (event.source !== 'group_chat' && !allowed(user, event.profile)) return
+      const envelope = appEventEnvelope(event)
+      if (!envelope || closed || revision !== ticket) return
+      seen.add(event.id); if (seen.size > 2000) seen.delete(seen.values().next().value!)
+      socket.emit('app.event', envelope)
+    }).catch(() => {}).finally(() => { pending-- })
+  })
+  socket.on('disconnect', () => { closed = true; revision++; subscription = null; stop(); seen.clear() })
+}
+export function publishDomainEvent(type: 'group.message.created' | 'workflow.run.completed' | 'workflow.run.failed', profile: string,
+  subject: BusinessEvent['subject'], display: Record<string, unknown>): void {
+  const identity = type === 'group.message.created' ? `${subject.room_id}:${subject.message_id}` : `${subject.workflow_id}:${subject.run_id}`
+  businessEvents.publish({ schema_version: 1, id: stableChatWebhookEventId(`${type}:${identity}`), type,
+    occurred_at: new Date().toISOString(), profile: profile?.trim() || 'default', source: type.startsWith('group.') ? 'group_chat' : 'workflow', subject, payload: { display } })
+}
+
+export function publishGroupMessage(room: {id:string;name:string;summaryProfile:string}, message: Record<string, unknown>, agents: unknown[]): void {
+  businessEvents.publish({schema_version:1,id:stableChatWebhookEventId(`group.message.created:${room.id}:${message.id}`),type:'group.message.created',occurred_at:new Date().toISOString(),profile:room.summaryProfile?.trim() || 'default',source:'group_chat',subject:{room_id:room.id,message_id:String(message.id)},payload:{room:{id:room.id,name:room.name},message,agents}})
+}

--- a/packages/server/src/modules/studio/services/webhooks/business-consumers.ts
+++ b/packages/server/src/modules/studio/services/webhooks/business-consumers.ts
@@ -1,0 +1,16 @@
+import { businessEvents } from './business-events'
+import { getChatWebhookDispatcher } from './dispatcher'
+import { notifySessionPush } from '../../public/social-messages'
+
+const SOCIAL_EVENTS = new Set(['chat.run.completed', 'chat.approval.requested', 'chat.clarification.requested'])
+let initialized = false
+export function ensureBusinessConsumers(): void {
+  if (initialized) return
+  initialized = true
+  businessEvents.subscribe('http-webhook', event => event.chat ? getChatWebhookDispatcher().enqueue(event.chat) : false)
+  businessEvents.subscribe('social-messages', event => {
+    if (!event.chat || !SOCIAL_EVENTS.has(event.type)) return
+    const original = event.type === 'chat.clarification.requested' ? 'clarify.requested' : event.type.slice(5)
+    return notifySessionPush(event.subject.session_id!, original, event.payload, event.chat.agent)
+  })
+}

--- a/packages/server/src/modules/studio/services/webhooks/business-events.ts
+++ b/packages/server/src/modules/studio/services/webhooks/business-events.ts
@@ -1,0 +1,44 @@
+import type { ChatRunWebhookEvent } from './envelope'
+
+export const APP_BUSINESS_TYPES = [
+  'chat.run.completed', 'chat.run.failed', 'chat.approval.requested', 'chat.approval.resolved',
+  'chat.clarification.requested', 'chat.clarification.resolved', 'group.message.created',
+  'workflow.run.completed', 'workflow.run.failed',
+] as const
+export type AppBusinessType = typeof APP_BUSINESS_TYPES[number]
+export interface BusinessEvent {
+  schema_version: 1
+  id: string
+  type: string
+  occurred_at: string
+  profile: string
+  source: string
+  subject: { session_id?: string; run_id?: string; room_id?: string; message_id?: string; workflow_id?: string; approval_id?: string; clarification_id?: string }
+  /** Internal source data. Never sent directly to App or HTTP subscribers. */
+  payload: Record<string, unknown>
+  chat?: ChatRunWebhookEvent
+}
+type Consumer = (event: BusinessEvent) => unknown
+export function createBusinessEventHub(onError: (name: string) => void = () => {}) {
+  const consumers = new Map<string, Consumer>()
+  return {
+    subscribe(name: string, consumer: Consumer) {
+      consumers.set(name, consumer)
+      return () => { if (consumers.get(name) === consumer) consumers.delete(name) }
+    },
+    publish(event: BusinessEvent) {
+      let accepted = false
+      for (const [name, consume] of consumers) {
+        try {
+          const result = consume(event)
+          if (result === true) accepted = true
+          if (result && typeof (result as Promise<unknown>).then === 'function') {
+            void Promise.resolve(result).catch(() => onError(name))
+          }
+        } catch { onError(name) }
+      }
+      return accepted
+    },
+  }
+}
+export const businessEvents = createBusinessEventHub(name => console.warn('[business-events] consumer failed:', name))

--- a/packages/server/src/modules/studio/services/webhooks/index.ts
+++ b/packages/server/src/modules/studio/services/webhooks/index.ts
@@ -1,7 +1,6 @@
 import { randomUUID } from 'crypto'
-import { getChatWebhookDispatcher } from './dispatcher'
-import { logger } from '../../public/logging'
-import { notifySessionPush } from '../../public/social-messages'
+import { businessEvents } from './business-events'
+import { ensureBusinessConsumers } from './business-consumers'
 import {
   stableChatWebhookEventId,
   truncateChatWebhookContent,
@@ -67,12 +66,6 @@ const EVENT_MAPPING: Record<string, { type: ChatWebhookEventType; status: ChatWe
   'run.failed': { type: 'chat.run.failed', status: 'failed' },
 }
 
-const SESSION_PUSH_EVENTS = new Set([
-  'run.completed',
-  'approval.requested',
-  'clarify.requested',
-])
-
 function messageRole(value: unknown): ChatWebhookMessageRole {
   return value === 'command' ? 'command' : value === 'assistant' ? 'assistant' : 'user'
 }
@@ -107,7 +100,7 @@ export function observeChatRunWebhookEvent(input: ObserveChatRunWebhookEventInpu
   const toolCallId = identifierValue(payload.tool_call_id) || identifierValue(payload.call_id)
   const approvalId = identifierValue(payload.approval_id)
   const clarificationId = identifierValue(payload.clarify_id)
-  const occurrenceKey = messageId || toolCallId || approvalId || clarificationId || runId || queueId || randomUUID()
+  const occurrenceKey = approvalId || clarificationId || (input.event.startsWith('run.') ? runId || queueId || messageId : messageId || toolCallId || runId || queueId) || randomUUID()
   const dedupeKey = `${mapping.type}:${sessionId}:${occurrenceKey}`
   const rawContent = input.event === 'run.completed'
     ? stringValue(payload.output)
@@ -159,12 +152,9 @@ export function observeChatRunWebhookEvent(input: ObserveChatRunWebhookEventInpu
     content_truncated: content.truncated,
     content_role: input.event === 'message.created' ? role : input.event === 'run.completed' ? 'assistant' : undefined,
   }
-  if (SESSION_PUSH_EVENTS.has(input.event)) {
-    void notifySessionPush(sessionId, input.event, payload, input.agent).catch(error => {
-      logger.warn({ error, sessionId, event: input.event }, '[chat-webhooks] failed to dispatch session push')
-    })
-  }
-  return getChatWebhookDispatcher().enqueue(event)
+  ensureBusinessConsumers()
+  return businessEvents.publish({ schema_version: 1, id: event.id, type: event.type, occurred_at: event.occurred_at,
+    profile: event.profile.trim() || 'default', source: event.source, subject: event.subject, payload, chat: event })
 }
 
 export * from './dispatcher'

--- a/packages/server/src/modules/studio/services/webhooks/legacy-app-events.ts
+++ b/packages/server/src/modules/studio/services/webhooks/legacy-app-events.ts
@@ -1,0 +1,46 @@
+import type { Socket } from 'socket.io'
+import { appEventEnvelope } from './app-events'
+import { authenticateUserToken } from '../../public/auth'
+import { businessEvents, type BusinessEvent } from './business-events'
+
+/** Compatibility projection for old clients; new clients use only /chat-run app.event. */
+export function bindLegacyAppEvents(socket: Socket, kind: 'chat' | 'group' | 'workflow', canReceive: (event: BusinessEvent) => boolean): void {
+  const name = `legacy-app:${kind}:${socket.id}`
+  const seen = new Set<string>()
+  let closed = false
+  let chain = Promise.resolve()
+  const deliver = (event: BusinessEvent) => {
+    if (closed || socket.data.appEventVersion === 1 || socket.handshake.auth?.appEventVersion === 1 || !canReceive(event)) return
+    if (kind === 'chat' && !event.type.startsWith('chat.')) return
+    if (kind === 'group' && event.type !== 'group.message.created') return
+    if (kind === 'workflow' && !event.type.startsWith('workflow.run.')) return
+    const envelope = appEventEnvelope(event)
+    if (!envelope || seen.has(event.id)) return
+    seen.add(event.id); if (seen.size > 2000) seen.delete(seen.values().next().value!)
+    const d = envelope.display as Record<string, unknown>
+    const common = { title:d.title,content:d.preview ?? d.content,agent:d.agent,profile:event.profile,timestamp:Date.parse(event.occurred_at),resolved:event.type.endsWith('.resolved'),kind:event.type.endsWith('.failed')?'failure':'completion' }
+    if (kind === 'chat') {
+      const interaction = event.subject.approval_id || event.subject.clarification_id
+      socket.emit('app.notification',{...common,sessionId:event.subject.session_id,
+        id:interaction?`${event.subject.session_id}:${event.subject.approval_id?'approval':'clarify'}:${interaction}`:`${event.subject.session_id}:run:${event.subject.run_id}`,
+        kind:interaction?'approval':common.kind})
+    } else if (kind === 'group') {
+      socket.emit('app.group-notification',{...common,id:`group:${event.subject.room_id}:message:${event.subject.message_id}`,target:'group',roomId:event.subject.room_id,messageId:event.subject.message_id,agents:d.agents,agentCount:d.agentCount})
+    } else {
+      socket.emit('app.workflow-notification',{...common,id:`workflow:${event.subject.workflow_id}:run:${event.subject.run_id}`,target:'workflow',workflowId:event.subject.workflow_id,runId:event.subject.run_id})
+    }
+  }
+  const stop = businessEvents.subscribe(name, event => {
+    if (closed || socket.handshake.auth?.appEventVersion === 1 || socket.data.appEventVersion === 1) return
+    const token = socket.handshake.auth?.token
+    if (typeof token !== 'string' || !token) { deliver(event); return }
+    chain = chain.then(async () => {
+      const user = await authenticateUserToken(token)
+      if (!user || closed) return
+      socket.data.user = user
+      if (kind === 'group') socket.data.authUser = user
+      deliver(event)
+    }).catch(() => {})
+  })
+  socket.on('disconnect',()=>{closed=true;stop();seen.clear()})
+}

--- a/packages/server/src/modules/studio/sockets/chat-run.ts
+++ b/packages/server/src/modules/studio/sockets/chat-run.ts
@@ -1,3 +1,4 @@
+import { foregroundNotification, foregroundNotificationPreview, foregroundNotificationAgent } from '../services/chat-run/foreground-notification'
 import { mobileDeviceRoom, mobileDeviceId, sameMobileDevice, mobileEventAllowed, type MobileDeviceTarget } from '../services/chat-run/mobile-device-target'
 /**
  * ChatRunSocket — Socket.IO namespace /chat-run.
@@ -12,7 +13,7 @@ import type { Server, Socket } from 'socket.io'
 import { randomUUID } from 'crypto'
 import { logger } from '../public/logging'
 import { getSystemPrompt } from '../public/runs/prompt'
-import { clearSessionMessages, deleteSession, getSession, getSessionMetadata, listSessions, updateMessageDisplayContent } from '../repositories/session-store'
+import { clearSessionMessages, deleteSession, getSessionNotificationPreview, getSession, getSessionMetadata, listSessions, updateMessageDisplayContent } from '../repositories/session-store'
 import { listWorkspaceRunChangesForAssistantMessages } from '../repositories/workspace-run-changes-store'
 import { getSessionCategory } from '../repositories/session-category-store'
 import { getActiveProfileName, getProfileDir, listProfileNamesFromDisk } from '../public/profile-config'
@@ -2374,7 +2375,7 @@ export class ChatRunSocket {
       workflowNodeId: state?.webhookWorkflowNodeId,
     })
     this.observePetEvent(profile, event, tagged)
-    this.emitSessionActivity(profile, event, tagged)
+    this.emitPendingInteraction(profile, event, tagged)
     if (state?.isWorking) {
       state.events.push({ event, data: tagged })
       if (state.events.length > 200) state.events.splice(0, state.events.length - 200)
@@ -2620,6 +2621,12 @@ export class ChatRunSocket {
 
   private emitPendingInteraction(profile: string, event: string, payload: any) {
     this.emitSessionActivity(profile, event, payload)
+    const notification = foregroundNotification(event, payload || {})
+    const notificationSession = notification ? getSession(notification.sessionId) : null
+    // Group/workflow navigation is a separate contract; do not misroute it as single chat.
+    if (notification && notificationSession?.source !== 'group_chat' && notificationSession?.source !== 'workflow') {
+      this.nsp.to(`pending-interactions:${profile}`).emit('app.notification', { ...notification, agent: foregroundNotificationAgent(notificationSession?.agent), ...foregroundNotificationPreview(notification.kind, getSessionNotificationPreview(notification.sessionId) || notificationSession, payload || {}), profile })
+    }
     if (event !== 'approval.requested' && event !== 'approval.resolved'
       && event !== 'clarify.requested' && event !== 'clarify.resolved'
       && event !== 'location.requested' && event !== 'location.resolved'

--- a/packages/server/src/modules/studio/sockets/chat-run.ts
+++ b/packages/server/src/modules/studio/sockets/chat-run.ts
@@ -1,4 +1,5 @@
-import { foregroundNotification, foregroundNotificationPreview, foregroundNotificationAgent } from '../services/chat-run/foreground-notification'
+import { bindLegacyAppEvents } from '../services/webhooks/legacy-app-events'
+import { bindAppEventSubscription } from '../services/webhooks/app-events'
 import { mobileDeviceRoom, mobileDeviceId, sameMobileDevice, mobileEventAllowed, type MobileDeviceTarget } from '../services/chat-run/mobile-device-target'
 /**
  * ChatRunSocket — Socket.IO namespace /chat-run.
@@ -13,7 +14,7 @@ import type { Server, Socket } from 'socket.io'
 import { randomUUID } from 'crypto'
 import { logger } from '../public/logging'
 import { getSystemPrompt } from '../public/runs/prompt'
-import { clearSessionMessages, deleteSession, getSessionNotificationPreview, getSession, getSessionMetadata, listSessions, updateMessageDisplayContent } from '../repositories/session-store'
+import { clearSessionMessages, deleteSession, getSession, getSessionMetadata, listSessions, updateMessageDisplayContent } from '../repositories/session-store'
 import { listWorkspaceRunChangesForAssistantMessages } from '../repositories/workspace-run-changes-store'
 import { getSessionCategory } from '../repositories/session-category-store'
 import { getActiveProfileName, getProfileDir, listProfileNamesFromDisk } from '../public/profile-config'
@@ -549,7 +550,7 @@ export class ChatRunSocket {
     if (!user) {
       return next(new Error('Authentication failed'))
     }
-    const socketProfile = String(socket.handshake.query?.profile || '').trim()
+    const socketProfile = String(socket.handshake.query?.profile || 'default').trim() || 'default'
     if (socketProfile && !this.canAccessProfile(user, socketProfile)) {
       return next(new Error('Profile access denied'))
     }
@@ -560,6 +561,12 @@ export class ChatRunSocket {
   // --- Connection handler ---
 
   private onConnection(socket: Socket) {
+    bindAppEventSubscription(socket)
+    bindLegacyAppEvents(socket, 'chat', event => {
+      const user = socket.data.user as AuthenticatedUser | undefined
+      return Boolean(user && this.canAccessProfile(user, event.profile)
+        && socket.rooms.has(`pending-interactions:${event.profile}`))
+    })
     const socketUser = socket.data.user as AuthenticatedUser | undefined
     const socketProfile = (socket.handshake.query?.profile as string) || 'default'
     const currentProfile = () => socketProfile || getActiveProfileName() || 'default'
@@ -2621,12 +2628,6 @@ export class ChatRunSocket {
 
   private emitPendingInteraction(profile: string, event: string, payload: any) {
     this.emitSessionActivity(profile, event, payload)
-    const notification = foregroundNotification(event, payload || {})
-    const notificationSession = notification ? getSession(notification.sessionId) : null
-    // Group/workflow navigation is a separate contract; do not misroute it as single chat.
-    if (notification && notificationSession?.source !== 'group_chat' && notificationSession?.source !== 'workflow') {
-      this.nsp.to(`pending-interactions:${profile}`).emit('app.notification', { ...notification, agent: foregroundNotificationAgent(notificationSession?.agent), ...foregroundNotificationPreview(notification.kind, getSessionNotificationPreview(notification.sessionId) || notificationSession, payload || {}), profile })
-    }
     if (event !== 'approval.requested' && event !== 'approval.resolved'
       && event !== 'clarify.requested' && event !== 'clarify.resolved'
       && event !== 'location.requested' && event !== 'location.resolved'

--- a/packages/server/src/modules/studio/sockets/group-chat.ts
+++ b/packages/server/src/modules/studio/sockets/group-chat.ts
@@ -1,3 +1,4 @@
+import { groupReplyNotification } from '../services/group-chat/foreground-notification'
 import { Server, Socket, Namespace } from 'socket.io'
 import type { Server as HttpServer } from 'http'
 import { mkdirSync } from 'fs'
@@ -3322,6 +3323,27 @@ export class GroupChatServer {
             : []
     }
 
+    private readonly notifiedGroupMessages = new Set<string>()
+
+    private notifyGroupReply(roomId: string, message: ChatMessage): void {
+        const room = this.storage.getRoom(roomId)
+        if (!room) return
+        const notice = groupReplyNotification(room, message)
+        if (!notice || this.notifiedGroupMessages.has(notice.id)) return
+        this.notifiedGroupMessages.add(notice.id)
+        if (this.notifiedGroupMessages.size > 2000) this.notifiedGroupMessages.delete(this.notifiedGroupMessages.values().next().value!)
+        for (const socket of this.nsp.sockets.values()) {
+            // Recheck membership/permissions at emission time, not just on connect.
+            if (this.canSocketObserveRoom(socket, roomId)) {
+                const agents = this.storage.getRoomAgents(roomId)
+                const visible = agents.length > 4 ? agents.slice(0, 3) : agents.slice(0, 4)
+                socket.emit('app.group-notification', { ...notice, agentCount: agents.length,
+                    agents: visible.map(agent => ({ id: agent.id, name: agent.name.slice(0, 80), agent: agent.agent,
+                        avatar: typeof agent.avatar === 'string' && agent.avatar.length <= 65536 ? agent.avatar : '' })) })
+            }
+        }
+    }
+
     private broadcastExecutionQueue(roomId: string): void {
         this.nsp.to(roomId).emit('execution_queue_updated', {
             roomId,
@@ -4609,6 +4631,7 @@ export class GroupChatServer {
         const totalTokens = saved.totalTokens
 
         this.nsp.to(roomId).emit('message', buildOutboundGroupMessage(savedMsg))
+        this.notifyGroupReply(roomId, savedMsg)
         this.nsp.to(roomId).emit('room_updated', { roomId, totalTokens })
         ack?.({ id: savedMsg.id })
 

--- a/packages/server/src/modules/studio/sockets/group-chat.ts
+++ b/packages/server/src/modules/studio/sockets/group-chat.ts
@@ -1,4 +1,5 @@
-import { groupReplyNotification } from '../services/group-chat/foreground-notification'
+import { bindLegacyAppEvents } from '../services/webhooks/legacy-app-events'
+import { publishGroupMessage, registerGroupEventAccess } from '../services/webhooks/app-events'
 import { Server, Socket, Namespace } from 'socket.io'
 import type { Server as HttpServer } from 'http'
 import { mkdirSync } from 'fs'
@@ -3259,6 +3260,10 @@ export class GroupChatServer {
         })
         servers.slice(1).forEach((httpServer) => this.io.attach(httpServer))
         this.nsp = this.io.of('/group-chat')
+        const removeGroupEventAccess = registerGroupEventAccess({ canReceive: (user, roomId) => this.canSocketObserveRoom({
+            id: '', data: { authUser: user },
+        } as unknown as Socket, roomId) })
+        for (const server of servers) server.once('close', removeGroupEventAccess)
         this.nsp.use(this.authMiddleware.bind(this))
         this.nsp.on('connection', this.onConnection.bind(this))
 
@@ -3328,20 +3333,11 @@ export class GroupChatServer {
     private notifyGroupReply(roomId: string, message: ChatMessage): void {
         const room = this.storage.getRoom(roomId)
         if (!room) return
-        const notice = groupReplyNotification(room, message)
-        if (!notice || this.notifiedGroupMessages.has(notice.id)) return
-        this.notifiedGroupMessages.add(notice.id)
+        // Publish persisted message facts; the App adapter chooses which replies notify.
+        if (this.notifiedGroupMessages.has(message.id)) return
+        this.notifiedGroupMessages.add(message.id)
         if (this.notifiedGroupMessages.size > 2000) this.notifiedGroupMessages.delete(this.notifiedGroupMessages.values().next().value!)
-        for (const socket of this.nsp.sockets.values()) {
-            // Recheck membership/permissions at emission time, not just on connect.
-            if (this.canSocketObserveRoom(socket, roomId)) {
-                const agents = this.storage.getRoomAgents(roomId)
-                const visible = agents.length > 4 ? agents.slice(0, 3) : agents.slice(0, 4)
-                socket.emit('app.group-notification', { ...notice, agentCount: agents.length,
-                    agents: visible.map(agent => ({ id: agent.id, name: agent.name.slice(0, 80), agent: agent.agent,
-                        avatar: typeof agent.avatar === 'string' && agent.avatar.length <= 65536 ? agent.avatar : '' })) })
-            }
-        }
+        publishGroupMessage(room, message as unknown as Record<string, unknown>, this.storage.getRoomAgents(roomId))
     }
 
     private broadcastExecutionQueue(roomId: string): void {
@@ -3902,6 +3898,7 @@ export class GroupChatServer {
     // ─── Connection ─────────────────────────────────────────────
 
     private onConnection(socket: Socket): void {
+        bindLegacyAppEvents(socket, 'group', event => Boolean(event.subject.room_id && this.canSocketObserveRoom(socket, event.subject.room_id)))
         const auth = socket.handshake.auth as { userId?: string; name?: string; description?: string; source?: string; agentSocketSecret?: string; authUserId?: number }
         const requestedSource = auth.source === 'agent' && auth.agentSocketSecret === GROUP_CHAT_AGENT_SOCKET_SECRET ? 'agent' : 'human'
         const authenticatedUser = socket.data.authUser as AuthenticatedUser | undefined

--- a/packages/server/src/modules/studio/sockets/workflow.ts
+++ b/packages/server/src/modules/studio/sockets/workflow.ts
@@ -61,6 +61,7 @@ export class WorkflowSocketServer {
   private readonly nsp: ReturnType<Server['of']>
   private readonly manager: WorkflowManager
   private readonly removeStatusListener: () => void
+  private readonly notifiedRuns = new Set<string>()
 
   constructor(io: Server, manager: WorkflowManager = getWorkflowManager()) {
     this.manager = manager
@@ -191,7 +192,26 @@ export class WorkflowSocketServer {
 
   private emitRuntimeStatus(status: WorkflowRuntimeStatus): void {
     try {
-      this.nsp.to(this.workflowRoom(status.workflowId)).emit('workflow.status.updated', this.statusWithEvidence(status))
+      const snapshot = this.statusWithEvidence(status)
+      this.nsp.to(this.workflowRoom(status.workflowId)).emit('workflow.status.updated', snapshot)
+      if (!status.runId || !snapshot.run || !['completed', 'failed'].includes(status.status)
+        || snapshot.run.status !== status.status || this.notifiedRuns.has(status.runId)) return
+      const workflow = this.manager.get(status.workflowId)
+      if (!workflow) return
+      this.notifiedRuns.add(status.runId)
+      if (this.notifiedRuns.size > 2000) this.notifiedRuns.delete(this.notifiedRuns.values().next().value!)
+      const notice = {
+        id: `workflow:${status.workflowId}:run:${status.runId}`, target: 'workflow',
+        workflowId: status.workflowId, runId: status.runId, profile: workflow.profile || 'default',
+        title: workflow.name.slice(0, 120), kind: status.status === 'failed' ? 'failure' : 'completion',
+        resolved: false, timestamp: Date.now(),
+      }
+      for (const socket of this.nsp.sockets.values()) {
+        const user = socket.data.user as AuthenticatedUser | undefined
+        // Foreground notifications require authenticated profile access even
+        // when ordinary local workflow routes are configured without auth.
+        if (user && canAccessProfile(user, workflow.profile)) socket.emit('app.workflow-notification', notice)
+      }
     } catch (err: any) {
       logger.error(err, '[workflow-socket] failed to load persisted execution evidence for workflow %s', status.workflowId)
       this.nsp.to(this.workflowRoom(status.workflowId)).emit('workflow.status.error', {

--- a/packages/server/src/modules/studio/sockets/workflow.ts
+++ b/packages/server/src/modules/studio/sockets/workflow.ts
@@ -1,3 +1,5 @@
+import { bindLegacyAppEvents } from '../services/webhooks/legacy-app-events'
+import { publishDomainEvent } from '../services/webhooks/app-events'
 import type { Server, Socket } from 'socket.io'
 import { authenticateUserToken, isAuthEnabled, type AuthenticatedUser } from '../public/auth'
 import { listUserProfiles } from '../repositories/users-store'
@@ -103,6 +105,10 @@ export class WorkflowSocketServer {
   }
 
   private onConnection(socket: Socket): void {
+    bindLegacyAppEvents(socket, 'workflow', event => {
+      const user = socket.data.user as AuthenticatedUser | undefined
+      return Boolean(user && canAccessProfile(user, event.profile))
+    })
     socket.on('workflows.list', (request: WorkflowListRequest | Ack<{ workflows: WorkflowRecord[] }> | undefined, ack?: Ack<{ workflows: WorkflowRecord[] }>) => {
       const callback = typeof request === 'function' ? request : ack
       const payload = typeof request === 'function' ? {} : request || {}
@@ -200,18 +206,7 @@ export class WorkflowSocketServer {
       if (!workflow) return
       this.notifiedRuns.add(status.runId)
       if (this.notifiedRuns.size > 2000) this.notifiedRuns.delete(this.notifiedRuns.values().next().value!)
-      const notice = {
-        id: `workflow:${status.workflowId}:run:${status.runId}`, target: 'workflow',
-        workflowId: status.workflowId, runId: status.runId, profile: workflow.profile || 'default',
-        title: workflow.name.slice(0, 120), kind: status.status === 'failed' ? 'failure' : 'completion',
-        resolved: false, timestamp: Date.now(),
-      }
-      for (const socket of this.nsp.sockets.values()) {
-        const user = socket.data.user as AuthenticatedUser | undefined
-        // Foreground notifications require authenticated profile access even
-        // when ordinary local workflow routes are configured without auth.
-        if (user && canAccessProfile(user, workflow.profile)) socket.emit('app.workflow-notification', notice)
-      }
+      publishDomainEvent(status.status === 'failed' ? 'workflow.run.failed' : 'workflow.run.completed', workflow.profile || 'default', { workflow_id: status.workflowId, run_id: status.runId }, { title: workflow.name.slice(0,120), preview: '' })
     } catch (err: any) {
       logger.error(err, '[workflow-socket] failed to load persisted execution evidence for workflow %s', status.workflowId)
       this.nsp.to(this.workflowRoom(status.workflowId)).emit('workflow.status.error', {

--- a/tests/server/app-event-subscription.test.ts
+++ b/tests/server/app-event-subscription.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, it, expect, vi } from 'vitest'
+const auth=vi.hoisted(()=>({user:{id:1,role:'user'} as any,profiles:['default']}))
+vi.mock('../../packages/server/src/modules/studio/public/auth',()=>({authenticateUserToken:async()=>auth.user}))
+vi.mock('../../packages/server/src/modules/studio/repositories/users-store',()=>({listUserProfiles:()=>auth.profiles.map(profile_name=>({profile_name}))}))
+vi.mock('../../packages/server/src/modules/studio/repositories/session-store',()=>({getSession:()=>({source:'cli',agent:'codex',profile:'default'}),getSessionNotificationPreview:()=>({title:'Title',preview:'Reply'})}))
+import { bindAppEventSubscription, parseAppSubscription, publishDomainEvent, publishGroupMessage, registerGroupEventAccess } from '../../packages/server/src/modules/studio/services/webhooks/app-events'
+function socket(){const handlers=new Map<string,Function>();return {id:Math.random().toString(),handshake:{auth:{token:'test'}},data:{},emit:vi.fn(),on:(n:string,f:Function)=>{const old=handlers.get(n);handlers.set(n,old?(...args:any[])=>{old(...args);f(...args)}:f)},once:(n:string,f:Function)=>handlers.set(n,f),handlers}}
+const flush=()=>new Promise(r=>setTimeout(r,15))
+beforeEach(()=>{auth.user={id:1,role:'user'};auth.profiles=['default']})
+it('normalizes omitted/blank profile before authorization and validates types',async()=>{
+ expect(parseAppSubscription({schema_version:1}).profile).toBe('default')
+ expect(()=>parseAppSubscription({schema_version:1,types:['unsafe']})).toThrow()
+ const s=socket();bindAppEventSubscription(s as any);auth.profiles=['other'];const ack=vi.fn()
+ await s.handlers.get('app.events.subscribe')!({schema_version:1},ack)
+ expect(ack).toHaveBeenCalledWith({ok:false,error:'event_subscription_denied'})
+ s.handlers.get('disconnect')!()
+})
+it('receives unified workflow event without HTTP endpoints and rechecks revocation',async()=>{
+ const s=socket();bindAppEventSubscription(s as any)
+ await s.handlers.get('app.events.subscribe')!({schema_version:1},vi.fn())
+ publishDomainEvent('workflow.run.completed','default',{workflow_id:'w',run_id:'r'},{title:'W'})
+ await flush();expect(s.emit).toHaveBeenCalledWith('app.event',expect.objectContaining({schema_version:1,type:'workflow.run.completed',subject:{workflow_id:'w',run_id:'r'}}))
+ auth.profiles=[]
+ publishDomainEvent('workflow.run.completed','default',{workflow_id:'w',run_id:'r2'},{title:'W'})
+ await flush();expect(s.emit).toHaveBeenCalledTimes(1)
+ s.handlers.get('disconnect')!()
+})
+it('group membership and filters are intersected at delivery and disconnected listeners removed',async()=>{
+ let member=true;const unregister=registerGroupEventAccess({canReceive:()=>member})
+ const s=socket();bindAppEventSubscription(s as any)
+ await s.handlers.get('app.events.subscribe')!({schema_version:1,room_ids:['r']},vi.fn())
+ publishGroupMessage({id:'r',name:'R',summaryProfile:'other'},{id:'a',senderName:'Pi',senderType:'agent',role:'assistant',content:'Reply'},[])
+ await flush();expect(s.emit).toHaveBeenCalledTimes(1)
+ member=false;publishGroupMessage({id:'r',name:'R',summaryProfile:'other'},{id:'b',senderName:'Pi',senderType:'agent',role:'assistant',content:'Reply'},[])
+ await flush();expect(s.emit).toHaveBeenCalledTimes(1)
+ s.handlers.get('disconnect')!();member=true
+ publishGroupMessage({id:'r',name:'R',summaryProfile:'other'},{id:'c',senderName:'Pi',senderType:'agent',role:'assistant',content:'Reply'},[])
+ await flush();expect(s.emit).toHaveBeenCalledTimes(1);unregister()
+})
+it('new protocol selection excludes legacy delivery and requested/resolved identities remain distinct',async()=>{
+ const { bindLegacyAppEvents } = await import('../../packages/server/src/modules/studio/services/webhooks/legacy-app-events')
+ const s=socket();s.handshake.auth={token:'test',appEventVersion:1} as any
+ bindAppEventSubscription(s as any);bindLegacyAppEvents(s as any,'workflow',()=>true)
+ await s.handlers.get('app.events.subscribe')!({schema_version:1},vi.fn())
+ publishDomainEvent('workflow.run.completed','default',{workflow_id:'w',run_id:'versioned'},{title:'W'})
+ await flush();expect(s.emit.mock.calls.map(call=>call[0])).toEqual(['app.event'])
+ s.handlers.get('disconnect')!()
+})
+it('real Socket.IO transport restores subscriptions and emits the same envelope after reconnect',async()=>{
+ const {createServer}=await import('node:http')
+ const {Server}=await import('socket.io')
+ const {io}=await import('socket.io-client')
+ const http=createServer();const server=new Server(http)
+ server.of('/chat-run').on('connection',bindAppEventSubscription)
+ await new Promise<void>(resolve=>http.listen(0,'127.0.0.1',resolve))
+ const port=(http.address() as any).port
+ const client=io(`http://127.0.0.1:${port}/chat-run`,{auth:{token:'test',appEventVersion:1},transports:['websocket'],autoConnect:false})
+ const received:any[]=[];client.on('app.event',e=>received.push(e))
+ const connect=async()=>{const ready=new Promise<void>(resolve=>client.once('connect',()=>resolve()));client.connect();await ready;await new Promise<void>((resolve,reject)=>client.emit('app.events.subscribe',{schema_version:1,profile:'default'},(ack:any)=>ack.ok?resolve():reject(Error('denied'))))}
+ try {
+  await connect();publishDomainEvent('workflow.run.completed','default',{workflow_id:'w',run_id:'live1'},{title:'W'})
+  await vi.waitFor(()=>expect(received).toHaveLength(1))
+  expect(received[0]).toMatchObject({schema_version:1,type:'workflow.run.completed',subject:{workflow_id:'w',run_id:'live1'},display:{title:'W'}})
+  client.disconnect();await flush();publishDomainEvent('workflow.run.completed','default',{workflow_id:'w',run_id:'offline'},{title:'W'})
+  await connect();expect(received).toHaveLength(1)
+  publishDomainEvent('workflow.run.failed','default',{workflow_id:'w',run_id:'live2'},{title:'W'})
+  await vi.waitFor(()=>expect(received).toHaveLength(2))
+ } finally {client.disconnect();await new Promise<void>(resolve=>server.close(()=>resolve()));http.close()}
+})

--- a/tests/server/app-relay-client.test.ts
+++ b/tests/server/app-relay-client.test.ts
@@ -757,4 +757,49 @@ describe('AppRelayClient', () => {
       event: 'workflow.status.subscribe',
     })))
   })
+
+  it('bridges unified App subscriptions through cloud relay transport', async () => {
+    const { startAppRelayClient } = await import('../../packages/server/src/modules/studio/services/app-relay/client')
+    startAppRelayClient({
+      relayUrl: 'https://relay.example.com',
+      machineId: 'hwui_machine_1234567890',
+      publicKey: 'machine-public-key',
+      localBaseUrl: 'http://127.0.0.1:8648',
+      fetchImpl: vi.fn() as any,
+    })
+    const remote = sockets[0]
+    const openAck = vi.fn()
+    remote.__handlers.get('app.socket.open')({
+      id: 'relay-workflow-1',
+      namespace: '/chat-run',
+      auth: { token: 'local-user-token', appEventVersion: 1 }, query: { profile: 'default' },
+    }, openAck)
+
+    const local = sockets[1]
+    expect(local.__url).toBe('http://127.0.0.1:8648/chat-run')
+    expect(local.__options).toMatchObject({ auth: { token: 'local-user-token', appEventVersion: 1 } })
+    expect(openAck).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'relay-workflow-1',
+      ok: true,
+      namespace: '/chat-run',
+    }))
+
+    local.emit.mockImplementation((event: string, payload: unknown, ack?: (response: unknown) => void) => {
+      if (event === 'app.events.subscribe') {
+        ack?.({ ok: true, data: { statuses: [{ workflowId: 'workflow-a', status: 'idle' }] } })
+      }
+    })
+    const eventAck = vi.fn()
+    remote.__handlers.get('app.socket.event')({
+      id: 'relay-workflow-1',
+      event: 'app.events.subscribe',
+      payload: { schema_version: 1, profile: 'default', types: ['workflow.run.completed'] },
+      ack: true,
+    }, eventAck)
+    await vi.waitFor(() => expect(eventAck).toHaveBeenCalledWith(expect.objectContaining({
+      ok: true,
+      namespace: '/chat-run',
+      event: 'app.events.subscribe',
+    })))
+  })
 })

--- a/tests/server/app-relay-server.test.ts
+++ b/tests/server/app-relay-server.test.ts
@@ -832,4 +832,60 @@ describe('LocalAppRelayServer', () => {
       payload: { ok: true, data: { statuses: [{ workflowId: 'workflow-a', status: 'idle' }] } },
     })))
   })
+
+  it('bridges unified App subscriptions over local and manually addressed relay', async () => {
+    const namespace = createMockNamespace()
+    const io = { of: vi.fn(() => namespace) }
+    const { LocalAppRelayServer } = await import('../../packages/server/src/modules/studio/services/app-relay/server')
+    const server = new LocalAppRelayServer(io as any, {
+      machineId: 'hwui_local_machine_1234567890',
+      localBaseUrl: 'http://127.0.0.1:8748',
+    })
+    server.init()
+
+    const app = createMockAppSocket('app-workflow', {
+      role: 'app',
+      token: 'local-user-token',
+      machineId: 'hwui_local_machine_1234567890',
+    })
+    await connectApp(namespace, app)
+    const openAck = vi.fn()
+    app.__handlers.get('socket.open')({
+      id: 'workflow-1',
+      namespace: '/chat-run',
+      auth: { token: 'untrusted-token', appEventVersion: 1 }, query: { profile: 'default' },
+    }, openAck)
+
+    await vi.waitFor(() => expect(openAck).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'workflow-1',
+      ok: true,
+      namespace: '/chat-run',
+    })))
+    expect(clientSocketMocks.io).toHaveBeenCalledWith(
+      'http://127.0.0.1:8748/chat-run',
+      expect.objectContaining({ auth: { token: 'local-user-token', appEventVersion: 1 } }),
+    )
+
+    const local = clientSocketMocks.sockets[0]
+    local.emit.mockImplementation((event: string, payload: unknown, ack?: (response: unknown) => void) => {
+      if (event === 'app.events.subscribe') {
+        ack?.({ ok: true, data: { statuses: [{ workflowId: 'workflow-a', status: 'idle' }] } })
+      }
+    })
+    const eventAck = vi.fn()
+    app.__handlers.get('socket.event')({
+      id: 'workflow-1',
+      event: 'app.events.subscribe',
+      payload: { schema_version: 1, profile: 'default', types: ['workflow.run.completed'] },
+      ack: true,
+    }, eventAck)
+
+    await vi.waitFor(() => expect(eventAck).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'workflow-1',
+      ok: true,
+      namespace: '/chat-run',
+      event: 'app.events.subscribe',
+      payload: { ok: true, data: { statuses: [{ workflowId: 'workflow-a', status: 'idle' }] } },
+    })))
+  })
 })

--- a/tests/server/business-events.test.ts
+++ b/tests/server/business-events.test.ts
@@ -1,0 +1,10 @@
+import { it, expect, vi } from 'vitest'
+import { createBusinessEventHub } from '../../packages/server/src/modules/studio/services/webhooks/business-events'
+const event={schema_version:1 as const,id:'e',type:'chat.run.completed',occurred_at:new Date().toISOString(),profile:'default',source:'chat',subject:{session_id:'s'},payload:{}}
+it('HTTP and social failures cannot block App, with unsubscribe cleanup', async()=>{
+ const errors=vi.fn(),app=vi.fn();const hub=createBusinessEventHub(errors)
+ hub.subscribe('http',()=>{throw Error('failed')});hub.subscribe('social',async()=>{throw Error('failed')})
+ const stop=hub.subscribe('app',app);hub.publish(event);await Promise.resolve();await Promise.resolve()
+ expect(app).toHaveBeenCalledOnce();expect(errors).toHaveBeenCalledWith('http');expect(errors).toHaveBeenCalledWith('social')
+ stop();hub.publish(event);expect(app).toHaveBeenCalledOnce()
+})

--- a/tests/server/chat-run-bridge-readiness.test.ts
+++ b/tests/server/chat-run-bridge-readiness.test.ts
@@ -84,6 +84,7 @@ vi.mock('../../packages/server/src/modules/studio/public/runs/prompt', () => ({
 }))
 
 vi.mock('../../packages/server/src/modules/studio/repositories/session-store', () => ({
+  getSessionNotificationPreview: vi.fn(() => null),
   getSession: getSessionMock,
   getSessionMetadata: getSessionMock,
   getSessionDetail: vi.fn(() => null),

--- a/tests/server/foreground-notification.test.ts
+++ b/tests/server/foreground-notification.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { foregroundNotification as event, foregroundNotificationPreview, foregroundNotificationAgent } from '../../packages/server/src/modules/studio/services/chat-run/foreground-notification'
+describe('foreground notification contract', () => {
+  it('uses stable request and run identities without sensitive payload', () => {
+    expect(event('approval.requested', { session_id:'s',approval_id:'a',command:'secret' },10)).toEqual({id:'s:approval:a',sessionId:'s',kind:'approval',resolved:false,timestamp:10})
+    expect(event('approval.resolved',{session_id:'s',approval_id:'a'},11)?.id).toBe('s:approval:a')
+    expect(event('run.completed',{session_id:'s',run_id:'r'},10)?.kind).toBe('completion')
+  })
+  it('ignores progress, aborts, missing identity and queued/interrupted runs', () => {
+    for(const name of ['abort.completed','tool.completed','session.activity']) expect(event(name,{session_id:'s',run_id:'r'})).toBeNull()
+    expect(event('run.completed',{session_id:'s'})).toBeNull()
+    expect(event('run.completed',{session_id:'s',run_id:'r',queue_remaining:1})).toBeNull()
+    expect(event('run.completed',{session_id:'s',run_id:'r',interrupted:true})).toBeNull()
+  })
+})
+
+ it('ships bounded title and completion preview without command or error payloads', () => {
+   expect(foregroundNotificationPreview('completion', {title:'Chat',preview:'fallback'}, {output:'Done\nnow'})).toEqual({title:'Chat',content:'Done now'})
+   expect(foregroundNotificationPreview('approval', {title:'Chat'}, {command:'secret',error:'secret'})).toEqual({title:'Chat',content:''})
+   expect(foregroundNotificationPreview('completion', {title:'x'.repeat(500)}, {output:'y'.repeat(1000)}).content).toHaveLength(240)
+ })
+
+it('normalizes stored agent identity without arbitrary avatar URLs', () => {
+ expect(foregroundNotificationAgent('codex')).toBe('codex')
+ expect(foregroundNotificationAgent('Claude')).toBe('claude-code')
+ expect(foregroundNotificationAgent('ekko')).toBe('ekko-agent')
+ expect(foregroundNotificationAgent('https://example/avatar.png')).toBe('')
+})

--- a/tests/server/group-chat-approval.test.ts
+++ b/tests/server/group-chat-approval.test.ts
@@ -41,6 +41,25 @@ describe('group chat approval and context baseline', () => {
     vi.restoreAllMocks()
   })
 
+  it('group reply notifications recheck visibility, never replay duplicate messages', () => {
+    const allowed = { id: 'notice-allowed', emit: vi.fn() }
+    const denied = { id: 'notice-denied', emit: vi.fn() }
+    const server = groupServer as any
+    const old = server.nsp.sockets
+    server.nsp.sockets = new Map([[allowed.id, allowed], [denied.id, denied]])
+    const access = vi.spyOn(server, 'canSocketObserveRoom').mockImplementation((socket: any) => socket.id === allowed.id)
+    try {
+      const message = { id:'notice-message', roomId:'room-1', senderName:'Pi', senderType:'agent', role:'assistant', content:'Done' }
+      server.notifyGroupReply('room-1', message)
+      server.notifyGroupReply('room-1', message)
+      expect(allowed.emit).toHaveBeenCalledTimes(1)
+      expect(denied.emit).not.toHaveBeenCalled()
+      access.mockReturnValue(false)
+      server.notifyGroupReply('room-1', { ...message, id:'second-message' })
+      expect(allowed.emit).toHaveBeenCalledTimes(1)
+    } finally { server.nsp.sockets = old }
+  })
+
   async function joinPair() {
     const agentSessionId = groupRuntimeSessionId('room-1', 'default', 'Agent')
     const agent = await connectGroupChatClient(port, 'agent-1', 'Agent', {

--- a/tests/server/group-chat-approval.test.ts
+++ b/tests/server/group-chat-approval.test.ts
@@ -41,13 +41,16 @@ describe('group chat approval and context baseline', () => {
     vi.restoreAllMocks()
   })
 
-  it('group reply notifications recheck visibility, never replay duplicate messages', () => {
-    const allowed = { id: 'notice-allowed', emit: vi.fn() }
-    const denied = { id: 'notice-denied', emit: vi.fn() }
+  it('group reply notifications recheck visibility, never replay duplicate messages', async () => {
+    const { bindLegacyAppEvents } = await import('../../packages/server/src/modules/studio/services/webhooks/legacy-app-events')
+    const allowed = { id: 'notice-allowed', emit: vi.fn(), data: {}, handshake: {auth:{}}, on: vi.fn() }
+    const denied = { id: 'notice-denied', emit: vi.fn(), data: {}, handshake: {auth:{}}, on: vi.fn() }
     const server = groupServer as any
     const old = server.nsp.sockets
     server.nsp.sockets = new Map([[allowed.id, allowed], [denied.id, denied]])
     const access = vi.spyOn(server, 'canSocketObserveRoom').mockImplementation((socket: any) => socket.id === allowed.id)
+    bindLegacyAppEvents(allowed as any, 'group', event => server.canSocketObserveRoom(allowed, event.subject.room_id))
+    bindLegacyAppEvents(denied as any, 'group', event => server.canSocketObserveRoom(denied, event.subject.room_id))
     try {
       const message = { id:'notice-message', roomId:'room-1', senderName:'Pi', senderType:'agent', role:'assistant', content:'Done' }
       server.notifyGroupReply('room-1', message)
@@ -57,7 +60,7 @@ describe('group chat approval and context baseline', () => {
       access.mockReturnValue(false)
       server.notifyGroupReply('room-1', { ...message, id:'second-message' })
       expect(allowed.emit).toHaveBeenCalledTimes(1)
-    } finally { server.nsp.sockets = old }
+    } finally { for (const socket of [allowed, denied]) socket.on.mock.calls.find(call=>call[0] === 'disconnect')?.[1](); server.nsp.sockets = old }
   })
 
   async function joinPair() {

--- a/tests/server/group-chat-member-sync.test.ts
+++ b/tests/server/group-chat-member-sync.test.ts
@@ -1815,6 +1815,7 @@ describe('Group Chat member/agent identity sync', () => {
 
   it('routes trusted @mentions and always checks persisted public messages', async () => {
     const server = Object.create(GroupChatServer.prototype) as any
+    server.notifiedGroupMessages = new Set<string>()
     const emit = vi.fn()
     server.rooms = new Map([
       ['room-1', {

--- a/tests/server/group-foreground-notification.test.ts
+++ b/tests/server/group-foreground-notification.test.ts
@@ -1,0 +1,10 @@
+import { it, expect } from 'vitest'
+import { groupReplyNotification } from '../../packages/server/src/modules/studio/services/group-chat/foreground-notification'
+it('builds a WeChat-style room title and sender-prefixed bounded preview',()=>{
+ const event=groupReplyNotification({id:'room',name:'Team'},{id:'m',senderName:'Pi',senderType:'agent',role:'assistant',content:'Done\nnow'},10)
+ expect(event).toMatchObject({id:'group:room:message:m',target:'group',title:'Team',content:'Pi: Done now',messageId:'m',timestamp:10})
+})
+it('does not alert for human posts, tools, empty output or interrupted output',()=>{
+ const base={id:'m',senderName:'Pi',senderType:'agent',role:'assistant',content:'done'}
+ for(const patch of [{senderType:'member'},{role:'tool'},{content:''},{finish_reason:'tool_calls'},{finish_reason:'aborted'}]) expect(groupReplyNotification({id:'r',name:'Room'},{...base,...patch})).toBeNull()
+})

--- a/tests/server/run-chat-clarify-respond.test.ts
+++ b/tests/server/run-chat-clarify-respond.test.ts
@@ -40,6 +40,7 @@ vi.mock('../../packages/server/src/modules/studio/public/logging', () => ({
 }))
 
 const sessionStoreMock = vi.hoisted(() => ({
+  getSessionNotificationPreview: vi.fn(() => null),
   getSession: vi.fn(() => ({ id: 'session-1', profile: 'default' })),
   getSessionMetadata: vi.fn(() => null),
   getSessionDetail: vi.fn(() => null),

--- a/tests/server/run-chat-mobile-location.test.ts
+++ b/tests/server/run-chat-mobile-location.test.ts
@@ -31,6 +31,7 @@ vi.mock('../../packages/server/src/modules/studio/public/logging', () => ({
 
 const sessionStoreMock = vi.hoisted(() => ({
   getSession: vi.fn(),
+  getSessionNotificationPreview: vi.fn(() => null),
   getSessionMetadata: vi.fn(() => null),
   getSessionDetail: vi.fn(() => null),
 }))
@@ -295,5 +296,47 @@ describe('ChatRunSocket mobile location', () => {
       profile: 'default',
       purpose: 'test',
     })).toThrow('Mobile location is available only in direct chats')
+  })
+})
+
+
+describe('App notification room delivery', () => {
+  it('broadcasts only minimal stable identity to the authorized profile room', async () => {
+    const { ChatRunSocket } = await import('../../packages/server/src/modules/studio/sockets/chat-run')
+    const { io, emitted } = createHarness()
+    sessionStoreMock.getSession.mockReturnValue({ id:'s',profile:'default',source:'cli' })
+    const server = new ChatRunSocket(io as any)
+    ;(server as any).emitPendingInteraction('default','approval.requested',{session_id:'s',approval_id:'a',command:'secret'})
+    const event = emitted.find(item => item.event === 'app.notification')
+    expect(event?.room).toBe('pending-interactions:default')
+    expect(event?.payload).toMatchObject({id:'s:approval:a',sessionId:'s',profile:'default',kind:'approval',resolved:false})
+    expect(event?.payload).not.toHaveProperty('command')
+    sessionStoreMock.getSession.mockReturnValue({id:'g',profile:'default',source:'group_chat'})
+    ;(server as any).emitPendingInteraction('default','run.completed',{session_id:'g',run_id:'r'})
+    expect(emitted.filter(item => item.event === 'app.notification')).toHaveLength(1)
+  })
+})
+
+
+describe('external Coding Agent notifications', () => {
+  it('forwards terminal and approval events through the profile notification path', async () => {
+    const { ChatRunSocket } = await import('../../packages/server/src/modules/studio/sockets/chat-run')
+    const { io, emitted } = createHarness()
+    sessionStoreMock.getSession.mockReturnValue({ id:'external',profile:'default',source:'coding_agent',agent:'codex' })
+    const server = new ChatRunSocket(io as any)
+    server.emitExternalEvent('external','run.completed',{run_id:'run-1'})
+    server.emitExternalEvent('external','approval.requested',{approval_id:'approval-1'})
+    server.emitExternalEvent('external','approval.resolved',{approval_id:'approval-1',resolved:true})
+    const notices=emitted.filter(item=>item.event==='app.notification')
+    expect(notices.every(item => item.payload.agent === 'codex')).toBe(true)
+    expect(notices.map(item=>[item.room,item.payload.id,item.payload.resolved])).toEqual([
+      ['pending-interactions:default','external:run:run-1',false],
+      ['pending-interactions:default','external:approval:approval-1',false],
+      ['pending-interactions:default','external:approval:approval-1',true],
+    ])
+    expect(emitted.filter(item=>item.event==='session.activity')).toHaveLength(1)
+    server.emitExternalEvent('external','run.completed',{run_id:'run-2',queue_remaining:1})
+    server.emitExternalEvent('external','abort.completed',{run_id:'run-3'})
+    expect(emitted.filter(item=>item.event==='app.notification')).toHaveLength(3)
   })
 })

--- a/tests/server/run-chat-mobile-location.test.ts
+++ b/tests/server/run-chat-mobile-location.test.ts
@@ -300,43 +300,22 @@ describe('ChatRunSocket mobile location', () => {
 })
 
 
-describe('App notification room delivery', () => {
-  it('broadcasts only minimal stable identity to the authorized profile room', async () => {
+describe('App business event production', () => {
+  it('normalizes external Coding Agent terminal and interaction events on the common bus', async () => {
     const { ChatRunSocket } = await import('../../packages/server/src/modules/studio/sockets/chat-run')
-    const { io, emitted } = createHarness()
-    sessionStoreMock.getSession.mockReturnValue({ id:'s',profile:'default',source:'cli' })
+    const { businessEvents } = await import('../../packages/server/src/modules/studio/services/webhooks/business-events')
+    const events: any[] = []
+    const stop = businessEvents.subscribe('test-producer', event => events.push(event))
+    const { io } = createHarness()
+    sessionStoreMock.getSession.mockReturnValue({id:'external',profile:'default',source:'coding_agent',agent:'codex'})
     const server = new ChatRunSocket(io as any)
-    ;(server as any).emitPendingInteraction('default','approval.requested',{session_id:'s',approval_id:'a',command:'secret'})
-    const event = emitted.find(item => item.event === 'app.notification')
-    expect(event?.room).toBe('pending-interactions:default')
-    expect(event?.payload).toMatchObject({id:'s:approval:a',sessionId:'s',profile:'default',kind:'approval',resolved:false})
-    expect(event?.payload).not.toHaveProperty('command')
-    sessionStoreMock.getSession.mockReturnValue({id:'g',profile:'default',source:'group_chat'})
-    ;(server as any).emitPendingInteraction('default','run.completed',{session_id:'g',run_id:'r'})
-    expect(emitted.filter(item => item.event === 'app.notification')).toHaveLength(1)
-  })
-})
-
-
-describe('external Coding Agent notifications', () => {
-  it('forwards terminal and approval events through the profile notification path', async () => {
-    const { ChatRunSocket } = await import('../../packages/server/src/modules/studio/sockets/chat-run')
-    const { io, emitted } = createHarness()
-    sessionStoreMock.getSession.mockReturnValue({ id:'external',profile:'default',source:'coding_agent',agent:'codex' })
-    const server = new ChatRunSocket(io as any)
-    server.emitExternalEvent('external','run.completed',{run_id:'run-1'})
-    server.emitExternalEvent('external','approval.requested',{approval_id:'approval-1'})
-    server.emitExternalEvent('external','approval.resolved',{approval_id:'approval-1',resolved:true})
-    const notices=emitted.filter(item=>item.event==='app.notification')
-    expect(notices.every(item => item.payload.agent === 'codex')).toBe(true)
-    expect(notices.map(item=>[item.room,item.payload.id,item.payload.resolved])).toEqual([
-      ['pending-interactions:default','external:run:run-1',false],
-      ['pending-interactions:default','external:approval:approval-1',false],
-      ['pending-interactions:default','external:approval:approval-1',true],
-    ])
-    expect(emitted.filter(item=>item.event==='session.activity')).toHaveLength(1)
-    server.emitExternalEvent('external','run.completed',{run_id:'run-2',queue_remaining:1})
-    server.emitExternalEvent('external','abort.completed',{run_id:'run-3'})
-    expect(emitted.filter(item=>item.event==='app.notification')).toHaveLength(3)
+    try {
+      server.emitExternalEvent('external','run.completed',{run_id:'run-1'})
+      server.emitExternalEvent('external','approval.requested',{approval_id:'a'})
+      server.emitExternalEvent('external','approval.resolved',{approval_id:'a',resolved:true})
+      expect(events.map(event=>event.type)).toEqual(['chat.run.completed','chat.approval.requested','chat.approval.resolved'])
+      expect(events[1].subject.approval_id).toBe(events[2].subject.approval_id)
+      expect(events[1].id).not.toBe(events[2].id)
+    } finally { stop() }
   })
 })

--- a/tests/server/session-store-search.test.ts
+++ b/tests/server/session-store-search.test.ts
@@ -23,6 +23,16 @@ describe('session store filtering', () => {
     vi.resetModules()
   })
 
+  it('resolves notification title for untitled sessions and bounds assistant preview', async () => {
+    const { createSession, addMessage, getSessionNotificationPreview } = await import('../../packages/server/src/modules/studio/repositories/session-store')
+    createSession({ id: 'untitled-notice', profile: 'default', source: 'coding_agent' })
+    addMessage({ session_id: 'untitled-notice', role: 'user', content: 'First user question', timestamp: 1 })
+    addMessage({ session_id: 'untitled-notice', role: 'assistant', content: 'a'.repeat(1000), timestamp: 2 })
+    addMessage({ session_id: 'untitled-notice', role: 'tool', content: 'private tool output', timestamp: 3 })
+    expect(getSessionNotificationPreview('untitled-notice')).toEqual({ title: 'First user question', preview: 'a'.repeat(240) })
+    expect(getSessionNotificationPreview('missing')).toBeNull()
+  })
+
   it('finds rendered text when Markdown markers split the stored phrase', async () => {
     const { addMessage, createSession, searchSessions } = await import(
       '../../packages/server/src/modules/studio/repositories/session-store'

--- a/tests/server/workflow-foreground-notification.test.ts
+++ b/tests/server/workflow-foreground-notification.test.ts
@@ -1,0 +1,20 @@
+import { expect, it, vi } from 'vitest'
+vi.mock('../../packages/server/src/modules/studio/public/auth',()=>({authenticateUserToken:vi.fn(),isAuthEnabled:vi.fn()}))
+vi.mock('../../packages/server/src/modules/studio/repositories/users-store',()=>({listUserProfiles:()=>[{profile_name:'allowed'}]}))
+const run=vi.hoisted(()=>({status:'completed'}))
+vi.mock('../../packages/server/src/modules/studio/repositories/workflow-run-store',()=>({getWorkflowRunWithEvidence:()=>run}))
+vi.mock('../../packages/server/src/modules/studio/services/workflow/manager',()=>({getWorkflowManager:vi.fn()}))
+vi.mock('../../packages/server/src/modules/studio/public/logging',()=>({logger:{error:vi.fn(),info:vi.fn()}}))
+import { WorkflowSocketServer } from '../../packages/server/src/modules/studio/sockets/workflow'
+it('notifies only terminal run once to currently authorized users, never canceled or node progress',()=>{
+ const ok={data:{user:{id:1}},emit:vi.fn()},guest={data:{},emit:vi.fn()}
+ const nsp={sockets:new Map([['ok',ok],['guest',guest]]),to:()=>({emit:vi.fn()})}
+ const manager={onRuntimeStatus:vi.fn(()=>()=>{}),get:()=>({id:'w',name:'Workflow',profile:'allowed'})}
+ const server=new WorkflowSocketServer({of:()=>nsp} as any,manager as any)
+ const send=(status:string,runId='r')=>(server as any).emitRuntimeStatus({workflowId:'w',runId,status})
+ send('running');send('canceled');expect(ok.emit).not.toHaveBeenCalled()
+ send('completed');send('completed');expect(ok.emit).toHaveBeenCalledTimes(1);expect(guest.emit).not.toHaveBeenCalled()
+ expect(ok.emit.mock.calls[0][1]).toMatchObject({target:'workflow',workflowId:'w',runId:'r',kind:'completion'})
+ run.status='failed';send('failed','r2');expect(ok.emit).toHaveBeenCalledTimes(2)
+ manager.get=()=>({id:'w',name:'Workflow',profile:'denied'});send('failed','r3');expect(ok.emit).toHaveBeenCalledTimes(2)
+})

--- a/tests/server/workflow-foreground-notification.test.ts
+++ b/tests/server/workflow-foreground-notification.test.ts
@@ -1,3 +1,4 @@
+import { bindLegacyAppEvents } from '../../packages/server/src/modules/studio/services/webhooks/legacy-app-events'
 import { expect, it, vi } from 'vitest'
 vi.mock('../../packages/server/src/modules/studio/public/auth',()=>({authenticateUserToken:vi.fn(),isAuthEnabled:vi.fn()}))
 vi.mock('../../packages/server/src/modules/studio/repositories/users-store',()=>({listUserProfiles:()=>[{profile_name:'allowed'}]}))
@@ -7,14 +8,17 @@ vi.mock('../../packages/server/src/modules/studio/services/workflow/manager',()=
 vi.mock('../../packages/server/src/modules/studio/public/logging',()=>({logger:{error:vi.fn(),info:vi.fn()}}))
 import { WorkflowSocketServer } from '../../packages/server/src/modules/studio/sockets/workflow'
 it('notifies only terminal run once to currently authorized users, never canceled or node progress',()=>{
- const ok={data:{user:{id:1}},emit:vi.fn()},guest={data:{},emit:vi.fn()}
+ const ok={id:'wf-ok',data:{user:{id:1}},handshake:{auth:{}},on:vi.fn(),emit:vi.fn()},guest={id:'wf-guest',data:{},handshake:{auth:{}},on:vi.fn(),emit:vi.fn()}
  const nsp={sockets:new Map([['ok',ok],['guest',guest]]),to:()=>({emit:vi.fn()})}
  const manager={onRuntimeStatus:vi.fn(()=>()=>{}),get:()=>({id:'w',name:'Workflow',profile:'allowed'})}
  const server=new WorkflowSocketServer({of:()=>nsp} as any,manager as any)
+ bindLegacyAppEvents(ok as any,'workflow',e=>e.profile==='allowed')
+ bindLegacyAppEvents(guest as any,'workflow',()=>false)
  const send=(status:string,runId='r')=>(server as any).emitRuntimeStatus({workflowId:'w',runId,status})
  send('running');send('canceled');expect(ok.emit).not.toHaveBeenCalled()
  send('completed');send('completed');expect(ok.emit).toHaveBeenCalledTimes(1);expect(guest.emit).not.toHaveBeenCalled()
  expect(ok.emit.mock.calls[0][1]).toMatchObject({target:'workflow',workflowId:'w',runId:'r',kind:'completion'})
  run.status='failed';send('failed','r2');expect(ok.emit).toHaveBeenCalledTimes(2)
  manager.get=()=>({id:'w',name:'Workflow',profile:'denied'});send('failed','r3');expect(ok.emit).toHaveBeenCalledTimes(2)
+ for (const socket of [ok,guest]) socket.on.mock.calls.find(call=>call[0]==='disconnect')?.[1]()
 })


### PR DESCRIPTION
## Summary
Consolidates and supersedes #2929, #2934 and #2936 into one PR directly against latest main (999111ee). One squash commit, 18 files, no new product behavior introduced by consolidation.

- Single chat approval/clarification and terminal run notifications, stable identity, bounded title/preview and canonical Agent ID; external coding-agent event support.
- Group Agent reply notifications with delivery-time authorization and bounded roster avatar descriptors.
- Whole Workflow run completed/failed notifications with exact workflow/run identity and profile checks.
- Retain CI mock fixes from the rebased notification chain.

## App companion
EKKOLearnAI/hermes-studio-app#86 consolidates the matching App UI/receivers.

## Validation
- 101 focused tests across eight files passed.
- npm run harness:check passed.
- npm run build passed.
- git diff --check passed.
- Staged tree equals git merge-tree(main, prior #2936 HEAD), proving preservation of the full dependency stack plus latest main.
- Existing device acceptance belongs to predecessor integrated test packages; no new deployment/installation for consolidation.

## Scope boundaries
Foreground transport only, no APNs. Group alerts cover authenticated host-local Agent replies; no group approvals/failures or remote guest transport. Workflow alerts cover whole-run success/failure only; no node/approval/cancel alerts. No main merge, release or deployment performed.

Please review this PR instead of #2929/#2934/#2936.