### PR TITLE
feat(ekko): persist task plans and show live progress in chat

### DIFF
--- a/docs/planning/ekko-task-plan.md
+++ b/docs/planning/ekko-task-plan.md
@@ -1,0 +1,128 @@
+# Ekko 聊天任务计划
+
+状态：首期已实现，2026-09-08。范围为 Studio 中 Ekko 聊天的计划工具、快照入库、工具调用记录、实时任务卡片及历史恢复。
+
+## 目标与界面
+
+Ekko 在处理多步骤任务时维护一份有序计划。创建计划、开始步骤、完成步骤或修改计划时，发布结构化事件，Studio 显示同一张任务卡片的最新状态。
+
+```text
+任务计划                                 1 / 3 已完成
+✓ 查看现有实现                              已完成
+◉ 增加事件和状态存储                         进行中
+○ 验证刷新后的显示                           未完成
+```
+
+任务卡片放在聊天消息流中，默认展开；用户可以折叠。每个计划只显示一张卡片，更新时不重复追加。完成后保留卡片与完成数量。状态同时使用图标和文字，不能只靠颜色区别。
+
+首期范围是 Ekko 单聊的步骤进度跟踪。步骤由 agent 依照正常工具执行流程完成；计划本身不负责调度或启动任务。现有消息队列、Hermes Kanban、定时任务保持各自的数据与行为。用户的“触发 event”在这里解释为更新计划后推送显示事件；外部事件自动启动工作流属于独立的调度需求。
+
+## 现有代码与接入点
+
+实际修改目标是 `studio/packages/ekko-agent`，这是仓库声明的 canonical runtime；上级目录中另一个 `ekko-agent` 不作为本方案实现位置。
+
+| 层 | 当前文件 | 计划变更 |
+| --- | --- | --- |
+| 内置工具 | `packages/ekko-agent/src/tools/registry.ts` | 注册 `update_plan` 工具；新增 `tools/plan.ts` 处理校验与更新 |
+| 工具上下文 | `packages/ekko-agent/src/tools/types.ts` | 增加当前 run 的计划更新能力，避免把状态放在共享工具实例里 |
+| Runtime | `packages/ekko-agent/src/runtime/runtime.ts`、`events.ts` | 保存 run 内计划快照，发出 `plan.updated`，终止时处理尚未完成的步骤 |
+| 提示词 | `packages/ekko-agent/src/runtime/system-prompt.ts` | 工具可用时注入使用规则：多步骤任务建立计划，开始和完成时及时更新 |
+| Studio 适配 | `packages/server/src/modules/studio/services/chat-run/handle-ekko-agent-run.ts` | 接收计划事件，完成持久化后通过现有 emit 通道广播 |
+| 持久化 | `packages/server/src/modules/studio/repositories/` | 新增计划快照 repository，通过既有数据库迁移机制建表 |
+| 会话恢复 | `packages/server/src/modules/studio/sockets/chat-run.ts` 及会话历史响应 | 返回计划快照，覆盖重连、运行结束、服务重启后的恢复 |
+| 客户端传输 | `packages/client/src/api/studio/chat.ts` | 定义事件和快照类型，注册 `plan.updated` 监听并按 session 分发 |
+| 客户端状态 | `packages/client/src/stores/hermes/chat.ts` | 按 session、plan ID 保存快照，统一处理实时事件、恢复快照和历史加载 |
+| 显示 | `packages/client/src/components/hermes/chat/` | 新增 `TaskPlanCard.vue`，接入实时和历史消息列表；补齐所有语言文案 |
+
+当前 runtime 已定义 `tool.started`、`tool.completed`、`subagent.*` 和 run 生命周期事件，尚未定义步骤计划事件。Studio 已有 Socket.IO 转发与恢复机制。
+
+特别注意：`handle-ekko-agent-run.ts` 中的临时事件缓冲最多保留 200 条，且在运行结束时清空。因此不能把该缓冲作为计划的唯一数据源。当前工具消息会持久化，但工具调用以完整工具组写入；计划快照应独立保存，避免同组其他工具尚未结束时刷新丢失已展示的计划。
+
+## 工具与事件协议
+
+工具名称为 `update_plan`。首期一个 run 对应一份计划，`plan_id` 由 runtime 使用当前 run ID 确定；后续更新同一份计划。跨 run 的用户“继续”请求可以根据历史建立新计划，旧计划保留。跨 run 原地续办暂不承诺。
+
+模型提交完整步骤列表，不提交数据库 ID、版本或 session ID：
+
+```json
+{
+  "explanation": "接口已完成，开始做界面",
+  "plan": [
+    { "id": "inspect", "step": "查看现有实现", "status": "completed" },
+    { "id": "implement", "step": "增加事件和状态存储", "status": "in_progress" },
+    { "id": "verify", "step": "验证刷新后的显示", "status": "pending" }
+  ]
+}
+```
+
+服务端对外发送完整快照。字段命名沿用聊天事件的 snake_case：
+
+```json
+{
+  "event": "plan.updated",
+  "session_id": "session-example",
+  "run_id": "run-example",
+  "plan_id": "run-example",
+  "revision": 2,
+  "execution_state": "running",
+  "explanation": "接口已完成，开始做界面",
+  "plan": [
+    { "id": "inspect", "step": "查看现有实现", "status": "completed" },
+    { "id": "implement", "step": "增加事件和状态存储", "status": "in_progress" },
+    { "id": "verify", "step": "验证刷新后的显示", "status": "pending" }
+  ],
+  "updated_at": 1788832800000
+}
+```
+
+Runtime 内部事件沿用既有 camelCase，再由 Studio 转为传输字段。`revision` 单调递增，由 runtime 管理；客户端只接受比本地更新的版本，忽略重复或乱序的旧版本。完成数直接从 `completed` 步骤数量计算。
+
+## 更新规则
+
+- `pending` 显示“未完成”，`in_progress` 显示“进行中”，`completed` 显示“已完成”。
+- 步骤 ID 非空且唯一，标题非空，最多 30 个步骤、每个标题最多 200 字符、说明最多 1000 字符。至多一个步骤为 `in_progress`；agent 可在当前步骤内部执行多个工具。
+- 更新工具按串行工具执行。无效输入返回工具错误，不更新快照、不发布成功事件。
+- 只有 agent 明确更新为 `completed` 才勾选完成；单次工具成功、回复结束或子 agent 返回均不能自动勾选全部步骤。
+- agent 可增加、删除、调整顺序或重新打开步骤。相同步骤保持 ID；改动范围或撤回完成标记时填写说明。完整快照代表当前完整计划。
+- `execution_state` 与步骤状态分开：`running`、`ended`、`interrupted`、`failed`。全部步骤是否完成从列表推导，不能把 `ended` 当作任务全部完成。
+- 运行结束、失败或用户停止时，已完成的步骤保持完成，将还在 `in_progress` 的步骤恢复为 `pending`，保留其他未完成步骤，并注明运行结束或中断原因。终止更新也递增版本、持久化并广播。
+- 服务重启后，只有在确认所属 run 已无法恢复执行时，才把残留的 `running` 快照标记为 `interrupted`，避免恢复后一直显示进行中。
+- 首期子 agent 的计划不合并进主计划。主 agent 根据收到的实际结果更新主计划，避免子任务使用自己的步骤覆盖主任务。
+
+## 存储与恢复
+
+Studio 保存最新快照，使用 `(session_id, plan_id)` 唯一键，保存 run ID、revision、执行状态、步骤 JSON、说明、创建时间和更新时间。使用现有 Studio 数据库中的 `task_plans` 表，不写入 Ekko 源码目录或用户的任务工作区。
+
+同一个计划更新采用事务和版本比较，数据库更新成功后再发布对外事件。持久化失败时不得向客户端声称快照已可靠保存，应走明确的失败处理；实现使用同步 SQLite 写入：`AgentRuntimeRunInput.onPlanUpdate` 提交快照成功后，runtime 才发布 `plan.updated`。提交失败会返回工具错误，不发布成功更新。
+
+历史工具调用继续走原有消息存储，保留模型理解计划变更所需的上下文；计划快照用于界面恢复。无需首期实现专门的变更历史界面。
+
+Resume 响应包含当前运行的计划，以及当前消息页所涉及 run 的计划。历史分页响应随页附带关联计划，不能依赖最新 150 条消息中恰好包含计划工具调用。客户端按 plan ID 合并，避免 Socket 重放和历史读取生成重复卡片。
+
+删除会话时一并删除其计划记录。聊天中的普通工具折叠、隐藏工具轨迹设置不能隐藏任务卡片。
+
+## 实施顺序与验收
+
+1. 增加工具、输入校验、run 内计划状态和 runtime 事件；验证连续更新、非法输入、run 之间隔离和子 agent 隔离。
+2. 增加 Studio repository、迁移、事件适配和终止处理；验证写入失败、重启恢复、不同 session 隔离及完成标记不被误改。
+3. 接入客户端传输、store、resume 和历史加载；验证重复事件、乱序事件、刷新、多标签页、运行结束后的计划恢复。
+4. 增加任务卡片和多语言文案，用 mock API/Socket 的浏览器测试检查 0/3 → 1/3 → 3/3、停止后未完成、折叠、长标题、历史分页及隐藏工具轨迹时的显示。
+5. 运行相关 Ekko runtime、Studio chat、客户端 store 测试与聊天浏览器测试，再执行 `npm run harness:check` 和 `npm run build`。协议或公共 Ekko 类型变更同步更新包内 API 文档。
+
+验收的核心是：每次有效更新后，同一份计划即时显示准确状态；刷新或重开会话后状态一致；任务未完成时绝不因为运行结束而显示全部完成。
+
+## 实现补充
+
+- 一份计划保存一行最新快照，正常工具调用及返回结果继续通过现有消息持久化链路保存。
+- `taskPlans` 随 Socket resume 与聊天历史分页响应返回；最新页还附带最近一份计划，覆盖计划已提交但工具组消息尚未保存的窗口。
+- 取消信号立即提交 `interrupted`，在聊天流关闭前广播未完成状态。进程启动时，在建表之后恢复上次进程遗留的 running 计划。
+- `TaskPlanCard.vue` 同时用于聊天与历史界面，独立于工具轨迹的显示开关；所有 11 个语言文件均已添加文案。
+- 当前完成标记由 AI 主动调用工具维护，用户不能通过任务卡片手动修改；新一轮任务创建新的计划，历史计划保留。
+
+## 验证结果
+
+- 构建与 `npm run harness:check` 通过。
+- 任务计划专项及聊天适配器：49 项测试通过；另检查了现有 runtime、工具注册、会话存储与客户端聊天逻辑。
+- 任务计划、历史恢复和下载页浏览器复验：11 项通过；此前完整浏览器回归 175 项通过，下载页单项复验通过。
+- `PORT=8648 npm run test:coverage -- --maxWorkers=4`：5119 项通过，44 项失败，6 项跳过。将这 44 个失败与未修改的 HEAD 隔离检出逐项比较，失败名称完全一致，没有新增失败。
+- 浏览器使用模拟模型事件与 API；未调用真实模型供应商或修改用户聊天数据。

--- a/packages/client/src/api/studio/chat.ts
+++ b/packages/client/src/api/studio/chat.ts
@@ -1,3 +1,4 @@
+import type { TaskPlanSnapshot } from '@/utils/task-plan'
 import { io, type Socket } from 'socket.io-client'
 import { getBaseUrlValue, getApiKey } from '../client'
 import type { ChatCodingAgentId } from '../coding-agents'
@@ -159,6 +160,7 @@ export interface RunEvent {
 }
 
 export interface ResumeSessionPayload {
+  taskPlans?: TaskPlanSnapshot[]
   session_id: string
   messages: any[]
   workspaceRunChanges?: import('./sessions').WorkspaceRunChangeSummary[]
@@ -855,6 +857,7 @@ export function connectChatRun(requestedProfile?: string | null, transport: Chat
 
     // Usage events
     chatRunSocket.on('usage.updated', globalUsageUpdatedHandler)
+    chatRunSocket.on('plan.updated', globalAgentEventHandler)
     chatRunSocket.on('agent.event', globalAgentEventHandler)
     chatRunSocket.on('run.reattach_failed', globalRunReattachFailedHandler)
     chatRunSocket.on('session.command', globalSessionCommandHandler)

--- a/packages/client/src/api/studio/sessions.ts
+++ b/packages/client/src/api/studio/sessions.ts
@@ -74,6 +74,7 @@ export interface SessionContext {
 export interface PaginatedSessionMessages {
   session: SessionSummary
   messages: HermesMessage[]
+  taskPlans?: import('@/utils/task-plan').TaskPlanSnapshot[]
   workspaceRunChanges: WorkspaceRunChangeSummary[]
   total: number
   offset: number

--- a/packages/client/src/components/hermes/chat/HistoryMessageList.vue
+++ b/packages/client/src/components/hermes/chat/HistoryMessageList.vue
@@ -41,6 +41,7 @@ const listInstanceKey = computed(() => activeSessionScrollKey.value || "history-
 const displayMessages = computed(() =>
   groupCompletedToolsByRun((activeSession.value?.messages || []).filter((m) => {
     // Tool messages without a name are internal use only and remain hidden.
+    if (m.taskPlan) return true
     if (m.role === 'tool') return toolTraceVisible.value && !!m.toolName
     // Filter out messages with empty content.
     if (!m.content?.trim()) return false

--- a/packages/client/src/components/hermes/chat/MessageItem.vue
+++ b/packages/client/src/components/hermes/chat/MessageItem.vue
@@ -16,6 +16,7 @@ import { useFilesStore } from "@/stores/hermes/files";
 import { useToolPanelStore } from "@/stores/hermes/tool-panel";
 import { useSettingsStore } from "@/stores/hermes/settings";
 import { chatSessionAgentAvatar, type ChatAgentAvatar } from "@/utils/chat-agent-avatar";
+import TaskPlanCard from './TaskPlanCard.vue';
 import ToolChangeCard from "./ToolChangeCard.vue";
 import {
   copyTextToClipboard,
@@ -897,7 +898,8 @@ onBeforeUnmount(() => {
     :class="[message.role, { highlight }]"
     :id="`message-${message.id}`"
   >
-    <template v-if="message.role === 'tool'">
+    <TaskPlanCard v-if="message.taskPlan" :plan="message.taskPlan" />
+    <template v-else-if="message.role === 'tool'">
       <div
         class="tool-line"
         :class="{ expandable: hasInlineToolDetails || isSubagentTool, 'subagent-entry': isSubagentTool }"

--- a/packages/client/src/components/hermes/chat/TaskPlanCard.vue
+++ b/packages/client/src/components/hermes/chat/TaskPlanCard.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import type { TaskPlanSnapshot } from '@/utils/task-plan'
+
+const props = defineProps<{ plan: TaskPlanSnapshot }>()
+const { t } = useI18n()
+const expanded = ref(true)
+const completed = computed(() => props.plan.plan.filter(step => step.status === 'completed').length)
+const stateLabel = computed(() => completed.value === props.plan.plan.length
+  ? t('taskPlan.completed')
+  : t(`taskPlan.${props.plan.execution_state}`))
+</script>
+
+<template>
+  <section class="task-plan-card" data-testid="task-plan-card">
+    <button class="plan-header" type="button" :aria-expanded="expanded" @click="expanded = !expanded">
+      <span class="plan-title">{{ t('taskPlan.title') }}</span>
+      <span class="plan-count" aria-live="polite">{{ t('taskPlan.progress', { completed, total: plan.plan.length }) }}</span>
+      <span aria-hidden="true">{{ expanded ? '▾' : '▸' }}</span>
+    </button>
+    <div v-if="expanded" class="plan-body">
+      <ol>
+        <li v-for="step in plan.plan" :key="step.id" :class="step.status">
+          <span class="step-icon" aria-hidden="true">{{ step.status === 'completed' ? '✓' : step.status === 'in_progress' ? '◉' : '○' }}</span>
+          <span class="step-title" dir="auto">{{ step.step }}</span>
+          <span class="step-status">{{ t(`taskPlan.${step.status}`) }}</span>
+        </li>
+      </ol>
+      <p v-if="plan.explanation" class="plan-explanation" dir="auto">{{ plan.explanation }}</p>
+      <p class="plan-state">{{ stateLabel }}</p>
+    </div>
+  </section>
+</template>
+
+<style scoped lang="scss">
+.task-plan-card { color: var(--text-primary, #1a1a1a); background: var(--bg-card, #fff); width: 100%; max-width: 680px; border: 1px solid var(--border-color, #8884); border-radius: 12px; overflow: hidden; }
+.plan-header { display: flex; align-items: center; gap: 12px; width: 100%; padding: 12px 16px; border: 0; color: inherit; background: transparent; cursor: pointer; text-align: start; font: inherit; }
+.plan-header:focus-visible { outline: 2px solid var(--accent-primary, #333333); outline-offset: -3px; }
+.plan-title { font-weight: 600; }
+.plan-count { margin-inline-start: auto; font-size: 12px; opacity: .75; }
+.plan-body { padding: 0 16px 12px; }
+ol { list-style: none; padding: 0; margin: 0; }
+li { display: flex; align-items: baseline; gap: 10px; padding: 6px 0; }
+.step-icon { flex: 0 0 16px; }
+.step-title { flex: 1; min-width: 0; overflow-wrap: anywhere; }
+.step-status { flex-shrink: 0; font-size: 12px; opacity: .7; }
+.completed .step-icon { color: var(--success, #2e7d32); }
+.in_progress .step-icon { color: var(--accent-primary, #333333); }
+.plan-explanation, .plan-state { margin: 8px 0 0; font-size: 12px; opacity: .7; overflow-wrap: anywhere; }
+@media (max-width: 480px) { .plan-header { gap: 8px; padding-inline: 12px; } .plan-body { padding-inline: 12px; } }
+</style>

--- a/packages/client/src/i18n/locales/ar.ts
+++ b/packages/client/src/i18n/locales/ar.ts
@@ -1,6 +1,7 @@
 import { socialMessagesAr } from '../social-messages-locales'
 
 export default {
+  taskPlan: {"title": "خطة المهام", "progress": "اكتمل {completed}/{total}", "pending": "غير مكتمل", "in_progress": "قيد التقدم", "completed": "مكتمل", "running": "قيد التنفيذ", "ended": "انتهى التنفيذ؛ توجد خطوات غير مكتملة", "interrupted": "تمت المقاطعة؛ توجد خطوات غير مكتملة", "failed": "فشل التنفيذ؛ توجد خطوات غير مكتملة"},
   agentAutoUpdate: { label: 'التحديثات التلقائية' },
   ekkoConfig: {
     "settingsTitle": "الإعدادات",

--- a/packages/client/src/i18n/locales/de.ts
+++ b/packages/client/src/i18n/locales/de.ts
@@ -1,6 +1,7 @@
 import { socialMessagesDe } from '../social-messages-locales'
 
 export default {
+  taskPlan: {"title": "Aufgabenplan", "progress": "{completed}/{total} abgeschlossen", "pending": "Nicht abgeschlossen", "in_progress": "In Bearbeitung", "completed": "Abgeschlossen", "running": "Wird ausgeführt", "ended": "Lauf beendet; Schritte bleiben offen", "interrupted": "Unterbrochen; Schritte bleiben offen", "failed": "Lauf fehlgeschlagen; Schritte bleiben offen"},
   agentAutoUpdate: { label: 'Automatische Updates' },
   ekkoConfig: {
     "settingsTitle": "Einstellungen",

--- a/packages/client/src/i18n/locales/en.ts
+++ b/packages/client/src/i18n/locales/en.ts
@@ -1,6 +1,7 @@
 import { socialMessagesEn } from '../social-messages'
 
 export default {
+  taskPlan: {"title": "Task plan", "progress": "{completed}/{total} completed", "pending": "Not completed", "in_progress": "In progress", "completed": "Completed", "running": "Running", "ended": "Run ended; unfinished steps remain", "interrupted": "Interrupted; unfinished steps remain", "failed": "Run failed; unfinished steps remain"},
   agentAutoUpdate: { label: 'Automatic updates' },
   ekkoConfig: {
     "settingsTitle": "Settings",

--- a/packages/client/src/i18n/locales/es.ts
+++ b/packages/client/src/i18n/locales/es.ts
@@ -1,6 +1,7 @@
 import { socialMessagesEs } from '../social-messages-locales'
 
 export default {
+  taskPlan: {"title": "Plan de tareas", "progress": "{completed}/{total} completadas", "pending": "Pendiente", "in_progress": "En curso", "completed": "Completado", "running": "En ejecución", "ended": "Ejecución finalizada; quedan pasos pendientes", "interrupted": "Interrumpido; quedan pasos pendientes", "failed": "Ejecución fallida; quedan pasos pendientes"},
   agentAutoUpdate: { label: 'Actualizaciones automáticas' },
   ekkoConfig: {
     "settingsTitle": "Configuración",

--- a/packages/client/src/i18n/locales/fr.ts
+++ b/packages/client/src/i18n/locales/fr.ts
@@ -1,6 +1,7 @@
 import { socialMessagesFr } from '../social-messages-locales'
 
 export default {
+  taskPlan: {"title": "Plan des tâches", "progress": "{completed}/{total} terminées", "pending": "Non terminé", "in_progress": "En cours", "completed": "Terminé", "running": "Exécution en cours", "ended": "Exécution terminée ; des étapes restent à faire", "interrupted": "Interrompu ; des étapes restent à faire", "failed": "Échec ; des étapes restent à faire"},
   agentAutoUpdate: { label: 'Mises à jour automatiques' },
   ekkoConfig: {
     "settingsTitle": "Paramètres",

--- a/packages/client/src/i18n/locales/ja.ts
+++ b/packages/client/src/i18n/locales/ja.ts
@@ -1,6 +1,7 @@
 import { socialMessagesJa } from '../social-messages-locales'
 
 export default {
+  taskPlan: {"title": "タスク計画", "progress": "{completed}/{total} 完了", "pending": "未完了", "in_progress": "進行中", "completed": "完了", "running": "実行中", "ended": "実行終了・未完了の手順があります", "interrupted": "中断・未完了の手順があります", "failed": "実行失敗・未完了の手順があります"},
   agentAutoUpdate: { label: '自動更新' },
   ekkoConfig: {
     "settingsTitle": "設定",

--- a/packages/client/src/i18n/locales/ko.ts
+++ b/packages/client/src/i18n/locales/ko.ts
@@ -1,6 +1,7 @@
 import { socialMessagesKo } from '../social-messages-locales'
 
 export default {
+  taskPlan: {"title": "작업 계획", "progress": "{completed}/{total} 완료", "pending": "미완료", "in_progress": "진행 중", "completed": "완료", "running": "실행 중", "ended": "실행 종료 · 미완료 단계가 있습니다", "interrupted": "중단됨 · 미완료 단계가 있습니다", "failed": "실행 실패 · 미완료 단계가 있습니다"},
   agentAutoUpdate: { label: '자동 업데이트' },
   ekkoConfig: {
     "settingsTitle": "설정",

--- a/packages/client/src/i18n/locales/pt.ts
+++ b/packages/client/src/i18n/locales/pt.ts
@@ -1,6 +1,7 @@
 import { socialMessagesPt } from '../social-messages-locales'
 
 export default {
+  taskPlan: {"title": "Plano de tarefas", "progress": "{completed}/{total} concluídas", "pending": "Pendente", "in_progress": "Em andamento", "completed": "Concluído", "running": "Em execução", "ended": "Execução encerrada; há etapas pendentes", "interrupted": "Interrompido; há etapas pendentes", "failed": "Falha na execução; há etapas pendentes"},
   agentAutoUpdate: { label: 'Atualizações automáticas' },
   ekkoConfig: {
     "settingsTitle": "Configurações",

--- a/packages/client/src/i18n/locales/ru.ts
+++ b/packages/client/src/i18n/locales/ru.ts
@@ -1,6 +1,7 @@
 import { socialMessagesRu } from '../social-messages-locales'
 
 export default {
+  taskPlan: {"title": "План задач", "progress": "Завершено: {completed}/{total}", "pending": "Не завершено", "in_progress": "В процессе", "completed": "Завершено", "running": "Выполняется", "ended": "Запуск завершён; остались незавершённые шаги", "interrupted": "Прервано; остались незавершённые шаги", "failed": "Ошибка выполнения; остались незавершённые шаги"},
   agentAutoUpdate: { label: 'Автоматические обновления' },
   ekkoConfig: {
     "settingsTitle": "Настройки",

--- a/packages/client/src/i18n/locales/zh-TW.ts
+++ b/packages/client/src/i18n/locales/zh-TW.ts
@@ -1,6 +1,7 @@
 import { socialMessagesZhTw } from '../social-messages'
 
 export default {
+  taskPlan: {"title": "任務計畫", "progress": "{completed}/{total} 已完成", "pending": "未完成", "in_progress": "進行中", "completed": "已完成", "running": "執行中", "ended": "本次執行已結束，其餘步驟未完成", "interrupted": "已中斷，其餘步驟未完成", "failed": "執行失敗，其餘步驟未完成"},
   agentAutoUpdate: { label: '自動更新' },
   ekkoConfig: {
     "settingsTitle": "設定",

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -1,6 +1,7 @@
 import { socialMessagesZh } from '../social-messages'
 
 export default {
+  taskPlan: {"title": "任务计划", "progress": "{completed}/{total} 已完成", "pending": "未完成", "in_progress": "进行中", "completed": "已完成", "running": "执行中", "ended": "本次运行已结束，剩余步骤未完成", "interrupted": "已中断，剩余步骤未完成", "failed": "运行失败，剩余步骤未完成"},
   agentAutoUpdate: { label: '自动更新' },
   ekkoConfig: {
     "settingsTitle": "设置",

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -1,3 +1,4 @@
+import { mergeTaskPlanMessages, type TaskPlanSnapshot } from '@/utils/task-plan'
 import { startRunViaSocket, resumeSession, registerSessionHandlers, unregisterSessionHandlers, getChatRunSocket, respondToolApproval, onPeerUserMessage, onSessionCommand, onSessionTitleUpdated, onSessionWorkspaceUpdated, onSessionSettingsUpdated, respondClarify, type ChatRunTransport, type RunEvent, type ResumeSessionPayload, type StartRunRequest, type ContentBlock as ContentBlockImport } from '@/api/studio/chat'
 import { archiveSession as archiveSessionApi, deleteSession as deleteSessionApi, fetchSessionMessagesPage, fetchSessions, fetchWorkspaceRunChangeFile, setSessionModel, setSessionPushEnabled as persistSessionPushEnabled, setSessionReasoningEffort as persistSessionReasoningEffort, type HermesMessage, type SessionSummary, type WorkspaceRunChangeFileDetail, type WorkspaceRunChangeSummary } from '@/api/studio/sessions'
 import { getActiveProfileName } from '@/api/client'
@@ -74,6 +75,7 @@ export interface Attachment {
 }
 
 export interface Message {
+  taskPlan?: TaskPlanSnapshot
   id: string
   role: 'user' | 'assistant' | 'system' | 'tool' | 'command'
   content: string
@@ -885,7 +887,7 @@ function resolveResumedAssistantState(
   }
 }
 
-function mapHermesMessages(msgs: HermesMessage[]): Message[] {
+function mapHermesMessages(msgs: HermesMessage[], taskPlans: unknown[] = [], previous: Message[] = []): Message[] {
   // Filter out assistant messages with no display content unless they carry tool call metadata
   // needed to name later tool result rows when resuming persisted history.
   const filteredMsgs = msgs.filter(m => {
@@ -1106,7 +1108,9 @@ function mapHermesMessages(msgs: HermesMessage[]): Message[] {
       runMarker: readRunMarker(msg),
     })
   }
-  return result
+  const restored = mergeTaskPlanMessages(result, taskPlans)
+  const restoredIds = new Set(restored.map(message => message.id))
+  return mergeTaskPlanMessages(restored, previous.filter(message => message.taskPlan && restoredIds.has(message.id)).map(message => message.taskPlan))
 }
 
 function sessionActivitySeconds(s: SessionSummary): number {
@@ -1841,7 +1845,7 @@ export const useChatStore = defineStore('chat', () => {
       )
       const detail = await fetchSessionMessagesPage(sid, 0, limit, activeSession.value?.profile)
       if (!detail) return false
-      const mapped = mapHermesMessages(detail.messages || [])
+      const mapped = mapHermesMessages(detail.messages || [], detail.taskPlans, target.messages)
       target.messages = mapped
       restorePersistedSubagentStreams(sid)
       setWorkspaceRunChanges(sid, detail.workspaceRunChanges || [])
@@ -2006,8 +2010,8 @@ export const useChatStore = defineStore('chat', () => {
           target.parentTitle = (data as any).parentTitle || target.parentTitle || null
           target.parentLastMessage = (data as any).parentLastMessage || target.parentLastMessage || null
           target.parentLastMessageRole = (data as any).parentLastMessageRole || target.parentLastMessageRole || null
-          if (data.messages?.length) {
-            target.messages = mapHermesMessages(data.messages as any[])
+          if (Array.isArray(data.messages)) {
+            target.messages = mapHermesMessages(data.messages as any[], data.taskPlans, target.messages)
             restorePersistedSubagentStreams(sessionId)
             setWorkspaceRunChanges(sessionId, data.workspaceRunChanges || [])
             target.loadedMessageCount = data.messageLoadedCount ?? data.messages.length
@@ -2066,7 +2070,7 @@ export const useChatStore = defineStore('chat', () => {
                 addAgentErrorMessage(sessionId, e.error)
                 serverWorking.value.delete(sessionId)
                 queueLengths.value.delete(sessionId)
-              } else if (e.event === 'agent.event' || e.event === 'run.reattach_failed') {
+              } else if (e.event === 'plan.updated' || e.event === 'agent.event' || e.event === 'run.reattach_failed') {
                 handleAgentEvent(e)
               } else if (e.event === 'workspace.diff.completed') {
                 handleWorkspaceRunChangeEvent(sessionId, e)
@@ -2133,7 +2137,7 @@ export const useChatStore = defineStore('chat', () => {
 
       const existingIds = new Set(target.messages.map(message => message.id))
       const olderMessages = mapHermesMessages(page.messages).filter(message => !existingIds.has(message.id))
-      target.messages = [...olderMessages, ...target.messages]
+      target.messages = mergeTaskPlanMessages([...olderMessages, ...target.messages], page.taskPlans || [], sessionId)
       restorePersistedSubagentStreams(sessionId)
       mergeWorkspaceRunChanges(sessionId, page.workspaceRunChanges || [])
       target.loadedMessageCount = offset + page.messages.length
@@ -2908,6 +2912,11 @@ export const useChatStore = defineStore('chat', () => {
   function handleAgentEvent(evt: RunEvent) {
     const sid = evt.session_id
     if (!sid) return
+    if (evt.event === 'plan.updated') {
+      const target = sessions.value.find(session => session.id === sid)
+      if (target) target.messages = mergeTaskPlanMessages(target.messages, [evt], sid)
+      return
+    }
     if ((evt as any).source === 'coding_agent' && (evt as any).kind === 'status') return
     const text = String((evt as any).text || (evt as any).message || '').trim()
     if (!text) return
@@ -3723,7 +3732,7 @@ export const useChatStore = defineStore('chat', () => {
           const previousActiveAssistantMessageId = activeAssistantMessageId
           const previousReasoningAssistantMessageId = reasoningAssistantMessageId
           const replayRunMarker = getReplayRunMarker(data.events) ?? activeRunMarker
-          target.messages = mapHermesMessages(data.messages as any[])
+          target.messages = mapHermesMessages(data.messages as any[], data.taskPlans, target.messages)
           restorePersistedSubagentStreams(sid)
           setWorkspaceRunChanges(sid, data.workspaceRunChanges || [])
           target.loadedMessageCount = data.messageLoadedCount ?? data.messages.length
@@ -3815,6 +3824,7 @@ export const useChatStore = defineStore('chat', () => {
                 handleTerminalWorkspaceRunChange(sid, e)
                 if (!isQueueInsertionInterruption(e)) addAgentErrorMessage(sid, e.error)
                 break
+              case 'plan.updated':
               case 'agent.event':
                 handleAgentEvent(e)
                 break
@@ -3883,6 +3893,7 @@ export const useChatStore = defineStore('chat', () => {
               break
             }
 
+            case 'plan.updated':
             case 'agent.event': {
               handleAgentEvent(evt)
               break
@@ -4531,6 +4542,7 @@ export const useChatStore = defineStore('chat', () => {
           break
         }
 
+        case 'plan.updated':
         case 'agent.event': {
           handleAgentEvent(evt)
           break
@@ -5199,12 +5211,12 @@ export const useChatStore = defineStore('chat', () => {
             }
             if (!data.isWorking) setCompressionState(sid, null)
             applyResumedSessionSettings(data)
-            if (data.messages?.length && activeSession.value) {
+            if (Array.isArray(data.messages) && activeSession.value) {
               if (typeof data.workspace === 'string') {
                 activeSession.value.workspace = data.workspace.trim() || null
                 activeSession.value.isLocalOnly = false
               }
-              activeSession.value.messages = mapHermesMessages(data.messages as any[])
+              activeSession.value.messages = mapHermesMessages(data.messages as any[], data.taskPlans, activeSession.value.messages)
               restorePersistedSubagentStreams(sid)
               setWorkspaceRunChanges(sid, data.workspaceRunChanges || [])
               activeSession.value.loadedMessageCount = data.messageLoadedCount ?? data.messages.length

--- a/packages/client/src/utils/task-plan.ts
+++ b/packages/client/src/utils/task-plan.ts
@@ -1,0 +1,55 @@
+import type { Message } from '@/stores/hermes/chat'
+
+export interface TaskPlanSnapshot {
+  session_id: string
+  run_id: string
+  plan_id: string
+  revision: number
+  execution_state: 'running' | 'ended' | 'interrupted' | 'failed'
+  explanation?: string
+  plan: Array<{ id: string; step: string; status: 'pending' | 'in_progress' | 'completed' }>
+  created_at: number
+  updated_at: number
+}
+
+export function parseTaskPlan(value: unknown): TaskPlanSnapshot | null {
+  if (!value || typeof value !== 'object') return null
+  const p = value as TaskPlanSnapshot
+  if (![p.session_id, p.run_id, p.plan_id].every(id => typeof id === 'string' && id.length > 0)) return null
+  if (!Number.isSafeInteger(p.revision) || p.revision < 1 || !Number.isFinite(p.created_at) || !Number.isFinite(p.updated_at)) return null
+  if (!['running', 'ended', 'interrupted', 'failed'].includes(p.execution_state)) return null
+  if (p.explanation !== undefined && typeof p.explanation !== 'string') return null
+  if (!Array.isArray(p.plan) || p.plan.length < 1 || p.plan.length > 30) return null
+  const ids = new Set<string>()
+  for (const step of p.plan) {
+    if (!step || typeof step.id !== 'string' || !step.id.trim() || ids.has(step.id)) return null
+    if (typeof step.step !== 'string' || !step.step.trim() || step.step.length > 200) return null
+    if (!['pending', 'in_progress', 'completed'].includes(step.status)) return null
+    ids.add(step.id)
+  }
+  return p
+}
+
+/** Keep a single card per plan across stream replay and paginated history. */
+export function mergeTaskPlanMessages(messages: Message[], plans: unknown[], sessionId?: string): Message[] {
+  const result = [...messages]
+  for (const raw of plans) {
+    const plan = parseTaskPlan(raw)
+    if (!plan || (sessionId && plan.session_id !== sessionId)) continue
+    const id = `task-plan:${plan.session_id}:${plan.plan_id}`
+    const existing = result.findIndex(message => message.id === id)
+    if (existing >= 0 && (result[existing].taskPlan?.revision ?? 0) >= plan.revision) continue
+    const message: Message = {
+      id, role: 'system', content: '', timestamp: plan.created_at,
+      runMarker: plan.run_id, taskPlan: plan,
+    }
+    if (existing >= 0) {
+      result[existing] = message
+    } else {
+      let index = result.findIndex(item => item.runMarker === plan.run_id && item.role !== 'user' && item.role !== 'command')
+      if (index < 0) index = result.findIndex(item => item.timestamp > plan.created_at)
+      result.splice(index < 0 ? result.length : index, 0, message)
+    }
+  }
+  return result
+}

--- a/packages/client/src/views/hermes/HistoryView.vue
+++ b/packages/client/src/views/hermes/HistoryView.vue
@@ -9,6 +9,7 @@ import { NButton, NDropdown, NPopconfirm, NTooltip, useMessage, type DropdownOpt
 import { useI18n } from 'vue-i18n'
 import { getSourceLabel } from '@/shared/session-display'
 import { copyToClipboard } from '@/utils/clipboard'
+import { mergeTaskPlanMessages } from '@/utils/task-plan'
 import HistoryMessageList from '@/components/hermes/chat/HistoryMessageList.vue'
 import SessionListItem from '@/components/hermes/chat/SessionListItem.vue'
 import OutlinePanel from '@/components/hermes/chat/OutlinePanel.vue'
@@ -246,7 +247,7 @@ async function loadHistorySession(sessionId: string, profile?: string | null) {
 
   if (page) {
     const base = summary || page.session
-    sessionData = sessionFromSummary(base, mapHistoryMessages(page.messages))
+    sessionData = sessionFromSummary(base, mergeTaskPlanMessages(mapHistoryMessages(page.messages), page.taskPlans || [], sessionId))
     sessionData.profile = summary?.profile || sessionProfile || undefined
     sessionData.messageCount = page.total
     sessionData.messageTotal = page.total
@@ -304,7 +305,7 @@ async function loadOlderHistoryMessages(sessionId: string): Promise<boolean> {
 
     const existingIds = new Set(target.messages.map(message => message.id))
     const olderMessages = mapHistoryMessages(page.messages).filter(message => !existingIds.has(message.id))
-    target.messages = [...olderMessages, ...target.messages]
+    target.messages = mergeTaskPlanMessages([...olderMessages, ...target.messages], page.taskPlans || [], sessionId)
     target.loadedMessageCount = offset + page.messages.length
     target.messageTotal = page.total
     target.messageCount = page.total

--- a/packages/ekko-agent/docs/API.md
+++ b/packages/ekko-agent/docs/API.md
@@ -1381,6 +1381,10 @@ export { OpenAICompatibleModelClient, normalizeOpenAIChatResponse, toOpenAIChatP
 export { OpenAIResponsesModelClient, normalizeOpenAIResponsesResponse, toOpenAIResponsesPayload, } from './model/providers/openai-responses'
 
 export { PromptCompletionModelClient, normalizePromptCompletionResponse, toPromptCompletionPayload, } from './model/providers/prompt-completion'
+
+export { UpdatePlanTool } from './tools/plan'
+
+export type { AgentPlanStep, AgentPlanUpdate, AgentTaskPlan } from './tools/plan'
 ```
 ### `src/logging/file-logger.ts`
 
@@ -2522,7 +2526,7 @@ export class EkkoRecoveryService {
 ### `src/runtime/events.ts`
 
 ```ts
-export type AgentRuntimeEvent = | { type: 'run.started'; runId: string; maxSteps: number } | { type: 'memory.retrieved'; runId: string; diagnostics: MemoryContextDiagnostics; memoryIds: string[] } | { type: 'skill.review.started'; runId: string; reviewId: string } | { type: 'skill.review.completed'; runId: string; reviewId: string; mutations: number } | { type: 'skill.review.failed'; runId: string; reviewId: string; error: string } | { type: 'model.started'; runId: string; step: number } | { type: 'context.estimated'; runId: string; step: number; estimate: AgentRuntimeContextEstimate } | { type: 'model.retry'; runId: string; step: number; retry: number; maxRetries: number; error: string } | { type: 'model.message'; runId: string; step: number; message: AgentOutputMessage } | { type: 'model.delta'; runId: string; step: number; text: string } | { type: 'model.reasoning'; runId: string; step: number; text: string } | { type: 'model.tool_call'; runId: string; step: number; toolCall: AgentToolCall } | { type: 'model.usage'; runId: string; step: number; usage: ModelUsage } | { type: 'model.context'; runId: string; step: number; context: unknown } | { type: 'tool.started'; runId: string; step: number; toolCallId: string; toolName: string; arguments: Record<string, unknown> } | { type: 'tool.completed'; runId: string; step: number; toolCallId: string; toolName: string; result: AgentToolResult; durationMs: number } | { type: 'tool.failed'; runId: string; step: number; toolCallId: string; toolName: string; result: AgentToolResult; durationMs: number } | { type: 'subagent.start'; runId: string; subagentId: string; goal: string; background: boolean; model?: string; startedAt: number } | { type: 'subagent.text'; runId: string; childRunId?: string; subagentId: string; goal: string; background: boolean; text: string } | { type: 'subagent.thinking'; runId: string; childRunId?: string; subagentId: string; goal: string; background: boolean; text: string } | { type: 'subagent.tool'; runId: string; childRunId?: string; subagentId: string; goal: string; background: boolean; toolName: string; arguments: Record<string, unknown>; toolCount: number } | { type: 'subagent.complete' runId: string childRunId?: string subagentId: string goal: string background: boolean status: 'completed' | 'failed' | 'interrupted' summary: string output: string outputTail: string durationMs: number toolCount: number apiCalls: number inputTokens: number outputTokens: number cacheReadTokens: number cacheWriteTokens: number reasoningTokens: number continuationContext?: EkkoBackgroundContinuationContext } | { type: 'run.tool_recovery_required'; runId: string; toolName: string; failures: number } | { type: 'run.completed'; runId: string; output: AgentOutputMessage; steps: number; context?: unknown; contextEstimate?: AgentRuntimeContextEstimate } | { type: 'run.failed'; runId: string; error: string; steps: number } | { type: 'run.max_steps'; runId: string; maxSteps: number }
+export type AgentRuntimeEvent = | { type: 'plan.updated'; runId: string; plan: import('../tools/plan').AgentTaskPlan } | { type: 'run.started'; runId: string; maxSteps: number } | { type: 'memory.retrieved'; runId: string; diagnostics: MemoryContextDiagnostics; memoryIds: string[] } | { type: 'skill.review.started'; runId: string; reviewId: string } | { type: 'skill.review.completed'; runId: string; reviewId: string; mutations: number } | { type: 'skill.review.failed'; runId: string; reviewId: string; error: string } | { type: 'model.started'; runId: string; step: number } | { type: 'context.estimated'; runId: string; step: number; estimate: AgentRuntimeContextEstimate } | { type: 'model.retry'; runId: string; step: number; retry: number; maxRetries: number; error: string } | { type: 'model.message'; runId: string; step: number; message: AgentOutputMessage } | { type: 'model.delta'; runId: string; step: number; text: string } | { type: 'model.reasoning'; runId: string; step: number; text: string } | { type: 'model.tool_call'; runId: string; step: number; toolCall: AgentToolCall } | { type: 'model.usage'; runId: string; step: number; usage: ModelUsage } | { type: 'model.context'; runId: string; step: number; context: unknown } | { type: 'tool.started'; runId: string; step: number; toolCallId: string; toolName: string; arguments: Record<string, unknown> } | { type: 'tool.completed'; runId: string; step: number; toolCallId: string; toolName: string; result: AgentToolResult; durationMs: number } | { type: 'tool.failed'; runId: string; step: number; toolCallId: string; toolName: string; result: AgentToolResult; durationMs: number } | { type: 'subagent.start'; runId: string; subagentId: string; goal: string; background: boolean; model?: string; startedAt: number } | { type: 'subagent.text'; runId: string; childRunId?: string; subagentId: string; goal: string; background: boolean; text: string } | { type: 'subagent.thinking'; runId: string; childRunId?: string; subagentId: string; goal: string; background: boolean; text: string } | { type: 'subagent.tool'; runId: string; childRunId?: string; subagentId: string; goal: string; background: boolean; toolName: string; arguments: Record<string, unknown>; toolCount: number } | { type: 'subagent.complete' runId: string childRunId?: string subagentId: string goal: string background: boolean status: 'completed' | 'failed' | 'interrupted' summary: string output: string outputTail: string durationMs: number toolCount: number apiCalls: number inputTokens: number outputTokens: number cacheReadTokens: number cacheWriteTokens: number reasoningTokens: number continuationContext?: EkkoBackgroundContinuationContext } | { type: 'run.tool_recovery_required'; runId: string; toolName: string; failures: number } | { type: 'run.completed'; runId: string; output: AgentOutputMessage; steps: number; context?: unknown; contextEstimate?: AgentRuntimeContextEstimate } | { type: 'run.failed'; runId: string; error: string; steps: number } | { type: 'run.max_steps'; runId: string; maxSteps: number }
 ```
 ### `src/runtime/manager.ts`
 
@@ -2560,6 +2564,7 @@ export interface SystemPromptInput {
   runtimeInstructions?: string[]
   userSystemMessages?: string[]
   memoryContext?: string
+  planningEnabled?: boolean
   clarificationEnabled?: boolean
   skillDiscoveryEnabled?: boolean
   skillManagementEnabled?: boolean
@@ -2668,6 +2673,7 @@ export interface AgentRuntimeRunInput {
   backgroundDelegationEnabled?: boolean
   logContext?: EkkoRuntimeLogContext
   onSkillReviewUsage?: (input: SkillReviewUsageEvent) => void
+  onPlanUpdate?: (plan: import('../tools/plan').AgentTaskPlan) => void
   onEvent?: (event: AgentRuntimeEvent) => void
 }
 
@@ -3098,6 +3104,42 @@ export function resolveUnrestrictedToolPath( inputPath: string, context: { cwd?:
 
 export function resolveToolPath(inputPath: string, context: { cwd?: string; workspaceRoot?: string } = {}): string
 ```
+### `src/tools/plan.ts`
+
+```ts
+export interface AgentPlanStep {
+  id: string
+  step: string
+  status: 'pending' | 'in_progress' | 'completed'
+}
+
+export interface AgentPlanUpdate {
+  explanation?: string
+  plan: AgentPlanStep[]
+}
+
+export interface AgentTaskPlan extends AgentPlanUpdate {
+  runId: string
+  planId: string
+  revision: number
+  executionState: 'running' | 'ended' | 'interrupted' | 'failed'
+  createdAt: number
+  updatedAt: number
+}
+
+export function parsePlanUpdate(input: Record<string, unknown>): AgentPlanUpdate
+
+export class RunTaskPlan {
+  constructor(private runId: string, private commit: (plan: AgentTaskPlan) => void)
+  update(update: AgentPlanUpdate): AgentTaskPlan
+  finish(state: Exclude<AgentTaskPlan['executionState'], 'running'>): void
+}
+
+export class UpdatePlanTool implements AgentTool {
+  readonly definition = { name: 'update_plan', description: 'Create or update the task plan for this run. Send the complete ordered list on every update. Keep step IDs stable. Mark a step completed only after its work is verified. Use for multi-step tasks; skip simple questions.', parameters: { type: 'object', properties: { explanation: { type: 'string', maxLength: 1000, description: 'Brief reason for the update or scope change.' }, plan: { type: 'array', minItems: 1, maxItems: 30, items: { type: 'object', properties: { id: { type: 'string', minLength: 1, maxLength: 100 }, step: { type: 'string', minLength: 1, maxLength: 200 }, status: { type: 'string', enum: ['pending', 'in_progress', 'completed'] }, }, required: ['id', 'step', 'status'], additionalProperties: false, }, }, }, required: ['plan'], additionalProperties: false, }, }
+  async execute(input: Record<string, unknown>, context?: AgentToolContext): Promise<AgentToolResult>
+}
+```
 ### `src/tools/recovery.ts`
 
 ```ts
@@ -3309,6 +3351,7 @@ export interface AgentToolAuthorizationDecision {
 export type AgentToolAuthorizer = ( toolName: string, input: Record<string, unknown>, context?: AgentToolContext, ) => Promise<AgentToolAuthorizationDecision>
 
 export interface AgentToolContext {
+  updatePlan?: (update: import('./plan').AgentPlanUpdate) => import('./plan').AgentTaskPlan
   runId?: string
   cwd?: string
   workspaceRoot?: string

--- a/packages/ekko-agent/src/index.ts
+++ b/packages/ekko-agent/src/index.ts
@@ -98,3 +98,6 @@ export {
   normalizePromptCompletionResponse,
   toPromptCompletionPayload,
 } from './model/providers/prompt-completion'
+
+export { UpdatePlanTool } from './tools/plan'
+export type { AgentPlanStep, AgentPlanUpdate, AgentTaskPlan } from './tools/plan'

--- a/packages/ekko-agent/src/runtime/events.ts
+++ b/packages/ekko-agent/src/runtime/events.ts
@@ -5,6 +5,7 @@ import type { AgentRuntimeContextEstimate, EkkoBackgroundContinuationContext } f
 import type { MemoryContextDiagnostics } from '../memory/types'
 
 export type AgentRuntimeEvent =
+  | { type: 'plan.updated'; runId: string; plan: import('../tools/plan').AgentTaskPlan }
   | { type: 'run.started'; runId: string; maxSteps: number }
   | { type: 'memory.retrieved'; runId: string; diagnostics: MemoryContextDiagnostics; memoryIds: string[] }
   | { type: 'skill.review.started'; runId: string; reviewId: string }

--- a/packages/ekko-agent/src/runtime/runtime.ts
+++ b/packages/ekko-agent/src/runtime/runtime.ts
@@ -15,6 +15,7 @@ import { countTextTokens } from '../model/tokens'
 import type { AgentMessageInput, AgentOutputMessage } from '../model/messages'
 import type { AgentMessage, AgentToolCall, AgentToolDefinition, ModelRequest, ModelResponse } from '../model/types'
 import type { AgentSkill } from '../skills/types'
+import { RunTaskPlan } from '../tools/plan'
 import { AgentToolRegistry, createDefaultToolRegistry } from '../tools/registry'
 import { sanitizeAgentToolResult } from '../tools/tool-result-sanitizer'
 import type { AgentTaskRequest, AgentToolContext, AgentToolResult } from '../tools/types'
@@ -365,11 +366,25 @@ export class AgentRuntime {
       ?? this.toolFailureRecoveryThreshold,
     ))
     const pendingBackgroundSubagentIds = new Set<string>()
+    const taskPlan = new RunTaskPlan(runId, plan => {
+      input.onPlanUpdate?.(plan)
+      emit({ type: 'plan.updated', runId, plan })
+    })
     const emit = (event: AgentRuntimeEvent) => {
+      if (event.type === 'run.completed') {
+        taskPlan.finish(event.output.finishReason === 'boundary_interrupt' ? 'interrupted' : 'ended')
+      } else if (event.type === 'run.failed') {
+        taskPlan.finish(input.signal?.aborted ? 'interrupted' : 'failed')
+      }
       events.push(event)
       input.onEvent?.(event)
     }
 
+    // Publish interruption before the host closes its stream, even if an active tool
+    // takes time to acknowledge cancellation. The run error path retries failed commits.
+    const interruptPlan = () => {
+      try { taskPlan.finish('interrupted') } catch { /* Retried by run.failed. */ }
+    }
     const inputSkills = this.areSkillsAvailable() ? input.skills ?? [] : []
     this.registerSkillTools(inputSkills)
     const memoryIdentity = this.memoryIdentityFor(input)
@@ -384,6 +399,10 @@ export class AgentRuntime {
 
     const executionToolContext: AgentToolContext = {
       ...(this.runToolContext(input, memoryPreparation?.sourceMessageIds) || {}),
+      updatePlan: update => {
+        throwIfAborted(input.signal)
+        return taskPlan.update(update)
+      },
       runId,
       modelCapabilities: this.modelClientFor(input).capabilities,
       modelProvider: this.modelClientFor(input).provider,
@@ -440,6 +459,7 @@ export class AgentRuntime {
       return { runId, messages, output, steps, events, context, contextEstimate, memoryContext }
     }
 
+    input.signal?.addEventListener('abort', interruptPlan, { once: true })
     try {
       const automaticRecoveryCalls = this.currentRecoveryDirective()?.automaticToolCalls ?? []
       if (automaticRecoveryCalls.length) {
@@ -646,6 +666,7 @@ export class AgentRuntime {
       emit({ type: 'run.failed', runId, error: message, steps: steps.length })
       throw error
     } finally {
+      input.signal?.removeEventListener('abort', interruptPlan)
       for (const subagentId of pendingBackgroundSubagentIds) {
         const task = this.backgroundTasks.get(subagentId)
         task?.controller.abort()
@@ -815,6 +836,7 @@ export class AgentRuntime {
       runtimeInstructions: this.currentRuntimeInstructions(),
       userSystemMessages,
       memoryContext,
+      planningEnabled: this.toolsEnabled && !!this.tools.get('update_plan'),
       clarificationEnabled: this.toolsEnabled && !!this.tools.get('clarify'),
       skillDiscoveryEnabled: this.toolsEnabled && this.areSkillsAvailable() &&
         !!this.tools.get('skill_list') &&

--- a/packages/ekko-agent/src/runtime/system-prompt.ts
+++ b/packages/ekko-agent/src/runtime/system-prompt.ts
@@ -3,6 +3,7 @@ export interface SystemPromptInput {
   runtimeInstructions?: string[]
   userSystemMessages?: string[]
   memoryContext?: string
+  planningEnabled?: boolean
   clarificationEnabled?: boolean
   skillDiscoveryEnabled?: boolean
   skillManagementEnabled?: boolean
@@ -64,6 +65,10 @@ export function buildSystemPrompt(input: SystemPromptInput = {}): string {
     input.context?.platform ?? process.platform,
     input.context?.arch ?? process.arch,
   ))
+  if (input.planningEnabled) sections.push(`## Task Planning
+Use update_plan proactively for tasks with multiple meaningful steps. Skip planning for simple questions or one-step actions.
+Create a short plan before substantial work. Send the complete plan with stable step IDs on every update. Mark the current step in_progress and update completed steps promptly after verifying their outcome. At most one step is in_progress.
+Keep unfinished work pending. A successful tool call or the end of your response does not prove that all steps are complete. Explain changes in scope or reopening completed steps. Before your final response, update the plan to reflect what actually finished.`)
   if (input.clarificationEnabled) sections.push(EKKO_CLARIFICATION_GUIDELINES)
 
   if (input.runtimeInstructions?.length) {

--- a/packages/ekko-agent/src/runtime/types.ts
+++ b/packages/ekko-agent/src/runtime/types.ts
@@ -139,6 +139,8 @@ export interface AgentRuntimeRunInput {
   /** Correlation fields only; log events and payloads remain runtime-owned. */
   logContext?: EkkoRuntimeLogContext
   onSkillReviewUsage?: (input: SkillReviewUsageEvent) => void
+  /** Synchronous durable commit, called before plan.updated is published. Throw to reject an update. */
+  onPlanUpdate?: (plan: import('../tools/plan').AgentTaskPlan) => void
   onEvent?: (event: AgentRuntimeEvent) => void
 }
 

--- a/packages/ekko-agent/src/tools/plan.ts
+++ b/packages/ekko-agent/src/tools/plan.ts
@@ -1,0 +1,124 @@
+import type { AgentTool, AgentToolContext, AgentToolResult } from './types'
+
+export interface AgentPlanStep {
+  id: string
+  step: string
+  status: 'pending' | 'in_progress' | 'completed'
+}
+
+export interface AgentPlanUpdate {
+  explanation?: string
+  plan: AgentPlanStep[]
+}
+
+export interface AgentTaskPlan extends AgentPlanUpdate {
+  runId: string
+  planId: string
+  revision: number
+  executionState: 'running' | 'ended' | 'interrupted' | 'failed'
+  createdAt: number
+  updatedAt: number
+}
+
+export function parsePlanUpdate(input: Record<string, unknown>): AgentPlanUpdate {
+  if (!Array.isArray(input.plan) || input.plan.length < 1 || input.plan.length > 30) {
+    throw new Error('plan must contain between 1 and 30 steps.')
+  }
+  if (input.explanation !== undefined && (typeof input.explanation !== 'string' || input.explanation.length > 1000)) {
+    throw new Error('explanation must be a string of at most 1000 characters.')
+  }
+  const ids = new Set<string>()
+  const plan: AgentPlanStep[] = input.plan.map((item: unknown) => {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) throw new Error('Invalid plan step.')
+    const { id, step, status } = item as Record<string, unknown>
+    if (typeof id !== 'string' || !id.trim() || id.length > 100 || ids.has(id.trim())) {
+      throw new Error('Step IDs must be unique, non-empty strings of at most 100 characters.')
+    }
+    if (typeof step !== 'string' || !step.trim() || step.length > 200) {
+      throw new Error('Step titles must be non-empty strings of at most 200 characters.')
+    }
+    if (status !== 'pending' && status !== 'in_progress' && status !== 'completed') {
+      throw new Error('Step status must be pending, in_progress, or completed.')
+    }
+    ids.add(id.trim())
+    return { id: id.trim(), step: step.trim(), status }
+  })
+  if (plan.filter(step => step.status === 'in_progress').length > 1) {
+    throw new Error('Only one step may be in_progress.')
+  }
+  return { plan, ...(typeof input.explanation === 'string' ? { explanation: input.explanation.trim() } : {}) }
+}
+
+/** One instance per run; commit must succeed before publishing a new snapshot. */
+export class RunTaskPlan {
+  private snapshot?: AgentTaskPlan
+
+  constructor(private runId: string, private commit: (plan: AgentTaskPlan) => void) {}
+
+  update(update: AgentPlanUpdate): AgentTaskPlan {
+    const now = Date.now()
+    const next: AgentTaskPlan = {
+      ...structuredClone(update),
+      runId: this.runId,
+      planId: this.runId,
+      revision: (this.snapshot?.revision ?? 0) + 1,
+      executionState: 'running',
+      createdAt: this.snapshot?.createdAt ?? now,
+      updatedAt: now,
+    }
+    this.commit(structuredClone(next))
+    this.snapshot = next
+    return structuredClone(next)
+  }
+
+  finish(state: Exclude<AgentTaskPlan['executionState'], 'running'>): void {
+    if (!this.snapshot || this.snapshot.executionState !== 'running') return
+    const next: AgentTaskPlan = {
+      ...this.snapshot,
+      revision: this.snapshot.revision + 1,
+      executionState: state,
+      updatedAt: Date.now(),
+      plan: this.snapshot.plan.map(step => ({ ...step, status: step.status === 'in_progress' ? 'pending' : step.status })),
+    }
+    this.commit(structuredClone(next))
+    this.snapshot = next
+  }
+}
+
+export class UpdatePlanTool implements AgentTool {
+  readonly definition = {
+    name: 'update_plan',
+    description: 'Create or update the task plan for this run. Send the complete ordered list on every update. Keep step IDs stable. Mark a step completed only after its work is verified. Use for multi-step tasks; skip simple questions.',
+    parameters: {
+      type: 'object',
+      properties: {
+        explanation: { type: 'string', maxLength: 1000, description: 'Brief reason for the update or scope change.' },
+        plan: {
+          type: 'array', minItems: 1, maxItems: 30,
+          items: {
+            type: 'object',
+            properties: {
+              id: { type: 'string', minLength: 1, maxLength: 100 },
+              step: { type: 'string', minLength: 1, maxLength: 200 },
+              status: { type: 'string', enum: ['pending', 'in_progress', 'completed'] },
+            },
+            required: ['id', 'step', 'status'], additionalProperties: false,
+          },
+        },
+      },
+      required: ['plan'], additionalProperties: false,
+    },
+  }
+
+  async execute(input: Record<string, unknown>, context?: AgentToolContext): Promise<AgentToolResult> {
+    try {
+      const update = parsePlanUpdate(input)
+      if (!context?.updatePlan) throw new Error('Task planning is unavailable outside an active run.')
+      const snapshot = context.updatePlan(update)
+      return { ok: true, content: JSON.stringify(snapshot), data: snapshot }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      return { ok: false, content: message, error: message }
+    }
+  }
+}

--- a/packages/ekko-agent/src/tools/registry.ts
+++ b/packages/ekko-agent/src/tools/registry.ts
@@ -5,6 +5,7 @@ import type {
   AgentToolProvider,
   AgentToolResult,
 } from './types'
+import { UpdatePlanTool } from './plan'
 import { createBrowserTools } from './browser'
 import { createClarificationToolProvider } from './clarify'
 import { CodeExecTool, type CodeExecToolOptions } from './code-exec'
@@ -115,6 +116,7 @@ export interface DefaultToolRegistryOptions {
 export function createDefaultToolRegistry(options: DefaultToolRegistryOptions = {}): AgentToolRegistry {
   const registry = new AgentToolRegistry(options.authorizer)
   for (const tool of [
+    new UpdatePlanTool(),
     ...createFileTools(),
     ...createImageTools(),
     ...createTerminalTools({ timeoutMs: options.executionTimeoutMs }),

--- a/packages/ekko-agent/src/tools/types.ts
+++ b/packages/ekko-agent/src/tools/types.ts
@@ -43,6 +43,7 @@ export type AgentToolAuthorizer = (
 ) => Promise<AgentToolAuthorizationDecision>
 
 export interface AgentToolContext {
+  updatePlan?: (update: import('./plan').AgentPlanUpdate) => import('./plan').AgentTaskPlan
   runId?: string
   cwd?: string
   workspaceRoot?: string

--- a/packages/server/src/bootstrap/http.ts
+++ b/packages/server/src/bootstrap/http.ts
@@ -488,6 +488,8 @@ export async function bootstrap() {
   // Initialize all web-ui SQLite tables
   const { initAllStores } = await import('../modules/studio/infrastructure/database/init')
   initAllStores()
+  const { interruptOrphanedTaskPlans } = await import('../modules/studio/repositories/task-plan-store')
+  interruptOrphanedTaskPlans()
   startChatWebhookDispatcher()
   console.log('[bootstrap] all stores initialized')
 

--- a/packages/server/src/modules/studio/contracts/task-plan.ts
+++ b/packages/server/src/modules/studio/contracts/task-plan.ts
@@ -1,0 +1,11 @@
+export interface TaskPlanSnapshot {
+  session_id: string
+  run_id: string
+  plan_id: string
+  revision: number
+  execution_state: 'running' | 'ended' | 'interrupted' | 'failed'
+  explanation?: string
+  plan: Array<{ id: string; step: string; status: 'pending' | 'in_progress' | 'completed' }>
+  created_at: number
+  updated_at: number
+}

--- a/packages/server/src/modules/studio/controllers/sessions.ts
+++ b/packages/server/src/modules/studio/controllers/sessions.ts
@@ -1,3 +1,4 @@
+import { getSessionTaskPlans } from '../services/task-plans'
 import {
   deleteHermesSessionForProfile,
   getHermesCliSession,
@@ -2085,6 +2086,7 @@ export async function getConversationMessagesPaginated(ctx: any) {
       output_tokens: session.output_tokens,
     },
     messages: result.messages,
+    taskPlans: getSessionTaskPlans(ctx.params.id, result.messages, offset === 0),
     workspaceRunChanges: listWorkspaceRunChangesForAssistantMessages(ctx.params.id, assistantMessageIds),
     total: result.total,
     offset: result.offset,

--- a/packages/server/src/modules/studio/infrastructure/database/schemas.ts
+++ b/packages/server/src/modules/studio/infrastructure/database/schemas.ts
@@ -37,6 +37,17 @@ export const USAGE_RUN_INDEX = `CREATE UNIQUE INDEX IF NOT EXISTS idx_session_us
 // Session Store (session-store.ts)
 // ============================================================================
 
+export const TASK_PLANS_TABLE = 'task_plans'
+export const TASK_PLANS_SCHEMA: Record<string, string> = {
+  session_id: 'TEXT NOT NULL',
+  plan_id: 'TEXT NOT NULL',
+  run_id: 'TEXT NOT NULL',
+  revision: 'INTEGER NOT NULL',
+  execution_state: 'TEXT NOT NULL',
+  snapshot: 'TEXT NOT NULL',
+  created_at: 'INTEGER NOT NULL',
+}
+
 export const SESSIONS_TABLE = 'sessions'
 
 export const SESSION_CATEGORIES_TABLE = 'session_categories'
@@ -1503,6 +1514,13 @@ export function initAllHermesTables(): void {
     // Session store
     syncTable(SESSION_CATEGORIES_TABLE, SESSION_CATEGORIES_SCHEMA, {
       indexes: SESSION_CATEGORIES_INDEXES,
+    })
+    syncTable(TASK_PLANS_TABLE, TASK_PLANS_SCHEMA, {
+      indexes: {
+        idx_task_plans_identity: 'CREATE UNIQUE INDEX IF NOT EXISTS idx_task_plans_identity ON task_plans(session_id, plan_id)',
+        idx_task_plans_run: 'CREATE INDEX IF NOT EXISTS idx_task_plans_run ON task_plans(session_id, run_id)',
+        idx_task_plans_latest: 'CREATE INDEX IF NOT EXISTS idx_task_plans_latest ON task_plans(session_id, created_at DESC)',
+      },
     })
     syncTable(SESSIONS_TABLE, SESSIONS_SCHEMA, {
       indexes: SESSIONS_INDEXES,

--- a/packages/server/src/modules/studio/repositories/session-store.ts
+++ b/packages/server/src/modules/studio/repositories/session-store.ts
@@ -3,7 +3,7 @@
  * Uses the same ensureTable/getDb pattern as usage-store.ts.
  */
 import { isSqliteAvailable, getDb } from '../infrastructure/database'
-import { COMPRESSION_SNAPSHOT_TABLE, SESSIONS_TABLE, MESSAGES_TABLE } from '../infrastructure/database/schemas'
+import { TASK_PLANS_TABLE, COMPRESSION_SNAPSHOT_TABLE, SESSIONS_TABLE, MESSAGES_TABLE } from '../infrastructure/database/schemas'
 import { normalizeMessageContentForStorageRole } from './message-content'
 import { copyCompressionSnapshot } from './compression-snapshot'
 import { recordSkillUsageMessage } from './skill-usage-store'
@@ -456,6 +456,7 @@ export function deleteSession(id: string): boolean {
   const db = getDb()!
   db.exec('BEGIN')
   try {
+    db.prepare(`DELETE FROM ${TASK_PLANS_TABLE} WHERE session_id = ?`).run(id)
     db.prepare(`DELETE FROM ${COMPRESSION_SNAPSHOT_TABLE} WHERE session_id = ?`).run(id)
     db.prepare(`DELETE FROM ${MESSAGES_TABLE} WHERE session_id = ?`).run(id)
     const result = db.prepare(`DELETE FROM ${SESSIONS_TABLE} WHERE id = ?`).run(id)
@@ -473,6 +474,7 @@ export function clearSessionMessages(id: string): number {
   db.exec('BEGIN')
   try {
     const result = db.prepare(`DELETE FROM ${MESSAGES_TABLE} WHERE session_id = ?`).run(id)
+    db.prepare(`DELETE FROM ${TASK_PLANS_TABLE} WHERE session_id = ?`).run(id)
     db.prepare(`DELETE FROM ${COMPRESSION_SNAPSHOT_TABLE} WHERE session_id = ?`).run(id)
     db.prepare(
       `UPDATE ${SESSIONS_TABLE}

--- a/packages/server/src/modules/studio/repositories/task-plan-store.ts
+++ b/packages/server/src/modules/studio/repositories/task-plan-store.ts
@@ -1,0 +1,62 @@
+import { getDb, isSqliteAvailable } from '../infrastructure/database'
+import { TASK_PLANS_TABLE } from '../infrastructure/database/schemas'
+import type { TaskPlanSnapshot } from '../contracts/task-plan'
+
+export function saveTaskPlan(plan: TaskPlanSnapshot): void {
+  if (!isSqliteAvailable()) throw new Error('Task plan storage is unavailable.')
+  const result = getDb()!.prepare(`
+    INSERT INTO ${TASK_PLANS_TABLE} (session_id, plan_id, run_id, revision, execution_state, snapshot, created_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(session_id, plan_id) DO UPDATE SET
+      revision = excluded.revision, execution_state = excluded.execution_state, snapshot = excluded.snapshot
+    WHERE excluded.revision > ${TASK_PLANS_TABLE}.revision
+  `).run(plan.session_id, plan.plan_id, plan.run_id, plan.revision, plan.execution_state, JSON.stringify(plan), plan.created_at)
+  if (!result.changes) throw new Error('Task plan update has an outdated revision.')
+}
+
+export function listTaskPlansForPage(
+  sessionId: string,
+  messages: Array<{ run_marker?: string | null; runMarker?: string | null }>,
+  includeLatest = false,
+  activeRunId?: string,
+): TaskPlanSnapshot[] {
+  if (!isSqliteAvailable()) return []
+  const runs = new Set(messages.map(message => message.run_marker || message.runMarker).filter((run): run is string => !!run))
+  if (activeRunId) runs.add(activeRunId)
+  const db = getDb()!
+  const snapshots: TaskPlanSnapshot[] = []
+  const byRun = db.prepare(`SELECT snapshot FROM ${TASK_PLANS_TABLE} WHERE session_id = ? AND run_id = ?`)
+  for (const run of runs) {
+    for (const row of byRun.all(sessionId, run) as Array<{ snapshot: string }>) snapshots.push(JSON.parse(row.snapshot))
+  }
+  if (includeLatest) {
+    const row = db.prepare(`SELECT snapshot FROM ${TASK_PLANS_TABLE} WHERE session_id = ? ORDER BY created_at DESC, plan_id DESC LIMIT 1`)
+      .get(sessionId) as { snapshot: string } | undefined
+    if (row) {
+      const latest: TaskPlanSnapshot = JSON.parse(row.snapshot)
+      if (!snapshots.some(plan => plan.plan_id === latest.plan_id)) snapshots.push(latest)
+    }
+  }
+  return snapshots.sort((a, b) => a.created_at - b.created_at)
+}
+
+/** Ekko runs are in-process and cannot survive a Studio process restart. Bootstrap only. */
+export function interruptOrphanedTaskPlans(): void {
+  if (!isSqliteAvailable()) return
+  const db = getDb()!
+  db.exec('BEGIN')
+  try {
+    const rows = db.prepare(`SELECT snapshot FROM ${TASK_PLANS_TABLE} WHERE execution_state = 'running'`).all() as Array<{ snapshot: string }>
+    for (const row of rows) {
+      const plan: TaskPlanSnapshot = JSON.parse(row.snapshot)
+      saveTaskPlan({
+        ...plan, revision: plan.revision + 1, execution_state: 'interrupted', updated_at: Date.now(),
+        plan: plan.plan.map(step => ({ ...step, status: step.status === 'in_progress' ? 'pending' : step.status })),
+      })
+    }
+    db.exec('COMMIT')
+  } catch (error) {
+    db.exec('ROLLBACK')
+    throw error
+  }
+}

--- a/packages/server/src/modules/studio/services/chat-run/handle-ekko-agent-run.ts
+++ b/packages/server/src/modules/studio/services/chat-run/handle-ekko-agent-run.ts
@@ -1,3 +1,5 @@
+import { saveTaskPlan } from '../../repositories/task-plan-store'
+import type { TaskPlanSnapshot } from '../../contracts/task-plan'
 import type { Server, Socket } from 'socket.io'
 import { createHash, randomUUID } from 'crypto'
 import {
@@ -634,6 +636,17 @@ export async function handleEkkoAgentRun(
     { role: 'user', content: inputText },
   ]).inputTokens
 
+  const toTaskPlanSnapshot = (plan: any): TaskPlanSnapshot => ({
+    session_id: sessionId,
+    run_id: plan.runId,
+    plan_id: plan.planId,
+    revision: plan.revision,
+    execution_state: plan.executionState,
+    explanation: plan.explanation,
+    plan: plan.plan,
+    created_at: plan.createdAt,
+    updated_at: plan.updatedAt,
+  })
   let assistantText = ''
   let assistantReasoning = ''
   let assistantMessageId: string | null = null
@@ -954,6 +967,8 @@ export async function handleEkkoAgentRun(
           delta: event.text,
         })
       }
+    } else if (event.type === 'plan.updated') {
+      emit('plan.updated', { event: 'plan.updated', ...toTaskPlanSnapshot(event.plan) })
     } else if (event.type === 'tool.started') {
       emit('tool.started', {
         event: 'tool.started',
@@ -1387,6 +1402,7 @@ export async function handleEkkoAgentRun(
         sessionId,
         turnId,
       },
+      onPlanUpdate: (plan: any) => saveTaskPlan(toTaskPlanSnapshot(plan)),
       onEvent: handleRuntimeEvent,
       onSkillReviewUsage: (event: any) => {
         recordSessionUsage({

--- a/packages/server/src/modules/studio/services/chat-run/resume-payload.ts
+++ b/packages/server/src/modules/studio/services/chat-run/resume-payload.ts
@@ -35,6 +35,7 @@ export interface ResumeMessagePageOptions {
 }
 
 export interface ResumeMessagePage {
+  taskPlans?: import('../../contracts/task-plan').TaskPlanSnapshot[]
   messages: SessionMessage[]
   workspaceRunChanges?: WorkspaceRunChangeSummary[]
   messageTotal: number
@@ -250,6 +251,7 @@ export function buildAppResumeMessagePage(
     return {
       id,
       messagesCached: true,
+      ...(page.taskPlans ? { taskPlans: page.taskPlans } : {}),
       messageTotal: page.messageTotal,
       messageLoadedCount: page.messageLoadedCount,
       messagePageLimit: page.messagePageLimit,

--- a/packages/server/src/modules/studio/services/task-plans.ts
+++ b/packages/server/src/modules/studio/services/task-plans.ts
@@ -1,0 +1,10 @@
+import { listTaskPlansForPage } from '../repositories/task-plan-store'
+
+export function getSessionTaskPlans(
+  sessionId: string,
+  messages: Array<{ run_marker?: string | null; runMarker?: string | null }>,
+  includeLatest = false,
+  activeRunId?: string,
+) {
+  return listTaskPlansForPage(sessionId, messages, includeLatest, activeRunId)
+}

--- a/packages/server/src/modules/studio/sockets/chat-run.ts
+++ b/packages/server/src/modules/studio/sockets/chat-run.ts
@@ -1,3 +1,4 @@
+import { getSessionTaskPlans } from '../services/task-plans'
 import { bindLegacyAppEvents } from '../services/webhooks/legacy-app-events'
 import { bindAppEventSubscription } from '../services/webhooks/app-events'
 import { mobileDeviceRoom, mobileDeviceId, sameMobileDevice, mobileEventAllowed, type MobileDeviceTarget } from '../services/chat-run/mobile-device-target'
@@ -1698,7 +1699,8 @@ export class ChatRunSocket {
         .filter(message => String(message.display_role || message.role || '') === 'assistant')
         .map(message => message.id),
     )
-    const resumePage = { ...messagePage, workspaceRunChanges }
+    const taskPlans = getSessionTaskPlans(sid, messagePage.messages, true, state.runId)
+    const resumePage = { ...messagePage, workspaceRunChanges, taskPlans }
     const appMessagePage = options
       ? buildAppResumeMessagePage(resumePage, options.cachedId)
       : null
@@ -1706,6 +1708,7 @@ export class ChatRunSocket {
     socket.emit(options?.event || 'resumed', {
       session_id: sid,
       ...outboundMessagePage,
+      taskPlans,
       parentSessionId: sessionDetail?.parent_session_id || null,
       forkPointMessageId: sessionDetail?.fork_point_message_id || null,
       parentTitle: sessionDetail?.parent_title || null,

--- a/tests/client/chat-store-session-command.test.ts
+++ b/tests/client/chat-store-session-command.test.ts
@@ -552,6 +552,35 @@ describe('chat store session.command fanout', () => {
     ])
   })
 
+  it('applies empty history snapshots and restores plans without persisted message bodies', async () => {
+    const store = useChatStore()
+    const session = makeSession()
+    session.messages = [{ id: 'stale', role: 'user', content: 'Old cached message', timestamp: 1 }]
+    store.sessions = [session]
+    const plan = {
+      session_id: session.id, run_id: 'run-1', plan_id: 'run-1', revision: 1,
+      execution_state: 'running', created_at: 2, updated_at: 2,
+      plan: [{ id: 'a', step: 'Verify', status: 'pending' }],
+    }
+    chatApi.resumeSession.mockImplementationOnce((sessionId: string, onResumed: (data: any) => void) => {
+      onResumed({ session_id: sessionId, messages: [], taskPlans: [plan], messageTotal: 0, isWorking: false })
+      return {} as any
+    })
+
+    await store.switchSession(session.id)
+    expect(store.activeSession?.messages).toEqual([
+      expect.objectContaining({ taskPlan: plan }),
+    ])
+    expect(store.activeSession?.loadedMessageCount).toBe(0)
+
+    chatApi.resumeSession.mockImplementationOnce((sessionId: string, onResumed: (data: any) => void) => {
+      onResumed({ session_id: sessionId, messages: [], taskPlans: [], messageTotal: 0, isWorking: false })
+      return {} as any
+    })
+    await store.switchSession(session.id)
+    expect(store.activeSession?.messages).toEqual([])
+  })
+
   it('adds and switches to a branched child session from session.command branch events', async () => {
     const store = useChatStore()
     const session = makeSession()
@@ -559,20 +588,22 @@ describe('chat store session.command fanout', () => {
     store.activeSessionId = 'session-1'
     store.activeSession = session
 
-    chatApi.resumeSession.mockImplementationOnce((sessionId: string, onResumed: (data: any) => void) => {
+    chatApi.resumeSession.mockImplementation((sessionId: string, onResumed: (data: any) => void) => {
       onResumed({
         session_id: sessionId,
-        messages: [
+        messages: sessionId === 'branch-1' ? [
           { id: 1, role: 'user', content: 'Previous question', timestamp: 1 },
           { id: 2, role: 'assistant', content: 'Previous answer', timestamp: 2 },
+        ] : [
+          { id: 3, role: 'command', content: 'Branched session "Side path" from session-1.', timestamp: 3 },
         ],
         parentSessionId: 'session-1',
         forkPointMessageId: '2',
         parentTitle: 'session',
         parentLastMessage: 'Previous answer',
         parentLastMessageRole: 'assistant',
-        messageLoadedCount: 2,
-        messageTotal: 2,
+        messageLoadedCount: sessionId === 'branch-1' ? 2 : 1,
+        messageTotal: sessionId === 'branch-1' ? 2 : 1,
         hasMoreBefore: false,
         isWorking: false,
         events: [],
@@ -629,12 +660,17 @@ describe('chat store session.command fanout', () => {
     expect(store.activeSessionId).toBe('branch-1')
     expect(chatApi.resumeSession).toHaveBeenCalledWith('branch-1', expect.any(Function), 'default', 'chat-run')
 
+    expect(store.sessions.find((item: Session) => item.id === 'session-1')?.messages.at(-1)).toMatchObject({
+      role: 'command',
+      commandAction: 'branch',
+      content: 'Branched session "Side path" from session-1.',
+    })
+
     await store.switchSession('session-1')
     expect(store.activeSessionId).toBe('session-1')
     expect(store.activeSession?.id).toBe('session-1')
     expect(store.sessions.find((item: Session) => item.id === 'session-1')?.messages.at(-1)).toMatchObject({
       role: 'command',
-      commandAction: 'branch',
       content: 'Branched session "Side path" from session-1.',
     })
 

--- a/tests/client/i18n-coverage.test.ts
+++ b/tests/client/i18n-coverage.test.ts
@@ -36,6 +36,22 @@ const rawMessages: Record<string, Record<string, unknown>> = {
 }
 
 const messages: Record<string, Record<string, unknown>> = {}
+
+it('defines task plan dynamic statuses and progress placeholders in every raw locale', () => {
+  const keys = ['title', 'progress', 'pending', 'in_progress', 'completed', 'running', 'ended', 'interrupted', 'failed']
+  for (const locale of supportedLocales) {
+    const plan = rawMessages[locale].taskPlan as Record<string, string>
+    expect(plan, locale).toBeDefined()
+    expect(Object.keys(plan).sort(), locale).toEqual([...keys].sort())
+    for (const key of keys) {
+      expect(typeof plan[key], `${locale}: ${key}`).toBe('string')
+      expect(plan[key].trim(), `${locale}: ${key}`).not.toBe('')
+      if (locale !== 'en') expect(plan[key], `${locale}: ${key} copies English`).not.toBe(en.taskPlan[key as keyof typeof en.taskPlan])
+    }
+    expect(interpolationNames(plan.progress), locale).toEqual(['completed', 'total'])
+  }
+})
+
 for (const [locale, localeMessages] of Object.entries(rawMessages)) {
   messages[locale] = locale === 'en'
     ? localeMessages

--- a/tests/client/task-plan.test.ts
+++ b/tests/client/task-plan.test.ts
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import TaskPlanCard from '@/components/hermes/chat/TaskPlanCard.vue'
+import { mergeTaskPlanMessages, type TaskPlanSnapshot } from '@/utils/task-plan'
+import type { Message } from '@/stores/hermes/chat'
+import en from '@/i18n/locales/en'
+
+const plan: TaskPlanSnapshot = {
+  session_id: 's1', run_id: 'r1', plan_id: 'r1', revision: 1, execution_state: 'running', created_at: 2, updated_at: 2,
+  plan: [{ id: 'a', step: 'Inspect', status: 'completed' }, { id: 'b', step: 'Verify', status: 'pending' }],
+}
+
+describe('task plan display', () => {
+  it('places one card before the associated run and ignores duplicate or stale replay', () => {
+    const messages: Message[] = [
+      { id: 'u', role: 'user', content: 'Work', timestamp: 1 },
+      { id: 'a', role: 'assistant', content: 'Done', timestamp: 3, runMarker: 'r1' },
+    ]
+    const initial = mergeTaskPlanMessages(messages, [plan])
+    expect(initial.map(message => message.id)).toEqual(['u', 'task-plan:s1:r1', 'a'])
+    const updated = mergeTaskPlanMessages(initial, [{ ...plan, revision: 3, execution_state: 'ended' }, plan, { ...plan, revision: 2 }])
+    expect(updated).toHaveLength(3)
+    expect(updated[1].taskPlan?.revision).toBe(3)
+  })
+
+  it('ignores malformed data and snapshots from another session', () => {
+    expect(mergeTaskPlanMessages([], [{ ...plan, plan: [{ id: 'x', step: 'bad', status: 'done' }] }, plan], 's2')).toEqual([])
+  })
+
+  it('preserves multiple runs in a history page without merging their steps', () => {
+    const messages = mergeTaskPlanMessages([], [plan, { ...plan, plan_id: 'r2', run_id: 'r2', created_at: 5 }])
+    expect(messages).toHaveLength(2)
+  })
+
+  it('shows unfinished steps after interruption, updates the counter and supports folding', async () => {
+    const wrapper = mount(TaskPlanCard, { props: { plan: { ...plan, execution_state: 'interrupted' } },
+      global: { plugins: [createI18n({ legacy: false, locale: 'en', messages: { en } })] } })
+    expect(wrapper.text()).toContain('1/2 completed')
+    expect(wrapper.text()).toContain('Not completed')
+    expect(wrapper.text()).toContain('Interrupted; unfinished steps remain')
+    await wrapper.get('button').trigger('click')
+    expect(wrapper.find('ol').exists()).toBe(false)
+    expect(wrapper.get('button').attributes('aria-expanded')).toBe('false')
+    await wrapper.get('button').trigger('click')
+    await wrapper.setProps({ plan: { ...plan, revision: 2, plan: plan.plan.map(step => ({ ...step, status: 'completed' })) } })
+    expect(wrapper.text()).toContain('2/2 completed')
+    expect(wrapper.findAll('.completed')).toHaveLength(2)
+  })
+})

--- a/tests/e2e/history-session-deeplink.spec.ts
+++ b/tests/e2e/history-session-deeplink.spec.ts
@@ -240,6 +240,33 @@ test.describe('history session deep links', () => {
     await expect(page).toHaveURL(/#\/hermes\/history\/session\/hist-beta$/)
   })
 
+  test('restores the task plan independently of tool traces in paginated history', async ({ page }) => {
+    await page.addInitScript(() => localStorage.setItem('hermes_show_tool_calls', 'false'))
+    await page.route('**/api/studio/sessions/conversations/hist-beta/messages/paginated*', route => {
+      const detail = detailFor('hist-beta', historySessions)!
+      const taskPlan = {
+        session_id: 'hist-beta', run_id: 'history-plan-run', plan_id: 'history-plan-run', revision: 3,
+        execution_state: 'ended', created_at: detail.started_at * 1000, updated_at: detail.last_active * 1000,
+        plan: [{ id: 'inspect', step: 'Inspect existing implementation', status: 'completed' },
+          { id: 'verify', step: 'Verify remaining work', status: 'pending' }],
+      }
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({
+        session: detail,
+        messages: detail.messages.map(message => ({ ...message, run_marker: message.role === 'user' ? null : taskPlan.run_id })),
+        taskPlans: [taskPlan], workspaceRunChanges: [], total: detail.messages.length, offset: 0, limit: 150, hasMore: false,
+      }) })
+    })
+    await page.goto('/#/hermes/history/session/hist-beta')
+    const card = page.getByTestId('task-plan-card')
+    await expect(card).toContainText('1/2 completed')
+    await expect(card).toContainText('Run ended; unfinished steps remain')
+    await expect(card.locator('.pending')).toHaveCount(1)
+    await page.reload()
+    await expect(card).toHaveCount(1)
+    await expect(card).toContainText('1/2 completed')
+    await card.screenshot({ path: test.info().outputPath('task-plan-history.png'), animations: 'disabled' })
+  })
+
   test('completed tool runs can expand and collapse in history', async ({ page }) => {
     await page.goto('/#/hermes/history/session/hist-alpha')
 

--- a/tests/e2e/task-plan.spec.ts
+++ b/tests/e2e/task-plan.spec.ts
@@ -1,0 +1,87 @@
+import { expect, test } from '@playwright/test'
+import { authenticate, mockChatSocket, mockHermesApi, TEST_ACCESS_KEY } from './fixtures'
+
+const now = Date.now()
+const plan = {
+  session_id: 'plan-session', run_id: 'plan-run', plan_id: 'plan-run', revision: 1,
+  execution_state: 'running', created_at: now, updated_at: now,
+  plan: [
+    { id: 'inspect', step: 'Inspect existing implementation', status: 'pending' },
+    { id: 'build', step: 'Build the task plan card', status: 'pending' },
+    { id: 'verify', step: 'Verify refresh recovery', status: 'pending' },
+  ],
+}
+
+test('updates one plan card live and preserves unfinished work on stop with tool traces hidden', async ({ page }) => {
+  await authenticate(page, TEST_ACCESS_KEY, 'research')
+  await page.addInitScript(() => localStorage.setItem('hermes_show_tool_calls', 'false'))
+  await mockHermesApi(page)
+  await mockChatSocket(page)
+  await page.goto('/#/hermes/chat')
+  await page.getByPlaceholder('Type a message... (Enter to send, Shift+Enter for new line)').fill('Implement task planning')
+  await page.getByRole('button', { name: 'Send', exact: true }).click()
+  const run = await (await page.waitForFunction(() => (window as any).__PW_CHAT_SOCKET__?.emitted.find((entry: any) => entry.event === 'run')?.payload)).jsonValue()
+  const active = { ...plan, session_id: run.session_id }
+  await page.evaluate(p => {
+    const socket = (window as any).__PW_CHAT_SOCKET__.latest
+    socket.__trigger('run.started', { event: 'run.started', session_id: p.session_id, run_id: p.run_id })
+    socket.__trigger('plan.updated', { event: 'plan.updated', ...p })
+  }, active)
+  const card = page.getByTestId('task-plan-card')
+  await expect(card).toHaveCount(1)
+  await expect(card).toContainText('0/3 completed')
+  await page.evaluate(p => {
+    const socket = (window as any).__PW_CHAT_SOCKET__.latest
+    socket.__trigger('plan.updated', { event: 'plan.updated', ...p, revision: 2,
+      plan: p.plan.map((step, i) => ({ ...step, status: i === 0 ? 'completed' : i === 1 ? 'in_progress' : 'pending' })) })
+    socket.__trigger('plan.updated', { event: 'plan.updated', ...p })
+  }, active)
+  await expect(card).toContainText('1/3 completed')
+  await expect(card).toContainText('In progress')
+  await page.evaluate(p => {
+    const socket = (window as any).__PW_CHAT_SOCKET__.latest
+    socket.__trigger('plan.updated', { event: 'plan.updated', ...p, revision: 3, execution_state: 'interrupted',
+      plan: p.plan.map((step, i) => ({ ...step, status: i === 0 ? 'completed' : 'pending' })) })
+    socket.__trigger('abort.completed', { event: 'abort.completed', session_id: p.session_id, run_id: p.run_id, synced: true })
+  }, active)
+  await expect(card).toHaveCount(1)
+  await expect(card).toContainText('Interrupted; unfinished steps remain')
+  await expect(card.locator('.pending')).toHaveCount(2)
+  await card.getByRole('button').click()
+  await expect(card.locator('ol')).toHaveCount(0)
+  await card.getByRole('button').click()
+  await expect(card.locator('li')).toHaveCount(3)
+})
+
+test('restores a completed plan from a resume snapshot after reload', async ({ page }) => {
+  await authenticate(page, TEST_ACCESS_KEY, 'research')
+  const completed = { ...plan, execution_state: 'ended', revision: 4,
+    plan: plan.plan.map(step => ({ ...step, status: 'completed' })) }
+  await page.addInitScript(p => {
+    ;(window as any).__PW_CHAT_SOCKET_RESUMES__ = {
+      [p.session_id]: {
+        session_id: p.session_id, isWorking: false, events: [], taskPlans: [p],
+        messages: [
+          { id: 1, role: 'user', content: 'Implement task planning', timestamp: p.created_at / 1000 - 1 },
+          { id: 2, role: 'assistant', content: 'Task planning is ready', run_marker: p.run_id, timestamp: p.created_at / 1000 + 1 },
+        ],
+      },
+    }
+    localStorage.setItem('hermes_show_tool_calls', 'false')
+  }, completed)
+  await mockHermesApi(page, { sessions: [{ id: plan.session_id, profile: 'research', source: 'coding_agent', agent: 'ekko-agent',
+    model: 'test-model', title: 'Task plan session', preview: 'Implement task planning', started_at: now / 1000,
+    ended_at: now / 1000 + 1, last_active: now / 1000 + 1, message_count: 2, tool_call_count: 1, input_tokens: 0, output_tokens: 0 }] })
+  await mockChatSocket(page)
+  await page.goto(`/#/hermes/session/${plan.session_id}`)
+  await expect(page.getByTestId('task-plan-card')).toContainText('3/3 completed')
+  await page.reload()
+  await expect(page.getByTestId('task-plan-card')).toHaveCount(1)
+  await expect(page.getByTestId('task-plan-card')).toContainText('3/3 completed')
+  await expect(page.getByText('Task planning is ready', { exact: true })).toBeVisible()
+  await page.setViewportSize({ width: 390, height: 844 })
+  const card = page.getByTestId('task-plan-card')
+  await expect(card).toBeVisible()
+  const width = await card.evaluate(el => el.scrollWidth <= el.clientWidth)
+  expect(width).toBe(true)
+})

--- a/tests/ekko-agent/task-plan.test.ts
+++ b/tests/ekko-agent/task-plan.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi } from 'vitest'
+import { AgentRuntime } from '../../packages/ekko-agent/src/runtime/runtime'
+import { AgentToolRegistry, createDefaultToolRegistry } from '../../packages/ekko-agent/src/tools/registry'
+import { DelegateTaskTool } from '../../packages/ekko-agent/src/tools/delegation'
+import { UpdatePlanTool, parsePlanUpdate, type AgentTaskPlan } from '../../packages/ekko-agent/src/tools/plan'
+import type { AgentRuntimeEvent } from '../../packages/ekko-agent/src/runtime/events'
+import type { ModelClient, ModelRequest } from '../../packages/ekko-agent/src/model/types'
+
+const initial = { plan: [
+  { id: 'inspect', step: 'Inspect implementation', status: 'completed' },
+  { id: 'verify', step: 'Verify behavior', status: 'in_progress' },
+] }
+
+function runtime(responder: (request: ModelRequest, call: number) => any) {
+  let calls = 0
+  const modelClient: ModelClient = {
+    provider: 'test', requestStyle: 'custom-runtime',
+    capabilities: { streaming: false, tools: true, vision: false, jsonMode: false, systemPrompt: true },
+    create: vi.fn(async request => responder(request, ++calls)), stream: vi.fn(),
+  }
+  const tools = new AgentToolRegistry()
+  tools.register(new UpdatePlanTool())
+  tools.register(new DelegateTaskTool())
+  return new AgentRuntime({ modelClient, tools, maxSteps: 5 })
+}
+
+const callPlan = (argumentsValue = initial) => ({ content: '', toolCalls: [{ id: 'plan-call', name: 'update_plan', arguments: argumentsValue }] })
+
+describe('Ekko task planning', () => {
+  it('registers the tool by default and rejects calls outside a run', async () => {
+    const tool = createDefaultToolRegistry().get('update_plan')!
+    expect(tool).toBeInstanceOf(UpdatePlanTool)
+    expect((await tool.execute(initial)).ok).toBe(false)
+  })
+
+  it.each([
+    { plan: [] },
+    { plan: [{ id: 'a', step: '', status: 'pending' }] },
+    { plan: [{ id: 'a', step: 'x', status: 'done' }] },
+    { plan: [{ id: 'a', step: 'x', status: 'pending' }, { id: 'a', step: 'y', status: 'pending' }] },
+    { plan: [{ id: 'a', step: 'x', status: 'in_progress' }, { id: 'b', step: 'y', status: 'in_progress' }] },
+    { ...initial, explanation: 'x'.repeat(1001) },
+  ])('rejects invalid input without committing: %j', async input => {
+    const updatePlan = vi.fn()
+    expect(() => parsePlanUpdate(input)).toThrow()
+    expect((await new UpdatePlanTool().execute(input, { updatePlan })).ok).toBe(false)
+    expect(updatePlan).not.toHaveBeenCalled()
+  })
+
+  it('commits before publishing, records tool history, and retains unfinished work on completion', async () => {
+    const committed: AgentTaskPlan[] = []
+    const events: AgentRuntimeEvent[] = []
+    const agent = runtime((request, call) => {
+      expect(request.messages[0].content).toContain('Use update_plan proactively')
+      if (call === 1) return callPlan()
+      const result = request.messages.find(message => message.role === 'tool')!
+      expect(JSON.parse(result.content).plan[1].status).toBe('in_progress')
+      return { content: 'Inspection done; verification remains.' }
+    })
+    const result = await agent.run({
+      messages: [{ role: 'user', content: 'Inspect and verify' }],
+      onPlanUpdate: plan => committed.push(plan),
+      onEvent: event => {
+        if (event.type === 'plan.updated') expect(committed.at(-1)).toEqual(event.plan)
+        events.push(event)
+      },
+    })
+    expect(committed.map(plan => plan.revision)).toEqual([1, 2])
+    expect(committed[1]).toMatchObject({ executionState: 'ended', plan: [{ status: 'completed' }, { status: 'pending' }] })
+    expect(events.filter(event => event.type === 'tool.completed')).toHaveLength(1)
+    expect(result.messages.some(message => message.role === 'tool' && message.toolCallId === 'plan-call')).toBe(true)
+  })
+
+  it('does not publish or advance a plan when durable commit fails', async () => {
+    const events: AgentRuntimeEvent[] = []
+    const agent = runtime((_request, call) => call === 1 ? callPlan() : { content: 'Storage unavailable.' })
+    const result = await agent.run({ messages: [{ role: 'user', content: 'Work' }],
+      onPlanUpdate: () => { throw new Error('disk full') }, onEvent: event => events.push(event) })
+    expect(events.some(event => event.type === 'plan.updated')).toBe(false)
+    expect(result.messages.find(message => message.role === 'tool')?.content).toContain('disk full')
+  })
+
+  it('settles cancelled runs without completing unfinished steps', async () => {
+    const controller = new AbortController()
+    const committed: AgentTaskPlan[] = []
+    const agent = runtime((_request, call) => {
+      if (call === 1) return callPlan()
+      controller.abort()
+      throw new Error('cancelled')
+    })
+    await expect(agent.run({ messages: [{ role: 'user', content: 'Work' }], signal: controller.signal,
+      onPlanUpdate: plan => committed.push(plan) })).rejects.toThrow()
+    expect(committed.at(-1)).toMatchObject({ executionState: 'interrupted', plan: [{ status: 'completed' }, { status: 'pending' }] })
+  })
+
+  it('does not publish a child plan into the parent commit callback', async () => {
+    const commits: AgentTaskPlan[] = []
+    const agent = runtime((_request, call) => {
+      if (call === 1) return { content: '', toolCalls: [
+        ...callPlan().toolCalls,
+        { id: 'delegate', name: 'delegate_task', arguments: { goal: 'Run independent checks', mode: 'foreground' } },
+      ] }
+      if (call === 2) return callPlan({ plan: [{ id: 'child', step: 'Child work', status: 'completed' }] })
+      return { content: 'Done' }
+    })
+    const result = await agent.run({ messages: [{ role: 'user', content: 'Plan and delegate' }], onPlanUpdate: plan => commits.push(plan) })
+    expect(commits).toHaveLength(2)
+    expect(commits.every(plan => plan.runId === result.runId)).toBe(true)
+    expect(commits.flatMap(plan => plan.plan).some(step => step.id === 'child')).toBe(false)
+  })
+
+  it('keeps separate runs isolated and accepts an explicit all-completed update', async () => {
+    const completed = { plan: initial.plan.map(step => ({ ...step, status: 'completed' })) }
+    const agent = runtime((_request, call) => call % 3 === 1 ? callPlan() : call % 3 === 2 ? callPlan(completed) : { content: 'Done' })
+    const first = await agent.run({ messages: [{ role: 'user', content: 'First' }] })
+    const second = await agent.run({ messages: [{ role: 'user', content: 'Second' }] })
+    const plans = (result: typeof first) => result.events.filter(event => event.type === 'plan.updated')
+    expect(plans(first).map(event => event.plan.revision)).toEqual([1, 2, 3])
+    expect(plans(second)[0].plan.planId).not.toBe(plans(first)[0].plan.planId)
+    expect(plans(second).at(-1)?.plan.plan.every(step => step.status === 'completed')).toBe(true)
+  })
+})

--- a/tests/ekko-agent/tools.test.ts
+++ b/tests/ekko-agent/tools.test.ts
@@ -480,6 +480,7 @@ describe('ekko-agent tools', () => {
       'skill_list',
       'skill_view',
       'terminal_exec',
+      'update_plan',
       'view_image',
       'write_file',
     ])

--- a/tests/server/run-chat-ekko-context.test.ts
+++ b/tests/server/run-chat-ekko-context.test.ts
@@ -4,6 +4,9 @@ import { join } from 'node:path'
 import { respondToEkkoToolApproval } from '../../packages/server/src/modules/ekko/services/approvals'
 import { respondToEkkoClarification } from '../../packages/server/src/modules/ekko/services/clarifications'
 
+const saveTaskPlanMock = vi.hoisted(() => vi.fn())
+vi.mock('../../packages/server/src/modules/studio/repositories/task-plan-store', () => ({ saveTaskPlan: saveTaskPlanMock }))
+
 const getSessionMock = vi.hoisted(() => vi.fn())
 const createSessionMock = vi.hoisted(() => vi.fn())
 const addMessageMock = vi.hoisted(() => vi.fn())
@@ -219,6 +222,37 @@ describe('ekko-agent context usage events', () => {
       },
     })
     completeWorkspaceRunCheckpointMock.mockReturnValue(null)
+  })
+
+  it('persists plan snapshots before broadcasting and records update_plan calls in chat history', async () => {
+    const plan = {
+      runId: 'run-plan', planId: 'run-plan', revision: 1, executionState: 'running',
+      createdAt: 100, updatedAt: 100,
+      plan: [{ id: 'a', step: 'Inspect', status: 'in_progress' }],
+    }
+    const toolCall = { id: 'call-plan', name: 'update_plan', arguments: { plan: plan.plan } }
+    agentRunMock.mockImplementationOnce(async (input: any) => {
+      input.onEvent({ type: 'run.started', runId: 'run-plan', maxSteps: 3 })
+      input.onEvent({ type: 'model.message', runId: 'run-plan', step: 1, message: { role: 'assistant', content: '', toolCalls: [toolCall] } })
+      input.onPlanUpdate(plan)
+      input.onEvent({ type: 'plan.updated', runId: 'run-plan', plan })
+      input.onEvent({ type: 'tool.completed', runId: 'run-plan', step: 1, toolCallId: 'call-plan', toolName: 'update_plan',
+        result: { ok: true, content: JSON.stringify(plan), data: plan }, durationMs: 1 })
+      return { runId: 'run-plan', output: { role: 'assistant', content: 'Working' }, steps: [], messages: [], events: [] }
+    })
+    const { handleEkkoAgentRun } = await import('../../packages/server/src/modules/studio/services/chat-run/handle-ekko-agent-run')
+    const { nsp, socket, sessionMap, events } = makeHarness()
+    await handleEkkoAgentRun(nsp as any, socket as any, {
+      session_id: 'session-1', input: 'Plan work', coding_agent_id: 'ekko-agent',
+      onEvent: (event: string, payload: any) => {
+        if (event === 'plan.updated') expect(saveTaskPlanMock).toHaveBeenCalledWith(expect.objectContaining({ session_id: 'session-1', revision: 1 }))
+        events.push({ event, payload })
+      },
+    }, 'default', sessionMap, vi.fn(() => false))
+    expect(events).toContainEqual({ event: 'plan.updated', payload: expect.objectContaining({ plan_id: 'run-plan', execution_state: 'running', plan: plan.plan }) })
+    const rows = addMessagesMock.mock.calls.flatMap(call => call[0])
+    expect(rows).toContainEqual(expect.objectContaining({ role: 'tool', tool_name: 'update_plan', content: JSON.stringify(plan) }))
+    expect(rows).toContainEqual(expect.objectContaining({ role: 'assistant', tool_calls: [expect.objectContaining({ function: expect.objectContaining({ name: 'update_plan' }) })] }))
   })
 
   it('bridges Ekko tool approval requests through the existing chat events', async () => {

--- a/tests/server/run-chat-resume-payload.test.ts
+++ b/tests/server/run-chat-resume-payload.test.ts
@@ -294,3 +294,18 @@ describe('buildResumeMessages', () => {
     expect(workspaceDiff.content).toBe(completeResult)
   })
 })
+
+// Plan state must survive App conditional resumes even when message bodies are cached.
+it('returns plan snapshots on cache hits and changes the cache id after a plan update', () => {
+  const page = buildResumeMessagePage([message({ id: 1, role: 'user', content: 'Work' })])
+  const taskPlans = [{ session_id: 's', run_id: 'r', plan_id: 'r', revision: 1, execution_state: 'running' as const,
+    created_at: 1, updated_at: 1, plan: [{ id: 'a', step: 'Work', status: 'pending' as const }] }]
+  const initial = buildAppResumeMessagePage({ ...page, taskPlans }, '')
+  const cached = buildAppResumeMessagePage({ ...page, taskPlans }, initial.id)
+  expect(cached.messagesCached).toBe(true)
+  expect(cached.messages).toBeUndefined()
+  expect(cached.taskPlans).toEqual(taskPlans)
+  const updated = buildAppResumeMessagePage({ ...page, taskPlans: [{ ...taskPlans[0], revision: 2 }] }, initial.id)
+  expect(updated.messagesCached).toBe(false)
+  expect(updated.id).not.toBe(initial.id)
+})

--- a/tests/server/task-plan-store.test.ts
+++ b/tests/server/task-plan-store.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { TaskPlanSnapshot } from '../../packages/server/src/modules/studio/contracts/task-plan'
+
+const snapshot = (sessionId = 's1', runId = 'r1', revision = 1): TaskPlanSnapshot => ({
+  session_id: sessionId, run_id: runId, plan_id: runId, revision, execution_state: 'running',
+  created_at: revision, updated_at: revision,
+  plan: [{ id: 'a', step: 'Inspect', status: 'completed' }, { id: 'b', step: 'Verify', status: 'in_progress' }],
+})
+
+describe('task plan persistence', () => {
+  let db: import('node:sqlite').DatabaseSync
+  beforeEach(async () => {
+    vi.resetModules()
+    const { DatabaseSync } = await import('node:sqlite')
+    db = new DatabaseSync(':memory:')
+    vi.doMock('../../packages/server/src/modules/studio/infrastructure/database/index', () => ({
+      getDb: () => db, isSqliteAvailable: () => true,
+    }))
+    const { initAllHermesTables } = await import('../../packages/server/src/modules/studio/infrastructure/database/schemas')
+    initAllHermesTables()
+  })
+  afterEach(() => {
+    db.close()
+    vi.doUnmock('../../packages/server/src/modules/studio/infrastructure/database/index')
+    vi.resetModules()
+  })
+
+  it('updates a single durable snapshot and rejects stale revisions', async () => {
+    const { saveTaskPlan, listTaskPlansForPage } = await import('../../packages/server/src/modules/studio/repositories/task-plan-store')
+    saveTaskPlan(snapshot())
+    saveTaskPlan({ ...snapshot('s1', 'r1', 2), explanation: 'Updated' })
+    expect(() => saveTaskPlan(snapshot())).toThrow('outdated')
+    expect(listTaskPlansForPage('s1', [{ run_marker: 'r1' }])).toEqual([expect.objectContaining({ revision: 2, explanation: 'Updated' })])
+    expect(listTaskPlansForPage('s2', [], true)).toEqual([])
+  })
+
+  it('loads plans for history pages and the latest plan even before tool messages persist', async () => {
+    const { saveTaskPlan, listTaskPlansForPage } = await import('../../packages/server/src/modules/studio/repositories/task-plan-store')
+    saveTaskPlan(snapshot())
+    saveTaskPlan({ ...snapshot('s1', 'r2'), created_at: 20 })
+    expect(listTaskPlansForPage('s1', [{ run_marker: 'r1' }]).map(plan => plan.run_id)).toEqual(['r1'])
+    expect(listTaskPlansForPage('s1', [], true).map(plan => plan.run_id)).toEqual(['r2'])
+    expect(listTaskPlansForPage('s1', [{ run_marker: 'r1' }], true)).toHaveLength(2)
+  })
+
+  it('recovers orphaned runs on restart while preserving completed steps', async () => {
+    const { saveTaskPlan, listTaskPlansForPage, interruptOrphanedTaskPlans } = await import('../../packages/server/src/modules/studio/repositories/task-plan-store')
+    saveTaskPlan(snapshot())
+    saveTaskPlan({ ...snapshot('s2'), execution_state: 'ended' })
+    interruptOrphanedTaskPlans()
+    interruptOrphanedTaskPlans()
+    expect(listTaskPlansForPage('s1', [], true)[0]).toMatchObject({ revision: 2, execution_state: 'interrupted', plan: [{ status: 'completed' }, { status: 'pending' }] })
+    expect(listTaskPlansForPage('s2', [], true)[0].revision).toBe(1)
+  })
+
+  it.each(['deleteSession', 'clearSessionMessages'] as const)('cleans up plans with %s', async method => {
+    const { saveTaskPlan, listTaskPlansForPage } = await import('../../packages/server/src/modules/studio/repositories/task-plan-store')
+    const sessions = await import('../../packages/server/src/modules/studio/repositories/session-store')
+    sessions.createSession({ id: 's1' })
+    saveTaskPlan(snapshot())
+    sessions[method]('s1')
+    expect(listTaskPlansForPage('s1', [], true)).toEqual([])
+  })
+})


### PR DESCRIPTION
Ekko can now create and update a task plan through `update_plan`. Chat and history show one card per run with pending, in-progress and completed steps; ending or interrupting a run keeps unfinished work visible.

Plan snapshots are committed to Studio's database before `plan.updated` is broadcast. Tool calls and results continue through normal chat persistence. Resume and paginated history restore the latest revisions, including App conditional resume responses. Session deletion removes plans, and startup marks orphaned running plans interrupted. Cards support folding and all 11 UI languages.

Validation:
- GitHub Build workflow passed on `7a6a249e`: repository harness, full coverage and production build.
- Full CI coverage: 5,164 tests passed, 8 skipped (629 passing test files, 2 skipped).
- Local session-command, task-plan and resume/compression regression tests: 52 passed. Coverage includes repeated parent/child session restoration, empty authoritative snapshots and plans without persisted message bodies.
- App resume and relay tests: 49 passed; locale/direction/card tests: 30 passed.
- Playwright passed on the preceding feature commit; its rerun on this test-only follow-up is still in progress.

Browser tests use mocked API/model events. Native App UI support is implemented separately in the App repository; Android/iOS device acceptance remains outstanding.
