### PR TITLE
fix(profiles): honor bridge timeout on restart

### DIFF
--- a/packages/server/src/modules/hermes/controllers/profiles.ts
+++ b/packages/server/src/modules/hermes/controllers/profiles.ts
@@ -31,6 +31,7 @@ import { isHermesAgentAvailable } from '../../studio/public/agent-status-registr
 import { readAppProfileAvatar } from '../services/profiles/app-profile-avatar'
 
 const bridgeCleanupClient = () => new AgentBridgeClient({ connectRetryMs: 0, timeoutMs: 5000 })
+const bridgeProfileRestartClient = () => new AgentBridgeClient({ connectRetryMs: 0 })
 
 interface ProfileAvatarMeta {
   type: 'generated' | 'image'
@@ -668,7 +669,7 @@ export async function restartProfileRuntime(ctx: any) {
     return
   }
   try {
-    const result = await bridgeCleanupClient().destroyProfile(name)
+    const result = await bridgeProfileRestartClient().destroyProfile(name)
     logger.info('[profiles] destroyed bridge sessions after profile restart profile=%s destroyed=%s', name, result.destroyed)
     const profiles = await listProfilesForStatus()
     const profile = profiles.find(item => item.name === name)

--- a/tests/server/profiles-routes.test.ts
+++ b/tests/server/profiles-routes.test.ts
@@ -79,6 +79,7 @@ vi.mock('../../packages/server/src/modules/studio/public/agent-status-registry',
 }))
 
 import * as hermesCli from '../../packages/server/src/modules/hermes/services/runtime/cli'
+import { AgentBridgeClient } from '../../packages/server/src/modules/hermes/services/bridge'
 
 describe('Profile Routes', () => {
   const originalHermesHome = process.env.HERMES_HOME
@@ -570,6 +571,31 @@ describe('Profile Routes', () => {
       expect(agentBridgeMocks.destroyProfile).toHaveBeenCalledWith('work')
       expect(agentBridgeMocks.destroyAll).not.toHaveBeenCalled()
       expect(sessionDeleterMocks.switchProfile).toHaveBeenCalledWith('work')
+    })
+  })
+
+  describe('profile runtime restart', () => {
+    it('uses the configurable bridge timeout for explicit profile cleanup', async () => {
+      vi.mocked(hermesCli.listProfiles).mockResolvedValue([{
+        name: 'work',
+        active: true,
+        model: 'gpt-test',
+        alias: '',
+      }] as any)
+      gatewayAutostartMocks.getGatewayRuntimeStatusForProfile.mockResolvedValue({
+        running: false,
+        profile: 'work',
+      })
+      agentBridgeMocks.destroyProfile.mockResolvedValue({ destroyed: 2 })
+      const { restartProfileRuntime } = await import('../../packages/server/src/modules/hermes/controllers/profiles')
+      const ctx: any = { params: { name: 'work' }, status: 200, body: undefined }
+
+      await restartProfileRuntime(ctx)
+
+      expect(ctx.status).toBe(200)
+      expect(ctx.body).toMatchObject({ success: true, destroyed: 2 })
+      expect(vi.mocked(AgentBridgeClient)).toHaveBeenNthCalledWith(1, { connectRetryMs: 0 })
+      expect(agentBridgeMocks.destroyProfile).toHaveBeenCalledWith('work')
     })
   })
 


### PR DESCRIPTION
## Summary

- let the explicit **Restart Configuration** profile action use the Agent Bridge's standard timeout policy instead of forcing a 5-second deadline
- preserve the existing short 5-second timeout for best-effort cleanup during gateway restart, profile switch, and profile deletion
- add a regression test that verifies explicit profile restart leaves `timeoutMs` unset, so `HERMES_AGENT_BRIDGE_TIMEOUT_MS` (or the 120-second default) is honored

Fixes #2784

## Problem and root cause

`restartProfileRuntime()` used the same fail-fast cleanup client as incidental cleanup paths:

```ts
new AgentBridgeClient({ connectRetryMs: 0, timeoutMs: 5000 })
```

`destroy_profile` synchronously tears down the profile's workers and sessions, so active profiles can legitimately take longer than five seconds. The explicit timeout also bypassed the bridge client's existing `HERMES_AGENT_BRIDGE_TIMEOUT_MS` configuration and 120-second default.

## Approach and tradeoffs

The explicit profile restart now uses a dedicated client with only connection retries disabled. This keeps the request deterministic while allowing the normal configurable operation timeout to apply.

The short timeout remains on cleanup that is already best-effort and caught by surrounding code. This avoids making gateway restart, profile switching, or deletion wait up to two minutes merely for secondary cleanup.

## Validation

- `npm run test -- tests/server/profiles-routes.test.ts` — 28 passed
- regression/sabotage check on pre-fix code — new test failed because the client received `timeoutMs: 5000`; passed after the fix
- `npm run harness:check` — passed
- `npm run test:e2e` — 174 passed
- `npm run build` — passed
- `npm run test:coverage` — 5,139 passed, 8 skipped, 1 failed in unrelated `tests/client/use-speech-tts.test.ts` (`Blob` cross-realm `instanceof` assertion)
- baseline reproduction on untouched `origin/main` (`4aa6d34c41c77a517ee5dd9c01cf3c35dec36698`): `npm run test:coverage -- tests/client/use-speech-tts.test.ts` fails at the same assertion

All commands used isolated `HERMES_WEB_UI_HOME`, `HERMES_WEBUI_STATE_DIR`, and `UPLOAD_DIR` paths inside the worktree.

## Risk and compatibility

- low-risk server-only timeout selection change; no API or persistence schema changes
- users can continue overriding the operation timeout with `HERMES_AGENT_BRIDGE_TIMEOUT_MS`
- long-running explicit restarts can now hold the HTTP request until cleanup completes or reaches the configured/default timeout
- no changes to bridge protocol, gateway lifecycle, or best-effort cleanup semantics

## Scope exclusions

- does not make `destroy_profile` asynchronous
- does not alter the bridge-wide default timeout
- does not address the pre-existing TTS coverage-test failure

## AI disclosure

This contribution was generated with AI assistance and was reviewed and validated against the repository's existing contribution and test conventions.
