### PR TITLE
fix: close App relay bridges without requiring acknowledgements

### DIFF
--- a/packages/server/src/modules/studio/services/app-relay/client.ts
+++ b/packages/server/src/modules/studio/services/app-relay/client.ts
@@ -357,7 +357,8 @@ export class AppRelayClient {
       void this.emitLocalSocketEvent(request).then(response => ack?.(response))
     })
     this.socket.on('app.socket.close', (request: AppRelaySocketCloseRequest, ack?: (response: AppRelaySocketResponse) => void) => {
-      ack?.(this.closeLocalSocket(request))
+      const response = this.closeLocalSocket(request)
+      ack?.(response)
     })
   }
 

--- a/tests/server/app-relay-client.test.ts
+++ b/tests/server/app-relay-client.test.ts
@@ -713,6 +713,32 @@ describe('AppRelayClient', () => {
     expect(local.disconnect).toHaveBeenCalled()
   })
 
+  it('closes a cloud bridge even when the cleanup notification has no acknowledgement', async () => {
+    const { startAppRelayClient } = await import('../../packages/server/src/modules/studio/services/app-relay/client')
+    startAppRelayClient({
+      relayUrl: 'https://relay.example.com',
+      machineId: 'hwui_machine_1234567890',
+      publicKey: 'machine-public-key',
+      localBaseUrl: 'http://127.0.0.1:8648',
+      fetchImpl: vi.fn() as any,
+    })
+    const remote = sockets[0]
+    remote.__handlers.get('app.socket.open')({
+      id: 'abandoned-bridge', namespace: '/chat-run', auth: { token: 'local-user-token' },
+    }, vi.fn())
+    const local = sockets[1]
+
+    remote.__handlers.get('app.socket.close')({ id: 'abandoned-bridge' })
+
+    expect(local.disconnect).toHaveBeenCalledTimes(1)
+    const eventAck = vi.fn()
+    remote.__handlers.get('app.socket.event')({ id: 'abandoned-bridge', event: 'run', payload: {} }, eventAck)
+    await vi.waitFor(() => expect(eventAck).toHaveBeenCalledWith(expect.objectContaining({
+      ok: false, error: expect.objectContaining({ code: 'socket_not_open' }),
+    })))
+    expect(local.emit).not.toHaveBeenCalled()
+  })
+
   it('bridges the /workflow status namespace and whitelisted subscription events', async () => {
     const { startAppRelayClient } = await import('../../packages/server/src/modules/studio/services/app-relay/client')
     startAppRelayClient({


### PR DESCRIPTION
## Summary

When an App disconnects, the cloud relay sends `app.socket.close` without requesting an acknowledgement. Studio previously evaluated `closeLocalSocket` inside `ack?.(...)`, so it left the local chat socket open when no ACK callback was present. The abandoned bridge could keep uploading events that the cloud discarded before recording App traffic.

Close the local bridge unconditionally, then acknowledge the result when a callback is supplied. Add a regression test that delivers cleanup without an ACK and verifies the socket disconnects and subsequent events cannot use the removed bridge.

The cloud compatibility fix for already released Studios is on server main at EKKOLearnAI/hermes-studio-server@bb3ffe1e.

## Validation

- Confirmed the new regression test fails before the fix.
- App relay client and Agent transport tests: 20 passed.
- Chat streaming Playwright tests: 17 passed.
- `npm run harness:check`: passed.
- `npm run build`: passed.
