### PR TITLE
fix(pi): avoid duplicate MCP adapter loading

### DIFF
--- a/packages/server/src/modules/coding-agents/services/index.ts
+++ b/packages/server/src/modules/coding-agents/services/index.ts
@@ -1395,6 +1395,15 @@ function getPiMcpAdapterEntry(): string {
   return join(getPiMcpAdapterRoot(), 'node_modules', 'pi-mcp-adapter', 'index.ts')
 }
 
+function isPiMcpAdapterReference(value: unknown): boolean {
+  if (typeof value !== 'string') return false
+  const normalized = value.trim().replace(/\\/g, '/')
+  if (!normalized) return false
+  const packageReference = normalized.replace(/^npm:/i, '')
+  return /(?:^|\/)pi-mcp-adapter(?:@[^/]+)?(?:\/index\.[cm]?[jt]sx?)?$/i.test(packageReference)
+    || /@npm:pi-mcp-adapter(?:@|$)/i.test(packageReference)
+}
+
 function piSettingsConfig(existingContents: string[] = [], runtimeExtensionPath = ''): string {
   let existing: Record<string, unknown> = {}
   for (const content of existingContents) {
@@ -1403,11 +1412,17 @@ function piSettingsConfig(existingContents: string[] = [], runtimeExtensionPath 
       if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) existing = { ...existing, ...parsed }
     } catch {}
   }
+  // Studio always injects its managed adapter below. Remove user copies only
+  // from the isolated runtime projection so the original Pi config stays intact.
   const configuredExtensions = Array.isArray(existing.extensions)
-    ? existing.extensions.filter(value => typeof value === 'string' && value.trim())
+    ? existing.extensions.filter(value => typeof value === 'string' && value.trim() && !isPiMcpAdapterReference(value))
     : []
+  const configuredPackages = Array.isArray(existing.packages)
+    ? existing.packages.filter(value => !isPiMcpAdapterReference(value))
+    : undefined
   return `${JSON.stringify({
     ...existing,
+    ...(configuredPackages ? { packages: configuredPackages } : {}),
     defaultProjectTrust: 'never',
     enableSkillCommands: true,
     extensions: [...new Set([

--- a/tests/server/coding-agents-launch.test.ts
+++ b/tests/server/coding-agents-launch.test.ts
@@ -450,6 +450,61 @@ describe('coding agent launch preparation', () => {
     })
   })
 
+  it('removes user-installed pi-mcp-adapter duplicates from isolated Pi settings', async () => {
+    const home = makeHome()
+    const managedAdapterEntry = join(
+      home,
+      'coding-agent',
+      'pi-mcp-adapter',
+      'node_modules',
+      'pi-mcp-adapter',
+      'index.ts',
+    )
+    mkdirSync(dirname(managedAdapterEntry), { recursive: true })
+    writeFileSync(managedAdapterEntry, 'export default {}')
+
+    const userAdapterEntry = join(
+      home,
+      'global-home',
+      '.pi',
+      'agent',
+      'npm',
+      'node_modules',
+      'pi-mcp-adapter',
+      'index.ts',
+    )
+    const userSettingsPath = join(home, 'global-home', '.pi', 'agent', 'settings.json')
+    mkdirSync(dirname(userSettingsPath), { recursive: true })
+    writeFileSync(userSettingsPath, `${JSON.stringify({
+      packages: ['pi-mcp-adapter@2.32.1', 'pi-extra-package@1.0.0'],
+    }, null, 2)}\n`)
+    const scopedSettingsPath = join(home, 'coding-agent', 'model', 'default', 'custom_test', 'pi', 'settings.json')
+    mkdirSync(dirname(scopedSettingsPath), { recursive: true })
+    writeFileSync(scopedSettingsPath, `${JSON.stringify({
+      extensions: [userAdapterEntry, '/tmp/pi-extra-extension.ts'],
+    }, null, 2)}\n`)
+
+    const result = await prepareCodingAgentLaunch('pi', {
+      profile: 'default',
+      provider: 'custom:test',
+      model: 'test-model',
+      baseUrl: 'https://api.example.com/v1',
+      apiKey: '«redacted:sk-…»',
+      apiMode: 'codex_responses',
+      sessionId: 'pi-adapter-dedupe-session',
+      agentSessionId: 'pi-adapter-dedupe-agent',
+    })
+
+    const runtimeSettings = JSON.parse(readFileSync(join(result.rootDir, 'settings.json'), 'utf8'))
+    expect(runtimeSettings.packages).toEqual(['pi-extra-package@1.0.0'])
+    expect(runtimeSettings.extensions).toContain('/tmp/pi-extra-extension.ts')
+    expect(runtimeSettings.extensions).toContain(managedAdapterEntry)
+    expect(runtimeSettings.extensions).not.toContain(userAdapterEntry)
+    expect(runtimeSettings.extensions.filter((value: string) => value.includes('pi-mcp-adapter'))).toEqual([
+      managedAdapterEntry,
+    ])
+  })
+
   it('migrates legacy plaintext Pi proxy targets to encrypted storage during restore', async () => {
     const home = makeHome()
     const targetPath = join(


### PR DESCRIPTION
## Summary

- remove user-configured `pi-mcp-adapter` package entries from Studio's isolated Pi runtime projection when Studio injects its managed adapter
- remove duplicate adapter extension paths while preserving unrelated Pi packages and extensions
- keep the user's original `~/.pi/agent/settings.json` unchanged
- add regression coverage for the package-plus-extension collision reported on Windows

Fixes #2935

## Problem and root cause

Studio always injects its managed `pi-mcp-adapter` entry into the isolated Pi runtime settings. At the same time, `piSettingsConfig()` merges the user's global and provider-scoped Pi settings verbatim. If the user already has `pi-mcp-adapter` in `packages`, Pi installs/loads that copy as well as Studio's managed copy. Both adapters register the fixed `mcp` tool and `--mcp-config` flag, so Pi exits with duplicate registration errors.

## Approach and tradeoffs

The runtime settings projection now recognizes `pi-mcp-adapter` package references and adapter entry paths across npm version specs, npm aliases, POSIX paths, and Windows-style paths. It filters those duplicate references before appending Studio's managed adapter.

This is intentionally limited to the generated isolated runtime settings. Studio does not rewrite or delete the user's Pi configuration, and unrelated packages/extensions continue to be inherited. The managed adapter version and Studio MCP configuration remain unchanged.

## Validation

- `npm run test -- tests/server/coding-agents-launch.test.ts` — 84 passed
- regression sabotage — with the filtering removed, the new test failed because `pi-mcp-adapter@2.32.1` remained in runtime `packages`; restoring the fix passed
- `npm run harness:check` — passed
- `npm run test:e2e` — 174 passed
- `npm run build` — passed
- `npm run test:coverage` — 5,139 passed, 8 skipped, 1 failed in unrelated `tests/client/use-speech-tts.test.ts` (`Blob` cross-realm `instanceof` assertion)
- baseline reproduction on untouched `origin/main` `4aa6d34c41c77a517ee5dd9c01cf3c35dec36698`: `npm run test:coverage -- tests/client/use-speech-tts.test.ts` fails at the same assertion

All commands used isolated `HERMES_WEB_UI_HOME`, `HERMES_WEBUI_STATE_DIR`, and `UPLOAD_DIR` paths inside temporary worktrees.

## Risk and compatibility

- low-risk launch-time configuration change; no API, schema, credential, or persistence migration
- users with their own adapter keep that configuration on disk, but Studio-run Pi sessions use the Studio-managed adapter to avoid duplicate tool/flag registration
- unrelated Pi packages and extension paths remain available in isolated Studio runs

## Scope exclusions

- does not upgrade Studio's pinned `pi-mcp-adapter` version
- does not change Pi's native/global configuration outside the isolated runtime projection
- does not adopt the newer `registerMcpServer()` integration API
- does not address the pre-existing TTS coverage-test failure

## AI disclosure

This contribution was generated with AI assistance and was reviewed and validated against the repository's existing contribution and test conventions.
