### PR TITLE
fix(desktop): reveal embedded browser panel before link load

### DIFF
--- a/packages/client/src/utils/desktop-browser.ts
+++ b/packages/client/src/utils/desktop-browser.ts
@@ -41,8 +41,9 @@ export async function openUrlInDesktopBrowser(url: string): Promise<boolean> {
   if (!hasDesktopBrowserBridge()) return false
   const browser = bridge?.browser
   if (!browser) return false
-  await browser.createTab(url, true)
+  const tabCreation = browser.createTab(url, true)
   revealDesktopBrowserPanel()
+  await tabCreation
   return true
 }
 

--- a/tests/client/desktop-browser-open.test.ts
+++ b/tests/client/desktop-browser-open.test.ts
@@ -46,6 +46,32 @@ describe('desktop browser open helpers', () => {
     window.removeEventListener(OPEN_DESKTOP_BROWSER_PANEL_EVENT, listener)
   })
 
+  it('reveals the browser panel before a slow tab finishes loading', async () => {
+    const browser = browserBridge()
+    let resolveTab!: (tab: { id: string }) => void
+    const pendingTab = new Promise<{ id: string }>(resolve => {
+      resolveTab = resolve
+    })
+    browser.createTab.mockReturnValue(pendingTab)
+    ;(window as typeof window & { hermesDesktop?: unknown }).hermesDesktop = {
+      isDesktop: true,
+      browser,
+    }
+    const listener = vi.fn()
+    const { OPEN_DESKTOP_BROWSER_PANEL_EVENT, openUrlInDesktopBrowser } = await import(
+      '../../packages/client/src/utils/desktop-browser'
+    )
+    window.addEventListener(OPEN_DESKTOP_BROWSER_PANEL_EVENT, listener)
+
+    const opening = openUrlInDesktopBrowser('https://example.com/slow')
+    await Promise.resolve()
+
+    expect(listener).toHaveBeenCalledTimes(1)
+    resolveTab({ id: 'web-tab' })
+    await expect(opening).resolves.toBe(true)
+    window.removeEventListener(OPEN_DESKTOP_BROWSER_PANEL_EVENT, listener)
+  })
+
   it('leaves a message URL for the system browser when that target is stored', async () => {
     const browser = browserBridge()
     ;(window as typeof window & { hermesDesktop?: unknown }).hermesDesktop = {


### PR DESCRIPTION
## Why this PR

When **Settings → Display → Web link opening target** is set to **Hermes Studio**, clicking an HTTP(S) link rendered in a chat message is expected to open that link in Hermes Studio's embedded browser and reveal the browser Side Panel automatically.

The Side Panel should become visible as soon as the embedded browser starts opening the link. The page may still be loading at that point, so the user should be able to see the browser panel and its loading state immediately rather than having to open the panel manually or wait without feedback.

### Expected behavior

1. The user clicks an HTTP(S) link in a Markdown-rendered chat message.
2. Hermes Studio starts creating/navigating an embedded browser tab for the link.
3. The browser Side Panel is revealed immediately and the new browser tab is selected.
4. The page continues loading inside the panel; if tab creation fails, the existing error handling still receives that failure.

### Current behavior before this PR

The link-opening helper waited for `browser.createTab(url, true)` to resolve before dispatching the event that reveals the Side Panel. As a result, panel visibility was incorrectly coupled to tab/page creation completing:

```text
click link
  → await create embedded browser tab / wait for navigation
  → reveal Side Panel
```

For a slow, blocked, or otherwise long-loading URL, the promise did not resolve promptly. The Side Panel therefore remained hidden even though the user had explicitly chosen **Hermes Studio** as the link-opening target. This made the feature appear unresponsive and prevented the user from seeing the embedded browser's loading state.

### Fix

Start tab creation and dispatch the Side Panel reveal event immediately, then continue awaiting the tab-creation promise:

```text
click link
  → start creating embedded browser tab
  → reveal Side Panel immediately
  → await tab creation / preserve error propagation
```

This separates the UI reveal from page-load completion while preserving the existing promise semantics and error handling.

## Scope

- Applies to HTTP(S) Markdown links opened with the **Hermes Studio** target.
- Keeps the default-browser flow unchanged.
- Keeps HTML artifact previews unchanged.
- Adds a deterministic regression test using a tab-creation promise that remains pending, proving that the Side Panel event fires before tab creation finishes.

## Validation

- `NODE_ENV=test mise exec node@24.20.0 -- npx vitest run tests/client/desktop-browser-open.test.ts tests/client/markdown-rendering.test.ts tests/client/desktop-browser-route.test.ts tests/client/file-preview-desktop-html.test.ts --reporter=dot` — 72 passed
- `env -u HERMES_AGENT_BRIDGE_WORKER_PROFILE -u HERMES_AGENT_BRIDGE_BASE_HOME PORT=8648 NODE_ENV=test mise exec node@24.20.0 -- npm run test:coverage -- --maxWorkers=1 --testTimeout=30000 --hookTimeout=30000` — 628 files passed; 5,148 tests passed; 6 skipped
- `env -u HERMES_AGENT_BRIDGE_WORKER_PROFILE -u HERMES_AGENT_BRIDGE_BASE_HOME PORT=8648 NODE_ENV=development PLAYWRIGHT_PORT=43204 PLAYWRIGHT_CHANNEL=chrome mise exec node@24.20.0 -- npx playwright test tests/e2e/link-opening-preference.spec.ts --workers=1` — 2 passed
- `env -u HERMES_AGENT_BRIDGE_WORKER_PROFILE -u HERMES_AGENT_BRIDGE_BASE_HOME PORT=8648 mise exec node@24.20.0 -- npm run harness:check` — passed
- `env -u HERMES_AGENT_BRIDGE_WORKER_PROFILE -u HERMES_AGENT_BRIDGE_BASE_HOME PORT=8648 NODE_ENV=development mise exec node@24.20.0 -- npm run build` — passed
- GitHub Actions `build` check — passed
- GitHub Actions `e2e` check — passed

The complete Playwright suite was also attempted locally but exceeded the local terminal runner wall-clock limit without returning a test verdict; the focused browser E2E passed locally and the required remote E2E check passed in GitHub Actions.
