### PR TITLE
fix(coding-agents): resolve coding agent command paths on POSIX launches

### DIFF
--- a/packages/server/src/modules/coding-agents/services/index.ts
+++ b/packages/server/src/modules/coding-agents/services/index.ts
@@ -2493,12 +2493,17 @@ async function findCommandPaths(command: string, env: NodeJS.ProcessEnv): Promis
 }
 
 async function resolveCommandForExecution(command: string, env: NodeJS.ProcessEnv): Promise<string> {
-  if (process.platform !== 'win32') return command
   const paths = await findCommandPaths(command, env)
-  // On Windows, prioritize paths with .cmd or .bat extensions since where may return
-  // both the unix-style script (without extension) and the Windows shim (.cmd)
-  const windowsPath = paths.find(path => windowsCommandNeedsShell(path))
-  return windowsPath || paths[0] || command
+  if (process.platform === 'win32') {
+    // On Windows, prioritize paths with .cmd or .bat extensions since where may return
+    // both the unix-style script (without extension) and the Windows shim (.cmd)
+    const windowsPath = paths.find(path => windowsCommandNeedsShell(path))
+    return windowsPath || paths[0] || command
+  }
+  // Resolve to an absolute path on POSIX so the child process can spawn even when
+  // the server was launched from a desktop GUI whose PATH misses user bin dirs
+  // such as ~/.npm-global/bin (spawn falls back to the bare command when missing).
+  return paths[0] || command
 }
 
 function commandExecution(command: string, args: string[]): CommandExecution {
@@ -3651,16 +3656,14 @@ async function startCodingAgentRunInternal(
       logger.warn({ err, agentId: id, runtimeMcpPath }, '[coding-agent-mcp] runtime isolation failed open')
     }
   }
-  const commandExecutionEnv = process.platform === 'win32'
-    ? {
-        ...(await commandEnv()),
-        ...launch.env,
-      }
-    : launch.env
-  const runtimeCommand = process.platform === 'win32'
-    ? await resolveCommandForExecution(launch.command, commandExecutionEnv)
-    : launch.command
-  const runtimeEnv = launch.agentId === 'pi' ? launch.env : commandExecutionEnv
+  const commandExecutionEnv = {
+    ...(await commandEnv()),
+    ...launch.env,
+  }
+  const runtimeCommand = await resolveCommandForExecution(launch.command, commandExecutionEnv)
+  const runtimeEnv = launch.agentId === 'pi' || process.platform !== 'win32'
+    ? launch.env
+    : commandExecutionEnv
   const persistedProvider = String(resolvedInput.provider || launch.provider || '').trim() || launch.provider
   const started = codingAgentRunManager.start({
     agentSessionId,
@@ -3735,12 +3738,10 @@ export async function compactStoredCodingAgentSession(
     isolateSettings: true,
   })
   const launchEnv = {
-    ...process.env,
+    ...(await commandEnv()),
     ...launch.env,
   }
-  const command = process.platform === 'win32'
-    ? await resolveCommandForExecution(launch.command, launchEnv)
-    : launch.command
+  const command = await resolveCommandForExecution(launch.command, launchEnv)
   return compactCodexThread({
     command,
     env: launchEnv,

--- a/tests/server/coding-agents-desktop-path.test.ts
+++ b/tests/server/coding-agents-desktop-path.test.ts
@@ -25,7 +25,7 @@ const execState = vi.hoisted(() => {
       return { stdout: '/Users/example/.npm-global/bin/claude\n', stderr: '' }
     }
 
-    if (command === 'claude' && args[0] === '--version') {
+    if ((command === 'claude' || command === '/Users/example/.npm-global/bin/claude') && args[0] === '--version') {
       return { stdout: '1.2.3\n', stderr: '' }
     }
 
@@ -87,7 +87,8 @@ describe('coding agent desktop PATH detection', () => {
     expect(status.installed).toBe(true)
     expect(status.version).toBe('1.2.3')
 
-    const versionCall = execState.calls.find(call => call.command === 'claude' && call.args[0] === '--version')
+    const versionCall = execState.calls.find(call => (call.command === 'claude' || call.command === '/Users/example/.npm-global/bin/claude') && call.args[0] === '--version')
+    expect(versionCall?.command).toBe('/Users/example/.npm-global/bin/claude')
     expect(versionCall?.options.env.PATH.split(delimiter)).toContain('/Users/example/.npm-global/bin')
   })
 })

--- a/tests/server/coding-agents-launch-command-resolution.test.ts
+++ b/tests/server/coding-agents-launch-command-resolution.test.ts
@@ -1,0 +1,169 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const execState = vi.hoisted(() => {
+  const calls: Array<{ command: string; args: string[]; options: any }> = []
+  const execFile = vi.fn()
+  ;(execFile as any)[Symbol.for('nodejs.util.promisify.custom')] = async (command: string, args: string[], options: any) => {
+    calls.push({ command, args, options })
+
+    if (command === '/bin/zsh') {
+      return {
+        stdout: ['/Users/example/.npm-global/bin', '/opt/homebrew/bin', '/usr/bin'].join(':'),
+        stderr: '',
+      }
+    }
+
+    if (command === 'which' && args[0] === '-a' && args[1] === 'claude') {
+      if (!String(options.env?.PATH || '').split(':').includes('/Users/example/.npm-global/bin')) {
+        throw Object.assign(new Error('claude not found'), { code: 'ENOENT' })
+      }
+      return { stdout: '/Users/example/.npm-global/bin/claude\n', stderr: '' }
+    }
+
+    throw new Error(`unexpected command: ${command} ${args.join(' ')}`)
+  }
+  return { calls, execFile }
+})
+
+const runStart = vi.hoisted(() => vi.fn())
+
+vi.mock('child_process', () => ({
+  execFile: execState.execFile,
+}))
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>()
+  return {
+    ...actual,
+    existsSync: (path: string) => path === '/bin/zsh' || actual.existsSync(path),
+  }
+})
+
+vi.mock('../../packages/server/src/modules/studio/public/sessions', () => ({
+  getSession: () => null,
+  updateSession: () => undefined,
+}))
+
+vi.mock('../../packages/server/src/modules/coding-agents/services/runtime/run-manager', () => ({
+  codingAgentRunManager: {
+    start: runStart,
+  },
+}))
+
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+const originalPath = process.env.PATH
+const originalShell = process.env.SHELL
+const originalHermesDesktop = process.env.HERMES_DESKTOP
+const originalWebUiHome = process.env.HERMES_WEB_UI_HOME
+const originalCodingAgentGlobalHome = process.env.HERMES_CODING_AGENT_GLOBAL_HOME
+
+const homes: string[] = []
+
+function setPlatform(platform: NodeJS.Platform) {
+  Object.defineProperty(process, 'platform', { value: platform })
+}
+
+beforeEach(() => {
+  execState.calls.length = 0
+  runStart.mockReset()
+  runStart.mockReturnValue({ pid: 123 })
+  setPlatform('darwin')
+  process.env.HERMES_DESKTOP = 'true'
+  process.env.SHELL = '/bin/zsh'
+  process.env.PATH = '/usr/bin'
+  const home = mkdtempSync(join(tmpdir(), 'hermes-coding-agent-launch-path-'))
+  homes.push(home)
+  process.env.HERMES_WEB_UI_HOME = home
+  process.env.HERMES_CODING_AGENT_GLOBAL_HOME = join(home, 'global-home')
+})
+
+afterEach(() => {
+  if (originalPlatform) Object.defineProperty(process, 'platform', originalPlatform)
+  process.env.PATH = originalPath
+  if (typeof originalShell === 'undefined') delete process.env.SHELL
+  else process.env.SHELL = originalShell
+  if (typeof originalHermesDesktop === 'undefined') delete process.env.HERMES_DESKTOP
+  else process.env.HERMES_DESKTOP = originalHermesDesktop
+  if (typeof originalWebUiHome === 'undefined') delete process.env.HERMES_WEB_UI_HOME
+  else process.env.HERMES_WEB_UI_HOME = originalWebUiHome
+  if (typeof originalCodingAgentGlobalHome === 'undefined') delete process.env.HERMES_CODING_AGENT_GLOBAL_HOME
+  else process.env.HERMES_CODING_AGENT_GLOBAL_HOME = originalCodingAgentGlobalHome
+  vi.resetModules()
+  vi.unstubAllGlobals()
+  vi.unstubAllEnvs()
+  for (const home of homes.splice(0)) rmSync(home, { recursive: true, force: true })
+})
+
+describe('coding agent launch command resolution', () => {
+  it('spawns Claude from the login shell PATH when Electron PATH is minimal', async () => {
+    const { startCodingAgentRun } = await import('../../packages/server/src/bootstrap/coding-agents')
+    const result = await startCodingAgentRun('claude-code', {
+      sessionId: 'session-1',
+      agentSessionId: 'agent-session-1',
+      profile: 'default',
+      mode: 'global',
+      groupSystemPrompt: 'test system prompt',
+      workspace: join(process.env.HERMES_WEB_UI_HOME!, 'workspace'),
+    })
+
+    expect(result.pid).toBe(123)
+    expect(runStart).toHaveBeenCalledTimes(1)
+    const started = runStart.mock.calls[0][0]
+    expect(started.command).toBe('/Users/example/.npm-global/bin/claude')
+    // The child env keeps the launch contract (no inherited process env),
+    // while the command was resolved with the enriched desktop PATH.
+    expect(started.env).toEqual({ HERMES_STUDIO_SESSION_ID: 'session-1' })
+  })
+
+  it('resolves scoped launches without leaking parent secrets into the child environment', async () => {
+    vi.stubEnv('ANTHROPIC_AUTH_TOKEN', 'sk-parent-secret')
+    vi.stubEnv('CLAUDECODE', '1')
+
+    const { configureProfileConfig } = await import('../../packages/server/src/modules/studio/public/profile-config')
+    const home = process.env.HERMES_WEB_UI_HOME!
+    configureProfileConfig({
+      buildModelGroups: () => ({ default: '', groups: [] }),
+      getProfilesBaseDir: () => join(home, 'profiles'),
+      getProfileDir: profile => join(home, 'profiles', profile),
+      getActiveProfileName: () => 'default',
+      listProfileNames: () => ['default'],
+      providerEnvironmentMap: {},
+      readConfigYaml: async () => ({}),
+      readConfigYamlForProfile: async () => ({}),
+      safeReadFile: async filePath => existsSync(filePath) ? readFileSync(filePath, 'utf-8') : null,
+      saveEnvValue: async () => undefined,
+      saveEnvValueForProfile: async () => undefined,
+      updateConfigYaml: async () => undefined,
+      updateConfigYamlForProfile: async () => undefined,
+    })
+
+    const { startCodingAgentRun } = await import('../../packages/server/src/bootstrap/coding-agents')
+    const result = await startCodingAgentRun('claude-code', {
+      sessionId: 'session-scoped',
+      agentSessionId: 'agent-session-scoped',
+      profile: 'default',
+      mode: 'scoped',
+      provider: 'custom:test',
+      model: 'claude-sonnet-test',
+      apiMode: 'anthropic_messages',
+      baseUrl: 'https://provider.example/anthropic',
+      apiKey: 'sk-upstream',
+      workspace: join(home, 'workspace'),
+    })
+
+    expect(result.pid).toBe(123)
+    expect(runStart).toHaveBeenCalledTimes(1)
+    const started = runStart.mock.calls[0][0]
+    expect(started.command).toBe('/Users/example/.npm-global/bin/claude')
+
+    const { isolatedCodingAgentChildEnv } = await import('../../packages/server/src/modules/coding-agents/services/runtime/child-env')
+    // The scoped spawn path applies this isolation on top of the launch env.
+    const childEnv = isolatedCodingAgentChildEnv(started.env)
+    expect(childEnv.ANTHROPIC_API_KEY).toMatch(/^hwui_/)
+    expect(childEnv.ANTHROPIC_AUTH_TOKEN).toBeUndefined()
+    expect(childEnv.CLAUDECODE).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Problem

When the desktop app (Electron) launches the server, the server process PATH only carries the GUI launch environment — user bin dirs such as `~/.npm-global/bin` are missing. Coding agent runs spawn the bare `claude` command on POSIX: `startCodingAgentRunInternal` used `launch.command` as-is, so `spawn claude` fails with `ENOENT` even when the CLI is installed. Only Windows received the enriched env plus command resolution; POSIX did not.

Observed on Hermes Studio 0.7.16: group-chat coding agent fails with `spawn claude ENOENT` in `server.log`, workable only by symlinking `claude` into a PATH directory.

## Fix

- `resolveCommandForExecution` now also resolves the command to an absolute path on POSIX (via `which -a` against the enriched PATH), falling back to the bare command when it cannot be resolved.
- `startCodingAgentRunInternal` builds the resolution env from `commandEnv()` (login-shell PATH, global npm bin, common desktop bin dirs) on all platforms and resolves the runtime command. The child env contract is unchanged: POSIX children still receive exactly `launch.env` (no inherited process env / credentials); only the spawned command is now an absolute path.
- `compactStoredCodingAgentSession` uses the same enriched env for resolution (its child env already inherited `process.env` before this change).

`commandEnv()` already existed and is used for availability checks (`getCodingAgentStatus`); this change makes the actual spawn path consistent with the status check.

## Tests

- Updated `tests/server/coding-agents-desktop-path.test.ts` to assert the version check runs the resolved absolute path.
- Added `tests/server/coding-agents-launch-command-resolution.test.ts`: starts a Claude Code run with a minimal `/usr/bin` PATH (Electron-like) and asserts the run launches with the absolute claude path while the child env keeps the launch contract.

## Validation

- Targeted: `coding-agents-desktop-path`, `coding-agents-launch-command-resolution`, `coding-agent-resume-config`, `coding-agents-launch` — 100 passed
- `tsc --noEmit -p packages/server/tsconfig.json` — clean
- `npm run harness:check` — passed
- `npm run build` — passed
- Full `npm run test` locally: 0 failures under `tests/server`. Remaining local failures (44 `tests/client` Vue tests + 1 `tests/desktop`) reproduce on unmodified `main` in this environment and are unrelated to this change.
