### PR TITLE
fix(desktop): guard browser debugger cleanup

### DIFF
--- a/packages/desktop/src/main/browser/browser-automation.ts
+++ b/packages/desktop/src/main/browser/browser-automation.ts
@@ -76,10 +76,12 @@ export class BrowserAutomation {
     this.snapshots.delete(tabId)
   }
 
-  detach(tabId: string, contents: WebContents): void {
+  detach(tabId: string, contents?: WebContents): void {
     this.invalidate(tabId)
-    if (contents.debugger.isAttached()) {
-      try { contents.debugger.detach() } catch { /* already detached */ }
+    if (!contents || contents.isDestroyed()) return
+    const debuggerApi = contents.debugger
+    if (debuggerApi.isAttached()) {
+      try { debuggerApi.detach() } catch { /* already detached */ }
     }
   }
 

--- a/packages/desktop/src/main/browser/browser-manager.ts
+++ b/packages/desktop/src/main/browser/browser-manager.ts
@@ -219,11 +219,12 @@ export class BrowserManager {
     await this.clearAnnotations(tabId, false)
     const ids = [...this.records.keys()]
     const index = ids.indexOf(tabId)
+    const contents = record.view.webContents
     this.window.contentView.removeChildView(record.view)
-    this.automation.detach(tabId, record.view.webContents)
+    this.automation.detach(tabId, contents)
     this.automationVisibleTabs.delete(tabId)
     this.agentDownloadGuardUntil.delete(tabId)
-    record.view.webContents.close()
+    if (contents && !contents.isDestroyed()) contents.close()
     this.records.delete(tabId)
     if (this.activeTabId === tabId) this.activeTabId = [...this.records.keys()][Math.max(0, index - 1)]
     await this.persistTabs()
@@ -741,13 +742,15 @@ export class BrowserManager {
     })
     contents.on('page-favicon-updated', (_event, favicons) => { tab.faviconUrl = favicons[0]; this.emitState() })
     contents.on('render-process-gone', () => { tab.crashed = true; tab.loading = false; this.emitState() })
-    contents.debugger.on('detach', () => {
-      this.automation.invalidate(id)
-      tab.agentControl = 'idle'
-      tab.agentLabel = undefined
-      tab.agentAction = undefined
-      this.emitState()
-    })
+    if (!contents.isDestroyed()) {
+      contents.debugger.on('detach', () => {
+        this.automation.invalidate(id)
+        tab.agentControl = 'idle'
+        tab.agentLabel = undefined
+        tab.agentAction = undefined
+        this.emitState()
+      })
+    }
     contents.on('console-message', details => {
       const levelNumber = ({ debug: 0, info: 1, warning: 2, error: 3 } as Record<string, number>)[details.level] ?? 1
       record.console.push({ level: levelNumber, message: details.message, line: details.lineNumber, sourceId: details.sourceId, timestamp: new Date().toISOString() })
@@ -989,9 +992,10 @@ export class BrowserManager {
 
   private destroyViews(): void {
     for (const [id, record] of this.records) {
+      const contents = record.view.webContents
       this.window.contentView.removeChildView(record.view)
-      this.automation.detach(id, record.view.webContents)
-      if (!record.view.webContents.isDestroyed()) record.view.webContents.close()
+      this.automation.detach(id, contents)
+      if (contents && !contents.isDestroyed()) contents.close()
     }
     this.records.clear()
     this.automationVisibleTabs.clear()

--- a/tests/desktop/browser-automation.test.ts
+++ b/tests/desktop/browser-automation.test.ts
@@ -56,6 +56,24 @@ describe('desktop browser automation safety', () => {
     })).rejects.toThrow(/stale/)
   })
 
+  it('skips debugger cleanup when web contents are missing', () => {
+    const automation = new BrowserAutomation()
+
+    expect(() => automation.detach('missing-tab', undefined)).not.toThrow()
+  })
+
+  it('skips debugger cleanup when web contents are destroyed', () => {
+    const automation = new BrowserAutomation()
+    const destroyedContents = {
+      isDestroyed: () => true,
+      get debugger() {
+        throw new Error('debugger must not be read after destruction')
+      },
+    } as unknown as WebContents
+
+    expect(() => automation.detach('destroyed-tab', destroyedContents)).not.toThrow()
+  })
+
   it.each([
     ['password', ['type', 'password']],
     ['payment', ['type', 'text', 'name', 'card_number']],


### PR DESCRIPTION
## Summary
- make Desktop Browser debugger cleanup tolerate missing or already-destroyed `WebContents`
- guard both single-tab and bulk tab closing from touching destroyed contents
- avoid registering the debugger detach listener if the newly created contents is already destroyed
- add regression coverage for missing and destroyed contents

Fixes #2942

## Problem and root cause
Desktop Browser tab teardown can race with renderer crashes or repeated close requests. `BrowserAutomation.detach()` invalidated its snapshot state and then immediately dereferenced `contents.debugger`. When Electron had already released the `WebContents` reference, this produced `TypeError: Cannot read properties of undefined (reading 'debugger')` during an otherwise non-fatal close.

## Approach and tradeoffs
The teardown path now always invalidates automation state first, then returns when contents are absent or destroyed. Live contents preserve the existing debugger-detach behavior. The manager captures the contents reference once and applies the same liveness rule before closing it, including bulk cleanup during profile switches or shutdown.

This is intentionally defensive and does not retry or recreate a destroyed tab. It only suppresses cleanup work that can no longer succeed.

## Validation
- `npm run test -- tests/desktop/browser-automation.test.ts` — passed, 10 tests
- sabotage run with the old `detach()` implementation restored — the new regression test failed with the reported `reading 'debugger'` TypeError; restoring the fix passed
- `npm run harness:check` — passed
- `npm --prefix packages/desktop run build` — passed
- `npm run test:e2e` — passed, 170 tests
- `npm run build` — passed
- `npm run test:coverage` — 5,106 passed, 8 skipped, 1 failed in the unrelated existing `tests/client/use-speech-tts.test.ts` Blob realm assertion; the same focused failure was reproduced on an unmodified `origin/main` worktree at `66066fc5`

## Risk, compatibility, and exclusions
- Low risk: live debugger detach behavior is unchanged; only missing/destroyed cleanup targets are skipped.
- No persistence, API, protocol, dependency, or migration changes.
- Manual Windows rapid-close/crashed-renderer verification was not available locally; automated coverage exercises the exact missing/destroyed object states.

## AI assistance disclosure
This change and PR description were prepared with AI assistance and were reviewed and validated against the repository's existing contribution and testing rules.
