### PR TITLE
fix(tts): preserve semantic symbols in speech text

### DIFF
--- a/packages/client/src/composables/useSpeech.ts
+++ b/packages/client/src/composables/useSpeech.ts
@@ -137,7 +137,7 @@ export function useSpeech() {
     // 移除 HTML 标签
     text = text.replace(/<[^>]+>/g, '')
 
-    text = text.replace(/[^\p{L}\p{N}\s.。!?;,，。！？；：、""''（）【】《》\n一-鿿㐀-䶿]/gu, '')
+    text = text.replace(/[^\p{L}\p{N}\s.。!?;,，。！？；：、""''（）【】《》+\-%:\/=~\n一-鿿㐀-䶿]/gu, '')
 
     text = text.replace(/\s+/g, ' ').trim()
 

--- a/tests/client/use-speech-webspeech.test.ts
+++ b/tests/client/use-speech-webspeech.test.ts
@@ -111,6 +111,16 @@ describe('useSpeech WebSpeech playback', () => {
     wrapper.unmount()
   })
 
+  it('preserves semantic symbols while filtering speech noise', () => {
+    const speech = useSpeech()
+
+    expect(speech.extractReadableText(
+      '跌幅 -3%，反弹 +8.3%，09:30 开盘，日期 2026-09-03，比例 3:1，区间 5~6，A/B = 0.5。🙂 # *',
+    )).toBe(
+      '跌幅 -3%，反弹 +8.3%，09:30 开盘，日期 2026-09-03，比例 3:1，区间 5~6，A/B = 0.5。',
+    )
+  })
+
   it('does not crash when Web Speech is unavailable', () => {
     Object.defineProperty(window, 'speechSynthesis', {
       configurable: true,


### PR DESCRIPTION
## Problem

The TTS pre-filter removes semantic symbols such as `-`, `%`, `+`, `:`, `/`, `=`, and `~`. This changes the meaning of numbers, times, ratios, ranges, and paths before text reaches the speech engine—for example, `-3%` becomes `3` and `09:30` becomes `0930`.

## Root cause

`extractReadableText()` uses an allowlist regex intended to remove Markdown and emoji noise, but the allowlist omitted symbols that carry spoken meaning.

## Solution

- Preserve `+ - % : / = ~` in readable speech text.
- Add a focused regression test covering negative and positive percentages, times, dates, ratios, ranges, division, and equality.
- Continue filtering unrelated noise such as emoji and Markdown markers.

## Verification

- `HERMES_WEB_UI_HOME=<temporary-dir> /Users/liuruijie/.local/bin/npm run test -- tests/client/use-speech-webspeech.test.ts` — 4/4 passed.
- `HERMES_WEB_UI_HOME=<temporary-dir> /Users/liuruijie/.local/bin/npm run harness:check` — passed.
- `hermes verify --phase build --json` — passed with `ok: true`.
- Full `hermes verify --json` — 5,105 tests passed and 8 skipped; one unrelated failure remained in `tests/client/use-speech-tts.test.ts:107`. The same cross-realm `Blob instanceof Blob` failure was reproduced on clean `origin/main`.

## Risk and compatibility

Low risk. The change only widens the existing TTS character allowlist. Code blocks, inline code, HTML tags, thinking content, emoji, and Markdown noise continue to be filtered. No API, persistence, dependency, or lockfile changes are included.

Fixes #2877

This pull request was prepared with AI assistance and manually verified through the commands listed above.
