### PR TITLE
fix(chat): skip hidden thinking in speech

### DIFF
--- a/packages/client/src/composables/useSpeech.ts
+++ b/packages/client/src/composables/useSpeech.ts
@@ -1,4 +1,5 @@
 import { ref, computed, onUnmounted } from 'vue'
+import { parseThinking } from '@/utils/thinking-parser'
 import {
   generateSpeech,
   playAudioBlob,
@@ -124,11 +125,7 @@ export function useSpeech() {
   function extractReadableText(content: string): string {
     if (!content) return ''
 
-    let text = content
-
-    // 移除 thinking 标签内容
-    text = text.replace(/<thinking[^>]*>[\s\S]*?<\/thinking>/gi, '')
-    text = text.replace(/<thinking[^>]*>[\s\S]*/gi, '')
+    let text = parseThinking(content, { streaming: false }).body
 
     // 移除代码块
     text = text.replace(/```[\s\S]*?```/g, '')

--- a/tests/client/use-speech-webspeech.test.ts
+++ b/tests/client/use-speech-webspeech.test.ts
@@ -121,6 +121,16 @@ describe('useSpeech WebSpeech playback', () => {
     )
   })
 
+  it('keeps collapsed thinking blocks out of speech text', () => {
+    const speech = useSpeech()
+
+    expect(speech.extractReadableText(
+      '<think>hidden plan</think>Visible answer. '
+      + '<thinking>legacy hidden plan</thinking>More detail. '
+      + '<reasoning>hidden rationale</reasoning>Done.',
+    )).toBe('Visible answer. More detail. Done.')
+  })
+
   it('does not crash when Web Speech is unavailable', () => {
     Object.defineProperty(window, 'speechSynthesis', {
       configurable: true,


### PR DESCRIPTION
## Summary
- reuse the chat thinking parser before TTS text cleanup so `<think>`, `<thinking>`, and `<reasoning>` blocks are excluded from speech
- cover the shared speech sanitizer used by browser, server-backed, Profile-aware, queued, manual, and auto-play playback

Fixes #2937

## Problem and root cause
The chat UI already uses `parseThinking()` to collapse reasoning blocks and render only the parsed body as the visible answer. The shared TTS sanitizer had a separate legacy regex that recognized only `<thinking>...</thinking>`. When assistant content used the supported `<think>` or `<reasoning>` variants, the HTML tags were removed but their hidden text remained and was spoken aloud.

## Approach and trade-offs
`extractReadableText()` now starts from `parseThinking(content, { streaming: false }).body`, then applies the existing code, HTML, symbol, and whitespace cleanup. Keeping the fix in the shared speech composable covers every current playback engine and both single-chat and group-chat callers without duplicating filtering at each event producer or message component.

This intentionally follows the UI parser's completed-message behavior. Malformed unclosed reasoning tags continue to degrade to body text rather than silently swallowing a possible answer.

## Validation
- `npm run test -- tests/client/use-speech-webspeech.test.ts tests/client/thinking-parser.test.ts` — passed, 29 tests
- regression sabotage — restoring the previous `<thinking>`-only regex made the new test fail because `<think>` and `<reasoning>` contents remained; restoring the fix passed
- `npm run harness:check` — passed, including Ekko API documentation check
- `npm run test:coverage` — 5,138 passed / 8 skipped; one pre-existing environment failure remained in `tests/client/use-speech-tts.test.ts` (`Blob instanceof Blob` cross-realm mismatch). The same test failed identically on clean `origin/main`.
- `npm run test:e2e` — 173 passed; `app-download-versions.spec.ts` had one unrelated route-load flake. The failed test passed on a focused rerun on this branch and also passed on clean `origin/main`.
- `npm run build` — passed

## Risk / compatibility
- Low client-side text-normalization risk; no API, schema, persistence, auth, or provider configuration changes.
- All TTS providers keep their existing downstream cleanup and playback behavior.
- Closed reasoning blocks now match what the UI hides; visible body text remains speakable.

## Not included
- No change to reasoning rendering or expansion controls.
- No change to malformed/unclosed reasoning-tag fallback behavior.
- No unrelated TTS provider or playback refactor.

AI-assisted contribution. The final diff was reviewed against the issue and repository guidance, regression-tested, and validated with the commands listed above.
