### PR TITLE
fix(chat): keep sidebar working while delegated tasks run

### DIFF
--- a/docs/chat-chain-changes/sidebar-delegation-working-indicator.md
+++ b/docs/chat-chain-changes/sidebar-delegation-working-indicator.md
@@ -1,0 +1,66 @@
+# Sidebar working indicator during background delegation
+
+## Scope
+
+The session-list working glow reflects foreground execution **or** a positive,
+server-reported background delegation count. Foreground completion must not stop
+that glow while delegated work is pending. The existing `isSessionLive`,
+`isStreaming`, and `isRunActive` contracts remain foreground-only: queue insertion,
+voice interruption, and composer controls must not change just for a sidebar cue.
+
+The chat store retains `background_pending` from live events and replaces it from
+`backgroundPending` in session-switch, reconnect, and visibility-resume snapshots.
+Historical subagent/tool traces are not evidence of current work. The aggregate
+count includes result delivery; a single child completion does not imply every
+delegation is terminal. Zero counts and terminal run events clear activity; runtime
+switches clear counts and invalidate earlier runtime callbacks. Session IDs follow
+the existing store/socket session ownership, including profile-scoped transport.
+
+Each known positive-background session temporarily owns a profile/transport-scoped
+status socket, independent of the execution socket. It resumes its session room
+on reconnect, so completion is still observed after switching execution profiles.
+The observer closes at terminal activity, deletion/archive, store/runtime disposal,
+or actual credential/backend invalidation. Credential clearing and replacement
+invalidate old callbacks and asynchronous send preparation without aborting server
+work; fresh login establishes new authenticated listeners. This costs one additional
+socket per known background-active session, not a polling loop or a task database.
+
+Session lists use the new display-only `isSessionWorking` predicate. There are no
+new labels or badges, server changes, persisted state, or modifications to Hermes
+runtime delegation. Reload restores activity for sessions resumed by the existing
+architecture; this does not add a global background-task discovery endpoint for
+unopened sessions.
+
+## Related work
+
+Refs #2625 and open PR #2629. This is an alternative, narrower fix: it retains the
+existing glow and separates visual activity from execution/queue semantics rather
+than broadening `isSessionLive` or adding active-chat text and count badges.
+
+## Regression coverage
+
+- `tests/client/chat-store-working-state.test.ts`: foreground/background overlap,
+  multiple delegations and terminal outcomes, session/profile separation,
+  authoritative resume/reconnect versus stale history, runtime reset and late
+  callbacks, visibility wake/passive listener attachment.
+- `tests/client/chat-store-working-transport.test.ts`: real API/store auth invalidation,
+  socket-room loss/reconnect, profile replacement, cancellation payloads, resource
+  disposal, delayed old-auth callbacks/uploads/model readiness, and fresh login.
+- `tests/e2e/chat-streaming.spec.ts`: foreground → background-only → terminal glow,
+  with the real center transcript and right-hand subagent panel rendered together.
+- `tests/e2e/sidebar-working.spec.ts`: navigation, reload, enabled composer, partial
+  completion, aggregate zero, and terminal reload despite historical task events.
+- Browser screenshots use explicitly mocked API/socket fixtures, not live tasks.
+
+## Validation
+
+```sh
+PATH=/opt/homebrew/bin:$PATH NODE_ENV=test npm run test -- tests/client
+PATH=/opt/homebrew/bin:$PATH NODE_ENV=development PLAYWRIGHT_PORT=14387 PLAYWRIGHT_CHANNEL=chrome npm run test:e2e -- tests/e2e/chat-streaming.spec.ts tests/e2e/sidebar-working.spec.ts --workers=2
+PATH=/opt/homebrew/bin:$PATH NODE_ENV=production npm run build
+PATH=/opt/homebrew/bin:$PATH npm run harness:check
+```
+
+The absolute Node path and Chrome channel are local environment choices; CI can use
+its supported Node and managed Playwright browser. Bound browser workers on a busy
+developer machine to avoid unrelated five-second initial-render timeouts.

--- a/packages/client/src/api/auth-invalidation.ts
+++ b/packages/client/src/api/auth-invalidation.ts
@@ -1,0 +1,11 @@
+// Dependency-free: API credentials and authenticated runtimes must not import each other.
+const listeners = new Set<() => void>()
+
+export function onAuthInvalidated(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => { listeners.delete(listener) }
+}
+
+export function invalidateAuth(): void {
+  for (const listener of [...listeners]) listener()
+}

--- a/packages/client/src/api/client.ts
+++ b/packages/client/src/api/client.ts
@@ -1,4 +1,5 @@
 import router from '@/router'
+import { invalidateAuth } from './auth-invalidation'
 
 const DEFAULT_BASE_URL = ''
 const ACTIVE_PROFILE_STORAGE_KEY = 'hermes_active_profile_name'
@@ -29,15 +30,20 @@ export function getApiKey(): string {
 }
 
 export function setServerUrl(url: string) {
+  const previousBase = getBaseUrl()
   localStorage.setItem('hermes_server_url', url)
+  if (getBaseUrl() !== previousBase) invalidateAuth()
 }
 
 export function setApiKey(key: string) {
+  const changed = getApiKey() !== key
   localStorage.setItem('hermes_api_key', key)
+  if (changed) invalidateAuth()
 }
 
 export function clearApiKey() {
   localStorage.removeItem('hermes_api_key')
+  invalidateAuth()
 }
 
 function clearAuthSessionState() {

--- a/packages/client/src/api/studio/background-status.ts
+++ b/packages/client/src/api/studio/background-status.ts
@@ -1,0 +1,62 @@
+import { io } from 'socket.io-client'
+import { getApiKey, getBaseUrlValue } from '../client'
+import type { ChatRunTransport, ResumeSessionPayload, RunEvent } from './chat'
+
+const disconnectObservers = new Set<() => void>()
+
+export function disconnectBackgroundStatusObservers(): void {
+  for (const disconnect of [...disconnectObservers]) disconnect()
+}
+
+/** Observe aggregate activity without owning or replacing the execution socket. */
+export function observeBackgroundStatus(
+  sessionId: string,
+  profile: string,
+  transport: ChatRunTransport,
+  onPending: (pending: unknown) => void,
+): () => void {
+  let closed = false
+  const namespace = transport === 'global-agent' ? '/global-agent' : '/chat-run'
+  const socket = io(`${getBaseUrlValue()}${namespace}`, {
+    auth: { token: getApiKey() },
+    query: { profile },
+    transports: ['websocket', 'polling'],
+    reconnection: true,
+    reconnectionAttempts: Infinity,
+    reconnectionDelay: 1000,
+    reconnectionDelayMax: 30000,
+    randomizationFactor: 0.5,
+    timeout: 30000,
+  })
+  const resume = () => {
+    if (!closed) socket.emit('resume', { session_id: sessionId, profile })
+  }
+  socket.on('connect', resume)
+  socket.on('resumed', (data: ResumeSessionPayload) => {
+    if (!closed && data.session_id === sessionId) onPending(data.backgroundPending)
+  })
+  const onEvent = (event: RunEvent) => {
+    if (closed || event.session_id !== sessionId) return
+    if (event.background_pending != null || event.event === 'run.completed'
+      || event.event === 'run.failed' || event.event === 'abort.completed') {
+      onPending(event.background_pending)
+    }
+  }
+  for (const event of ['delegation.updated', 'run.completed', 'run.failed', 'abort.completed']) {
+    socket.on(event, onEvent)
+  }
+  if (socket.connected) resume()
+  const dispose = () => {
+    if (closed) return
+    closed = true
+    disconnectObservers.delete(disconnect)
+    socket.removeAllListeners()
+    socket.disconnect()
+  }
+  const disconnect = () => {
+    dispose()
+    onPending(0)
+  }
+  disconnectObservers.add(disconnect)
+  return dispose
+}

--- a/packages/client/src/api/studio/chat.ts
+++ b/packages/client/src/api/studio/chat.ts
@@ -1,5 +1,7 @@
 import type { TaskPlanSnapshot } from '@/utils/task-plan'
 import { io, type Socket } from 'socket.io-client'
+import { disconnectBackgroundStatusObservers } from './background-status'
+import { onAuthInvalidated } from '../auth-invalidation'
 import { getBaseUrlValue, getApiKey } from '../client'
 import type { ChatCodingAgentId } from '../coding-agents'
 import type { ProviderApiMode } from './provider-api-mode'
@@ -812,58 +814,67 @@ export function connectChatRun(requestedProfile?: string | null, transport: Chat
     timeout: 30000,
   })
 
+  // Retained callbacks from a replaced/invalidated socket must not dispatch
+  // into handlers registered by a later authenticated session.
+  const ownerSocket = chatRunSocket
+  const on = (event: string, handler: (event: RunEvent) => void) => {
+    ownerSocket.on(event, (data: RunEvent) => {
+      if (chatRunSocket === ownerSocket) handler(data)
+    })
+  }
+
   // Register global listeners only once per socket connection
   if (!globalListenersRegistered) {
     // Message events
-    chatRunSocket.on('message.delta', globalMessageDeltaHandler)
-    chatRunSocket.on('message.interim', globalMessageInterimHandler)
-    chatRunSocket.on('reasoning.delta', globalReasoningDeltaHandler)
-    chatRunSocket.on('thinking.delta', globalThinkingDeltaHandler)
-    chatRunSocket.on('reasoning.available', globalReasoningAvailableHandler)
-    chatRunSocket.on('moa.reference', globalReasoningDeltaHandler)
-    chatRunSocket.on('moa.aggregating', globalAgentEventHandler)
+    on('message.delta', globalMessageDeltaHandler)
+    on('message.interim', globalMessageInterimHandler)
+    on('reasoning.delta', globalReasoningDeltaHandler)
+    on('thinking.delta', globalThinkingDeltaHandler)
+    on('reasoning.available', globalReasoningAvailableHandler)
+    on('moa.reference', globalReasoningDeltaHandler)
+    on('moa.aggregating', globalAgentEventHandler)
 
     // Tool events
-    chatRunSocket.on('tool.started', globalToolStartedHandler)
-    chatRunSocket.on('tool.completed', globalToolCompletedHandler)
-    chatRunSocket.on('tool.failed', globalToolCompletedHandler)
-    chatRunSocket.on('workspace.diff.completed', globalWorkspaceDiffCompletedHandler)
-    chatRunSocket.on('subagent.start', globalSubagentEventHandler)
-    chatRunSocket.on('subagent.tool', globalSubagentEventHandler)
-    chatRunSocket.on('subagent.progress', globalSubagentEventHandler)
-    chatRunSocket.on('subagent.text', globalSubagentEventHandler)
-    chatRunSocket.on('subagent.thinking', globalSubagentEventHandler)
-    chatRunSocket.on('subagent.complete', globalSubagentEventHandler)
-    chatRunSocket.on('delegation.updated', globalSubagentEventHandler)
+    on('tool.started', globalToolStartedHandler)
+    on('tool.completed', globalToolCompletedHandler)
+    on('tool.failed', globalToolCompletedHandler)
+    on('workspace.diff.completed', globalWorkspaceDiffCompletedHandler)
+    on('subagent.start', globalSubagentEventHandler)
+    on('subagent.tool', globalSubagentEventHandler)
+    on('subagent.progress', globalSubagentEventHandler)
+    on('subagent.text', globalSubagentEventHandler)
+    on('subagent.thinking', globalSubagentEventHandler)
+    on('subagent.complete', globalSubagentEventHandler)
+    on('delegation.updated', globalSubagentEventHandler)
 
     // Run lifecycle events
-    chatRunSocket.on('run.started', globalRunStartedHandler)
-    chatRunSocket.on('run.failed', globalRunFailedHandler)
-    chatRunSocket.on('run.completed', globalRunCompletedHandler)
-    chatRunSocket.on('run.queued', globalRunQueuedHandler)
-    chatRunSocket.on('run.queue_insertion.updated', globalQueueInsertionUpdatedHandler)
-    chatRunSocket.on('approval.requested', globalApprovalRequestedHandler)
-    chatRunSocket.on('approval.resolved', globalApprovalResolvedHandler)
-    chatRunSocket.on('run.peer_user_message', globalPeerUserMessageHandler)
-    chatRunSocket.on('clarify.requested', globalClarifyRequestedHandler)
-    chatRunSocket.on('clarify.resolved', globalClarifyResolvedHandler)
+    on('run.started', globalRunStartedHandler)
+    on('run.failed', globalRunFailedHandler)
+    on('run.completed', globalRunCompletedHandler)
+    on('run.queued', globalRunQueuedHandler)
+    on('run.queue_insertion.updated', globalQueueInsertionUpdatedHandler)
+    on('approval.requested', globalApprovalRequestedHandler)
+    on('approval.resolved', globalApprovalResolvedHandler)
+    on('run.peer_user_message', globalPeerUserMessageHandler)
+    on('clarify.requested', globalClarifyRequestedHandler)
+    on('clarify.resolved', globalClarifyResolvedHandler)
 
     // Compression events
-    chatRunSocket.on('compression.started', globalCompressionStartedHandler)
-    chatRunSocket.on('compression.completed', globalCompressionCompletedHandler)
-    chatRunSocket.on('abort.started', globalAbortStartedHandler)
-    chatRunSocket.on('abort.timeout', globalAbortTimeoutHandler)
-    chatRunSocket.on('abort.completed', globalAbortCompletedHandler)
+    on('compression.started', globalCompressionStartedHandler)
+    on('compression.completed', globalCompressionCompletedHandler)
+    on('abort.started', globalAbortStartedHandler)
+    on('abort.timeout', globalAbortTimeoutHandler)
+    on('abort.completed', globalAbortCompletedHandler)
 
-    // Usage events
-    chatRunSocket.on('usage.updated', globalUsageUpdatedHandler)
-    chatRunSocket.on('plan.updated', globalAgentEventHandler)
-    chatRunSocket.on('agent.event', globalAgentEventHandler)
-    chatRunSocket.on('run.reattach_failed', globalRunReattachFailedHandler)
-    chatRunSocket.on('session.command', globalSessionCommandHandler)
-    chatRunSocket.on('session.title.updated', globalSessionTitleUpdatedHandler)
-    chatRunSocket.on('session.workspace.updated', globalSessionWorkspaceUpdatedHandler)
-    chatRunSocket.on('session.settings.updated', globalSessionSettingsUpdatedHandler)
+    // Usage and task-plan events
+    on('usage.updated', globalUsageUpdatedHandler)
+    on('plan.updated', globalAgentEventHandler)
+    on('agent.event', globalAgentEventHandler)
+    on('run.reattach_failed', globalRunReattachFailedHandler)
+    on('session.command', globalSessionCommandHandler)
+    on('session.title.updated', globalSessionTitleUpdatedHandler)
+    on('session.workspace.updated', globalSessionWorkspaceUpdatedHandler)
+    on('session.settings.updated', globalSessionSettingsUpdatedHandler)
 
     globalListenersRegistered = true
   }
@@ -872,15 +883,19 @@ export function connectChatRun(requestedProfile?: string | null, transport: Chat
 }
 
 export function disconnectChatRun(): void {
+  disconnectBackgroundStatusObservers()
+  sessionEventHandlers.clear()
   if (chatRunSocket) {
+    chatRunSocket.removeAllListeners()
     chatRunSocket.disconnect()
     chatRunSocket = null
     chatRunSocketProfile = null
     chatRunSocketTransport = 'chat-run'
     globalListenersRegistered = false
-    sessionEventHandlers.clear()
   }
 }
+
+onAuthInvalidated(disconnectChatRun)
 
 function removeSocketListener(socket: Socket, event: string, handler: (...args: any[]) => void): void {
   const candidate = socket as Socket & {

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -2527,7 +2527,7 @@ async function handleSessionModelCustomSubmit() {
               :active="s.id === chatStore.activeSessionId"
               :pinned="sessionBrowserPrefsStore.isPinned(s.id)"
               :can-delete="s.id !== chatStore.activeSessionId || chatStore.sessions.length > 1"
-              :streaming="chatStore.isSessionLive(s.id)"
+              :streaming="chatStore.isSessionWorking(s.id)"
               :completed-unread="chatStore.isSessionCompletedUnread(s.id)"
               :selectable="isBatchMode"
               :selected="isSessionSelected(s)"
@@ -2574,7 +2574,7 @@ async function handleSessionModelCustomSubmit() {
               s.id !== chatStore.activeSessionId ||
               chatStore.sessions.length > 1
             "
-            :streaming="chatStore.isSessionLive(s.id)"
+            :streaming="chatStore.isSessionWorking(s.id)"
             :completed-unread="chatStore.isSessionCompletedUnread(s.id)"
             :selectable="isBatchMode"
             :selected="isSessionSelected(s)"
@@ -2641,7 +2641,7 @@ async function handleSessionModelCustomSubmit() {
                 s.id !== chatStore.activeSessionId ||
                 chatStore.sessions.length > 1
               "
-              :streaming="chatStore.isSessionLive(s.id)"
+              :streaming="chatStore.isSessionWorking(s.id)"
               :completed-unread="chatStore.isSessionCompletedUnread(s.id)"
               :selectable="isBatchMode"
               :selected="isSessionSelected(s)"

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -2,11 +2,13 @@ import { mergeTaskPlanMessages, type TaskPlanSnapshot } from '@/utils/task-plan'
 import { startRunViaSocket, resumeSession, registerSessionHandlers, unregisterSessionHandlers, getChatRunSocket, respondToolApproval, onPeerUserMessage, onSessionCommand, onSessionTitleUpdated, onSessionWorkspaceUpdated, onSessionSettingsUpdated, respondClarify, type ChatRunTransport, type RunEvent, type ResumeSessionPayload, type StartRunRequest, type ContentBlock as ContentBlockImport } from '@/api/studio/chat'
 import { archiveSession as archiveSessionApi, deleteSession as deleteSessionApi, fetchSessionMessagesPage, fetchSessions, fetchWorkspaceRunChangeFile, setSessionModel, setSessionPushEnabled as persistSessionPushEnabled, setSessionReasoningEffort as persistSessionReasoningEffort, type HermesMessage, type SessionSummary, type WorkspaceRunChangeFileDetail, type WorkspaceRunChangeSummary } from '@/api/studio/sessions'
 import { getActiveProfileName } from '@/api/client'
+import { onAuthInvalidated } from '@/api/auth-invalidation'
 import { inferCodingAgentApiMode, normalizeCodingAgentApiMode, type ChatCodingAgentId } from '@/api/coding-agents'
 import { getDownloadUrl } from '@/api/studio/download'
 import type { ProviderApiMode } from '@/api/studio/provider-api-mode'
 import { defineStore } from 'pinia'
-import { ref, computed } from 'vue'
+import { ref, computed, onScopeDispose } from 'vue'
+import { observeBackgroundStatus } from '@/api/studio/background-status'
 import { useAppStore } from './app'
 import { useProfilesStore } from './profiles'
 import { useSettingsStore } from './settings'
@@ -1307,6 +1309,57 @@ export const useChatStore = defineStore('chat', () => {
   const streamStates = ref<Map<string, { abort: () => void }>>(new Map())
   /** sessionId → server-reported isWorking status */
   const serverWorking = ref<Set<string>>(new Set())
+  /** Authoritative live delegation counts, never inferred from transcript history. */
+  const backgroundPendingBySession = ref<Map<string, number>>(new Map())
+  let runtimeGeneration = 0
+  const backgroundObservers = new Map<string, () => void>()
+
+  function clearBackgroundObservers() {
+    for (const dispose of backgroundObservers.values()) dispose()
+    backgroundObservers.clear()
+    backgroundPendingBySession.value.clear()
+  }
+
+  const unsubscribeAuthInvalidation = onAuthInvalidated(() => {
+    runtimeGeneration += 1
+    clearBackgroundObservers()
+    streamStates.value.clear()
+    serverWorking.value.clear()
+  })
+
+  onScopeDispose(() => {
+    unsubscribeAuthInvalidation()
+    runtimeGeneration += 1
+    clearBackgroundObservers()
+  })
+
+  function setBackgroundPending(sessionId: string, pending: unknown) {
+    const count = Number(pending)
+    if (Number.isFinite(count) && count > 0) {
+      const session = sessions.value.find(s => s.id === sessionId)
+      if (!session) return
+      backgroundPendingBySession.value.set(sessionId, count)
+      if (!backgroundObservers.has(sessionId)) {
+        const generation = runtimeGeneration
+        backgroundObservers.set(sessionId, observeBackgroundStatus(
+          sessionId, session.profile || 'default', runtimeTransport(),
+          pending => {
+            if (generation === runtimeGeneration) setBackgroundPending(sessionId, pending)
+          },
+        ))
+      }
+    } else {
+      backgroundPendingBySession.value.delete(sessionId)
+      backgroundObservers.get(sessionId)?.()
+      backgroundObservers.delete(sessionId)
+    }
+  }
+
+  function applyBackgroundPendingEvent(sessionId: string, evt: RunEvent) {
+    if (evt.background_pending != null || evt.event === 'run.completed' || evt.event === 'run.failed' || evt.event === 'abort.completed') {
+      setBackgroundPending(sessionId, evt.background_pending)
+    }
+  }
   /** sessionIds with a terminal /fork command submitted but not settled yet */
   const pendingForkCommands = ref<Set<string>>(new Set())
   /** Sessions that completed while the user was viewing another session. */
@@ -1345,7 +1398,8 @@ export const useChatStore = defineStore('chat', () => {
    * has to forget it — otherwise the next run in the same session inherits the
    * previous run's start and reports a far larger elapsed time.
    */
-  function applyResumedRunStartedAt(sessionId: string, data: { isWorking?: boolean; runStartedAt?: number }) {
+  function applyResumedRunActivity(sessionId: string, data: { isWorking?: boolean; runStartedAt?: number; backgroundPending?: number }) {
+    setBackgroundPending(sessionId, data.backgroundPending)
     const startedAt = Number(data?.runStartedAt) || 0
     if (data?.isWorking && startedAt > 0) setRunStartedAt(sessionId, startedAt)
     else clearRunStartedAt(sessionId)
@@ -1462,6 +1516,8 @@ export const useChatStore = defineStore('chat', () => {
     if (runtimeMode.value === mode) return
     activeRuntimeMode = mode
     runtimeMode.value = mode
+    runtimeGeneration += 1
+    clearBackgroundObservers()
     sessions.value = []
     completedUnreadSessions.value = new Set()
     queueLengths.value = new Map()
@@ -1523,6 +1579,11 @@ export const useChatStore = defineStore('chat', () => {
 
   function isSessionLive(sessionId: string): boolean {
     return streamStates.value.has(sessionId) || serverWorking.value.has(sessionId)
+  }
+
+  // Display activity is broader than foreground execution (send/queue/voice).
+  function isSessionWorking(sessionId: string): boolean {
+    return isSessionLive(sessionId) || (backgroundPendingBySession.value.get(sessionId) || 0) > 0
   }
 
   function isSessionCompletedUnread(sessionId: string): boolean {
@@ -1938,6 +1999,7 @@ export const useChatStore = defineStore('chat', () => {
   }
 
   async function switchSession(sessionId: string, focusId?: string | null) {
+    const generation = runtimeGeneration
     activeSelectionSequence++
     const requestSequence = ++switchSessionRequestSequence
     clearThinkingObservationFor(sessionId)
@@ -1962,6 +2024,7 @@ export const useChatStore = defineStore('chat', () => {
           clearTimeout(timeout)
           if (
             data.session_id !== sessionId
+            || generation !== runtimeGeneration
             || activeSessionId.value !== sessionId
             || requestSequence !== switchSessionRequestSequence
           ) {
@@ -1990,7 +2053,7 @@ export const useChatStore = defineStore('chat', () => {
             replaceQueuedUserMessages(sessionId, [])
           }
           replaceQueueInsertionState(sessionId, data.queueInsertion)
-          applyResumedRunStartedAt(sessionId, data as any)
+          applyResumedRunActivity(sessionId, data as any)
           if ((data as any).isAborting) {
             setAbortState(sessionId, { aborting: true, synced: null })
           } else if (!data.isWorking) {
@@ -2115,7 +2178,7 @@ export const useChatStore = defineStore('chat', () => {
     }
 
     // Resume in-flight run event listeners if needed
-    if (activeSessionId.value === sessionId && requestSequence === switchSessionRequestSequence) {
+    if (generation === runtimeGeneration && activeSessionId.value === sessionId && requestSequence === switchSessionRequestSequence) {
       resumeServerWorkingRun(sessionId, backgroundPendingOnResume > 0, !serverWorking.value.has(sessionId))
     }
   }
@@ -2232,6 +2295,7 @@ export const useChatStore = defineStore('chat', () => {
     const target = sessions.value.find(s => s.id === sessionId)
     const ok = await deleteSessionApi(sessionId, target?.profile)
     if (!ok) return false
+    setBackgroundPending(sessionId, 0)
     sessions.value = sessions.value.filter(s => s.id !== sessionId)
     clearMessageReference(sessionId)
     setAbortState(sessionId, null)
@@ -2250,6 +2314,7 @@ export const useChatStore = defineStore('chat', () => {
     const target = sessions.value.find(s => s.id === sessionId)
     const ok = await archiveSessionApi(sessionId)
     if (!ok) return false
+    setBackgroundPending(sessionId, 0)
     sessions.value = sessions.value.filter(s => s.id !== sessionId)
     clearMessageReference(sessionId)
     setAbortState(sessionId, null)
@@ -3473,6 +3538,7 @@ export const useChatStore = defineStore('chat', () => {
   }
 
   async function sendMessage(content: string, attachments?: Attachment[]) {
+    const generation = runtimeGeneration
     if ((!content.trim() && !(attachments && attachments.length > 0))) return
 
     primeNotificationSoundIfEnabled()
@@ -3551,6 +3617,7 @@ export const useChatStore = defineStore('chat', () => {
       if (attachments && attachments.length > 0) {
         // Has attachments: upload first, then build content blocks
         const uploaded = await uploadFiles(attachments)
+        if (generation !== runtimeGeneration) return
 
         // Update attachment URLs on the user message for display
         const urlMap = new Map(uploaded.map(f => {
@@ -3575,8 +3642,10 @@ export const useChatStore = defineStore('chat', () => {
 
         // Build content blocks with uploaded file paths
         input = await buildContentBlocks(submittedContent, attachments, uploaded)
+        if (generation !== runtimeGeneration) return
         if (attachments.some(attachment => attachment.context?.trim())) {
           displayInput = await buildContentBlocks(submittedContent, attachments, uploaded, false)
+          if (generation !== runtimeGeneration) return
         }
       } else {
         // No attachments: use plain text format
@@ -3585,6 +3654,7 @@ export const useChatStore = defineStore('chat', () => {
 
       const appStore = useAppStore()
       await appStore.waitForModelsForRun()
+      if (generation !== runtimeGeneration) return
       const sessionModel = activeSession.value?.model || appStore.selectedModel
       const sessionProvider = activeSession.value?.provider || appStore.selectedProvider
       const sessionProfile = activeSession.value?.profile || useProfilesStore().activeProfileName || undefined
@@ -3695,13 +3765,13 @@ export const useChatStore = defineStore('chat', () => {
       }
 
       const applyReconnectResume = (data: ResumeSessionPayload) => {
-        if (data.session_id !== sid) return
+        if (generation !== runtimeGeneration || data.session_id !== sid) return
         const target = sessions.value.find(s => s.id === sid)
         if (!target) return
 
         if (data.isWorking) serverWorking.value.add(sid)
         else serverWorking.value.delete(sid)
-        applyResumedRunStartedAt(sid, data as any)
+        applyResumedRunActivity(sid, data as any)
 
         if (data.queueLength && data.queueLength > 0) {
           queueLengths.value.set(sid, data.queueLength)
@@ -3846,6 +3916,8 @@ export const useChatStore = defineStore('chat', () => {
         runPayload,
         // onEvent
         (evt: RunEvent) => {
+          if (generation !== runtimeGeneration || (evt.session_id && evt.session_id !== sid)) return
+          applyBackgroundPendingEvent(sid, evt)
           const eventRunMarker = readRunMarker(evt)
           if (eventRunMarker) activeRunMarker = eventRunMarker
           switch (evt.event) {
@@ -4415,6 +4487,7 @@ export const useChatStore = defineStore('chat', () => {
         streamStates.value.set(sid, ctrl)
       }
     } catch (err: any) {
+      if (generation !== runtimeGeneration) return
       if (isBridgeForkCommand) {
         const nextPendingForkCommands = new Set(pendingForkCommands.value)
         nextPendingForkCommands.delete(sid)
@@ -4441,6 +4514,7 @@ export const useChatStore = defineStore('chat', () => {
    * then sets up event listeners to receive ongoing events.
    */
   function resumeServerWorkingRun(sid: string, force = false, passive = false) {
+    const generation = runtimeGeneration
     // Don't register duplicate listeners if already streaming
     if (streamStates.value.has(sid)) return
     // Only set up listeners if the server reported an active run during resume.
@@ -4511,9 +4585,10 @@ export const useChatStore = defineStore('chat', () => {
 
     // Shared event handler — filters by session_id tag
     function handleEvent(evt: RunEvent) {
-      if (closed) return
+      if (closed || generation !== runtimeGeneration) return
       // Filter events for this session (server tags all events with session_id)
       if (evt.session_id && evt.session_id !== sid) return
+      applyBackgroundPendingEvent(sid, evt)
       const eventRunMarker = readRunMarker(evt)
       if (eventRunMarker) activeRunMarker = eventRunMarker
       switch (evt.event) {
@@ -5197,13 +5272,15 @@ export const useChatStore = defineStore('chat', () => {
         const sid = activeSessionId.value
         if (sid && !streamStates.value.has(sid)) {
           // Re-load messages via resume (server loads from DB)
+          const generation = runtimeGeneration
           resumeSession(sid, (data) => {
+            if (generation !== runtimeGeneration || data.session_id !== sid || activeSessionId.value !== sid) return
             if (data.isWorking) {
               serverWorking.value.add(sid)
             } else {
               serverWorking.value.delete(sid)
             }
-            applyResumedRunStartedAt(sid, data as any)
+            applyResumedRunActivity(sid, data as any)
             if (data.isAborting) {
               setAbortState(sid, { aborting: true, synced: null })
             } else if (!data.isWorking) {
@@ -5224,7 +5301,7 @@ export const useChatStore = defineStore('chat', () => {
               activeSession.value.messageCount = activeSession.value.messageTotal
               activeSession.value.hasMoreBefore = data.hasMoreBefore ?? activeSession.value.loadedMessageCount < activeSession.value.messageTotal
             }
-            resumeServerWorkingRun(sid)
+            resumeServerWorkingRun(sid, (data.backgroundPending || 0) > 0, !data.isWorking)
           }, activeSession.value?.profile, runtimeTransport())
         }
       }
@@ -5398,6 +5475,7 @@ export const useChatStore = defineStore('chat', () => {
     isForkPending,
     isRunActive,
     isSessionLive,
+    isSessionWorking,
     runStartedAt,
     isSessionCompletedUnread,
     clearSessionCompletedUnread,

--- a/tests/client/chat-store-compression-state.test.ts
+++ b/tests/client/chat-store-compression-state.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createPinia, setActivePinia } from 'pinia'
+vi.mock('@/api/studio/background-status', () => ({ observeBackgroundStatus: vi.fn(() => vi.fn()) }))
 import { nextTick } from 'vue'
 
 const chatApi = vi.hoisted(() => ({

--- a/tests/client/chat-store-working-state.test.ts
+++ b/tests/client/chat-store-working-state.test.ts
@@ -1,0 +1,157 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+vi.mock('@/api/studio/background-status', () => ({ observeBackgroundStatus: vi.fn(() => vi.fn()) }))
+
+const api = vi.hoisted(() => ({
+  startRunViaSocket: vi.fn(), resumeSession: vi.fn(), registerSessionHandlers: vi.fn(),
+}))
+vi.mock('@/api/studio/chat', () => ({
+  ...api,
+  unregisterSessionHandlers: vi.fn(),
+  getChatRunSocket: vi.fn(() => ({ emit: vi.fn() })),
+  respondToolApproval: vi.fn(), respondClarify: vi.fn(),
+  onPeerUserMessage: vi.fn(), onSessionCommand: vi.fn(),
+  onSessionTitleUpdated: vi.fn(), onSessionWorkspaceUpdated: vi.fn(), onSessionSettingsUpdated: vi.fn(),
+}))
+vi.mock('@/api/client', () => ({ getActiveProfileName: () => 'default', hasApiKey: () => false }))
+vi.mock('@/api/studio/sessions', () => ({
+  archiveSession: vi.fn(), deleteSession: vi.fn(), fetchSession: vi.fn(), fetchSessions: vi.fn(async () => []),
+  fetchWorkspaceRunChangesForSession: vi.fn(async () => []), fetchWorkspaceRunChangeFile: vi.fn(), setSessionModel: vi.fn(),
+}))
+vi.mock('@/api/hermes/system', () => ({
+  checkHealth: vi.fn(), fetchAvailableModels: vi.fn(), addCustomModel: vi.fn(), removeCustomModel: vi.fn(),
+  updateDefaultModel: vi.fn(), updateModelVisibility: vi.fn(), triggerUpdate: vi.fn(), updateModelAlias: vi.fn(),
+}))
+vi.mock('@/utils/completion-sound', () => ({ primeCompletionSound: vi.fn(), playCompletionSound: vi.fn() }))
+import { useChatStore, type Session } from '@/stores/hermes/chat'
+
+function session(id: string, profile = 'default'): Session {
+  return { id, profile, title: id, messages: [], createdAt: Date.now(), updatedAt: Date.now() }
+}
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  setActivePinia(createPinia())
+  api.startRunViaSocket.mockReturnValue({ abort: vi.fn() })
+  api.resumeSession.mockImplementation((sid, callback) => {
+    callback({ session_id: sid, isWorking: false, messages: [], events: [], backgroundPending: 0 })
+  })
+})
+
+describe('sidebar working state', () => {
+  it('reattaches passive background listeners when a visible tab resumes idle foreground work', async () => {
+    const listen = vi.spyOn(document, 'addEventListener')
+    Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'visible' })
+    const store = useChatStore()
+    const onVisible = listen.mock.calls.find(call => call[0] === 'visibilitychange')![1] as () => void
+    listen.mockRestore()
+    store.sessions = [session('one')]
+    await store.switchSession('one')
+    api.resumeSession.mockImplementationOnce((sid, callback) => {
+      callback({ session_id: sid, isWorking: false, messages: [], events: [], backgroundPending: 1 })
+    })
+    onVisible()
+    expect(store.isSessionWorking('one')).toBe(true)
+    expect(store.isSessionLive('one')).toBe(false)
+    expect(api.registerSessionHandlers).toHaveBeenCalledTimes(1)
+    const handlers = api.registerSessionHandlers.mock.calls[0][1]
+    handlers.onSubagentEvent({ event: 'delegation.updated', session_id: 'one', background_pending: 0, status: 'cancelled' })
+    expect(store.isSessionWorking('one')).toBe(false)
+  })
+
+  it('clears delegated activity on runtime changes', async () => {
+    const store = useChatStore()
+    store.sessions = [session('one')]
+    await store.switchSession('one')
+    await store.sendMessage('delegate')
+    const onEvent = api.startRunViaSocket.mock.calls[0][1]
+    onEvent({ event: 'run.completed', session_id: 'one', output: 'Started', background_pending: 1 })
+    expect(store.isSessionWorking('one')).toBe(true)
+    store.setRuntimeMode('global_agent')
+    expect(store.isSessionWorking('one')).toBe(false)
+    onEvent({ event: 'delegation.updated', session_id: 'one', status: 'running', background_pending: 1 })
+    expect(store.isSessionWorking('one')).toBe(false)
+  })
+
+  it.each(['completed', 'failed', 'cancelled', 'interrupted'])('keeps work until every delegation is terminal (%s)', async (status) => {
+    const store = useChatStore()
+    store.sessions = [session('one'), session('two', 'research')]
+    await store.switchSession('one')
+    await store.sendMessage('delegate')
+    const onEvent = api.startRunViaSocket.mock.calls[0][1]
+    expect(store.isSessionWorking('one')).toBe(true)
+    onEvent({ event: 'run.completed', session_id: 'one', output: 'Started', background_pending: 2 })
+    expect(store.isStreaming).toBe(false)
+    expect(store.isSessionLive('one')).toBe(false)
+    expect(store.isSessionWorking('one')).toBe(true)
+    await store.switchSession('two')
+    onEvent({ event: 'delegation.updated', session_id: 'two', background_pending: 0, status })
+    expect(store.isSessionWorking('one')).toBe(true)
+    expect(store.isSessionWorking('two')).toBe(false)
+    onEvent({ event: 'delegation.updated', session_id: 'one', background_pending: 1, status })
+    expect(store.isSessionWorking('one')).toBe(true)
+    onEvent({ event: 'delegation.updated', session_id: 'one', background_pending: 0, status })
+    expect(store.isSessionWorking('one')).toBe(false)
+  })
+
+  it('reconciles reconnect snapshots and does not resurrect activity from historical tasks', async () => {
+    const store = useChatStore()
+    store.sessions = [session('one')]
+    await store.switchSession('one')
+    await store.sendMessage('delegate')
+    const reconnect = api.startRunViaSocket.mock.calls[0][5].onReconnectResume
+    reconnect({ session_id: 'one', isWorking: false, backgroundPending: 1, messages: [], events: [] })
+    expect(store.isSessionWorking('one')).toBe(true)
+    expect(store.isStreaming).toBe(false)
+    reconnect({ session_id: 'one', isWorking: false, backgroundPending: 0, messages: [], events: [
+      { event: 'delegation.updated', data: { event: 'delegation.updated', background_pending: 5, status: 'running' } },
+      { event: 'subagent.start', data: { event: 'subagent.start', subagent_id: 'historical', background_pending: 5 } },
+    ] })
+    expect(store.isSessionWorking('one')).toBe(false)
+  })
+
+  it('handles passive listeners and replaces stale activity when returning to a session', async () => {
+    api.resumeSession.mockImplementationOnce((sid, callback) => {
+      callback({ session_id: sid, isWorking: false, messages: [], events: [], backgroundPending: 2 })
+    })
+    const store = useChatStore()
+    store.sessions = [session('one'), session('two', 'research')]
+    await store.switchSession('one')
+    const handlers = api.registerSessionHandlers.mock.calls[0][1]
+    await store.switchSession('two')
+    handlers.onSubagentEvent({ event: 'delegation.updated', session_id: 'one', background_pending: 1, status: 'completed' })
+    expect(store.isSessionWorking('one')).toBe(true)
+    expect(store.isSessionWorking('two')).toBe(false)
+    await store.switchSession('one')
+    expect(store.isSessionWorking('one')).toBe(false)
+  })
+
+  it('does not stop foreground work when the background count reaches zero', async () => {
+    const store = useChatStore()
+    store.sessions = [session('one')]
+    await store.switchSession('one')
+    await store.sendMessage('delegate')
+    const onEvent = api.startRunViaSocket.mock.calls[0][1]
+    onEvent({ event: 'delegation.updated', session_id: 'one', background_pending: 0, status: 'completed' })
+    expect(store.isSessionWorking('one')).toBe(true)
+    onEvent({ event: 'run.failed', session_id: 'one', error: 'failed', background_pending: 1 })
+    expect(store.isSessionLive('one')).toBe(false)
+    expect(store.isSessionWorking('one')).toBe(true)
+    onEvent({ event: 'run.failed', session_id: 'one', error: 'failed', background_pending: 0 })
+    expect(store.isSessionWorking('one')).toBe(false)
+  })
+
+  it('restores background-only work from authoritative resume without making the composer busy', async () => {
+    api.resumeSession.mockImplementationOnce((sid, callback) => {
+      callback({ session_id: sid, isWorking: false, messages: [], events: [], backgroundPending: 2 })
+    })
+    const store = useChatStore()
+    store.sessions = [session('one')]
+    await store.switchSession('one')
+    expect(store.isSessionWorking('one')).toBe(true)
+    expect(store.isSessionLive('one')).toBe(false)
+    expect(store.isStreaming).toBe(false)
+    expect(store.isRunActive).toBe(false)
+  })
+})

--- a/tests/client/chat-store-working-transport.test.ts
+++ b/tests/client/chat-store-working-transport.test.ts
@@ -1,0 +1,381 @@
+// @vitest-environment jsdom
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
+
+const socketState = vi.hoisted(() => ({
+  sockets: [] as any[],
+  pending: new Map<string, number>(),
+}))
+
+vi.mock('socket.io-client', () => {
+  function createSocket(url: string, options: any) {
+    const rooms = new Set<string>()
+    const listeners = new Map<string, Set<(...args: any[]) => void>>()
+
+    const addListener = (event: string, handler: (...args: any[]) => void) => {
+      if (!listeners.has(event)) listeners.set(event, new Set())
+      listeners.get(event)!.add(handler)
+    }
+
+    const removeListener = (event: string, handler: (...args: any[]) => void) => {
+      const eventListeners = listeners.get(event)
+      if (!eventListeners) return
+      for (const candidate of [...eventListeners]) {
+        if (candidate === handler || (candidate as any).__original === handler) {
+          eventListeners.delete(candidate)
+        }
+      }
+    }
+
+    const socket: any = {
+      connected: true, url, profile: options.query.profile, token: options.auth.token,
+      on: vi.fn((event: string, handler: (...args: any[]) => void) => {
+        addListener(event, handler)
+        return socket
+      }),
+      once: vi.fn((event: string, handler: (...args: any[]) => void) => {
+        const wrapped = (...args: any[]) => {
+          removeListener(event, wrapped)
+          handler(...args)
+        }
+        ;(wrapped as any).__original = handler
+        addListener(event, wrapped)
+        return socket
+      }),
+      off: vi.fn((event: string, handler: (...args: any[]) => void) => {
+        removeListener(event, handler)
+        return socket
+      }),
+      removeListener: vi.fn((event: string, handler: (...args: any[]) => void) => {
+        removeListener(event, handler)
+        return socket
+      }),
+      removeAllListeners: vi.fn(() => {
+        listeners.clear()
+        return socket
+      }),
+      emit: vi.fn((event: string, data: any) => {
+        if (event === 'run') rooms.add(data.session_id)
+        if (event === 'resume') {
+          if (options.query.profile !== (data.session_id === 'two' ? 'research' : 'default')) return
+          rooms.add(data.session_id)
+          queueMicrotask(() => socket.__trigger('resumed', {
+            session_id: data.session_id, messages: [], events: [], isWorking: false,
+            ...(socketState.pending.has(data.session_id) ? { backgroundPending: socketState.pending.get(data.session_id) } : {}),
+          }))
+        }
+      }),
+      disconnect: vi.fn(() => {
+        socket.connected = false
+      }),
+      __listenerCount: (event: string) => listeners.get(event)?.size || 0,
+      __trigger: (event: string, ...args: any[]) => {
+        if (event === 'connect') socket.connected = true
+        if (event === 'disconnect') { socket.connected = false; rooms.clear() }
+        if (!['connect', 'disconnect', 'connect_error'].includes(event) &&
+            (!socket.connected || !rooms.has(args[0]?.session_id))) return
+        for (const handler of [...(listeners.get(event) || [])]) handler(...args)
+      },
+    }
+
+    return socket
+  }
+
+  return {
+    io: vi.fn((url: string, options: any) => {
+      const socket = createSocket(url, options)
+      socketState.sockets.push(socket)
+      return socket
+    }),
+  }
+})
+
+vi.mock('@/router', () => ({
+  default: { currentRoute: { value: { name: 'chat' } }, replace: vi.fn() },
+}))
+import { clearApiKey, getApiKey, request, setApiKey, setServerUrl } from '@/api/client'
+
+vi.mock('@/api/studio/sessions', () => ({
+  archiveSession: vi.fn(), deleteSession: vi.fn(), fetchSession: vi.fn(), fetchSessions: vi.fn(async () => []),
+  fetchWorkspaceRunChangesForSession: vi.fn(async () => []), fetchWorkspaceRunChangeFile: vi.fn(), setSessionModel: vi.fn(),
+}))
+vi.mock('@/api/hermes/system', () => ({
+  checkHealth: vi.fn(), fetchAvailableModels: vi.fn(), addCustomModel: vi.fn(), removeCustomModel: vi.fn(),
+  updateDefaultModel: vi.fn(), updateModelVisibility: vi.fn(), triggerUpdate: vi.fn(), updateModelAlias: vi.fn(),
+}))
+vi.mock('@/utils/completion-sound', () => ({ primeCompletionSound: vi.fn(), playCompletionSound: vi.fn() }))
+import { useChatStore, type Session } from '@/stores/hermes/chat'
+
+function session(id: string, profile = 'default'): Session {
+  return { id, profile, title: id, messages: [], createdAt: Date.now(), updatedAt: Date.now() }
+}
+
+let store: ReturnType<typeof useChatStore>
+beforeEach(async () => {
+  const { disconnectChatRun } = await import('@/api/studio/chat')
+  disconnectChatRun()
+  localStorage.clear()
+  setApiKey('test-token')
+  localStorage.setItem('hermes_active_profile_name', 'default')
+  socketState.sockets = []
+  socketState.pending.clear()
+  setActivePinia(createPinia())
+  store = useChatStore()
+  store.setRuntimeMode('default')
+  store.sessions = [session('one'), session('two', 'research')]
+})
+afterEach(async () => {
+  vi.unstubAllGlobals()
+  store.$dispose()
+  const { disconnectChatRun } = await import('@/api/studio/chat')
+  disconnectChatRun()
+})
+
+describe('sidebar activity through the real chat API', () => {
+  it.each(['clear', 'replace', 'server'])('does not submit a prepared send after %s invalidation', async (action) => {
+    await store.switchSession('one')
+    const { useAppStore } = await import('@/stores/hermes/app')
+    let release!: () => void
+    vi.spyOn(useAppStore(), 'waitForModelsForRun').mockImplementationOnce(() => new Promise<void>(resolve => { release = resolve }))
+    const sending = store.sendMessage('old-auth draft')
+    if (action === 'clear') clearApiKey()
+    else if (action === 'replace') setApiKey('replacement-token')
+    else setServerUrl('https://replacement.example')
+    setApiKey('new-login-token')
+    const socketCount = socketState.sockets.length
+    release()
+    await sending
+    expect(socketState.sockets).toHaveLength(socketCount)
+    expect(socketState.sockets.flatMap(socket => socket.emit.mock.calls).filter(call => call[0] === 'run')).toHaveLength(0)
+    expect(store.isSessionWorking('one')).toBe(false)
+    await store.sendMessage('fresh draft')
+    const fresh = socketState.sockets.at(-1)
+    expect(fresh.token).toBe('new-login-token')
+    expect(fresh.emit).toHaveBeenCalledWith('run', expect.objectContaining({ input: 'fresh draft' }))
+  })
+
+  it('ignores a stale preparation rejection instead of mutating the new login state', async () => {
+    await store.switchSession('one')
+    const { useAppStore } = await import('@/stores/hermes/app')
+    let rejectPreparation!: (error: Error) => void
+    vi.spyOn(useAppStore(), 'waitForModelsForRun').mockImplementationOnce(() => new Promise<void>((_, reject) => { rejectPreparation = reject }))
+    const sending = store.sendMessage('old-auth draft')
+    clearApiKey()
+    setApiKey('new-login-token')
+    await store.sendMessage('fresh draft')
+    const messageCount = store.sessions[0].messages.length
+    expect(store.isSessionLive('one')).toBe(true)
+    rejectPreparation(new Error('old preparation failed'))
+    await sending
+    expect(store.sessions[0].messages).toHaveLength(messageCount)
+    expect(store.isSessionLive('one')).toBe(true)
+  })
+
+  it('ignores attachment upload results arriving after credential invalidation', async () => {
+    await store.switchSession('one')
+    let finishUpload!: (response: Response) => void
+    vi.stubGlobal('fetch', vi.fn(() => new Promise<Response>(resolve => { finishUpload = resolve })))
+    const sending = store.sendMessage('old attachment', [{ name: 'note.txt', type: 'text/plain', file: new File(['private'], 'note.txt') } as any])
+    clearApiKey()
+    setApiKey('new-login-token')
+    const socketCount = socketState.sockets.length
+    finishUpload(new Response(JSON.stringify({ files: [{ name: 'note.txt', path: '/uploads/old-note.txt' }] }), { status: 200 }))
+    await sending
+    expect(socketState.sockets).toHaveLength(socketCount)
+    expect(store.sessions[0].messages.at(-1)?.attachments?.[0].url).toBeUndefined()
+    expect(store.isSessionWorking('one')).toBe(false)
+  })
+
+  it.each(['clear', '401', 'disabled403', 'replace', 'server'])('invalidates authenticated activity through %s and resumes only with fresh credentials', async (action) => {
+    socketState.pending.set('one', 1)
+    await store.switchSession('one')
+    const execution = socketState.sockets[0]
+    const observer = socketState.sockets[1]
+    const oldObserverResume = observer.on.mock.calls.find((call: any[]) => call[0] === 'resumed')[1]
+    await store.sendMessage('delegate')
+    const oldForegroundCompletion = execution.on.mock.calls.filter((call: any[]) => call[0] === 'run.completed').map((call: any[]) => call[1])
+    // Hold an initial switch resume while credentials are invalidated.
+    const originalEmit = execution.emit.getMockImplementation()
+    execution.emit.mockImplementation((event: string, data: any) => event === 'resume' ? undefined : originalEmit(event, data))
+    const switching = store.switchSession('one')
+    const oldInitialResume = execution.on.mock.calls.filter((call: any[]) => call[0] === 'resumed').at(-1)[1]
+
+    if (action === 'clear') clearApiKey() // Desktop LoginView recovery uses this exact path.
+    else if (action === 'replace') setApiKey('replacement-token')
+    else if (action === 'server') setServerUrl('https://replacement.example')
+    else {
+      const status = action === '401' ? 401 : 403
+      vi.stubGlobal('fetch', vi.fn(async () => new Response('User is disabled or does not exist', { status })))
+      await expect(request('/api/studio/sessions')).rejects.toThrow()
+      expect(getApiKey()).toBe('')
+      expect(localStorage.getItem('hermes_active_profile_name')).toBeNull()
+    }
+    expect(observer.connected).toBe(false)
+    expect(execution.connected).toBe(false)
+    expect(observer.__listenerCount('resumed')).toBe(0)
+    expect(store.isSessionWorking('one')).toBe(false)
+    const socketCount = socketState.sockets.length
+    const replay = () => {
+      oldObserverResume({ session_id: 'one', backgroundPending: 10 })
+      for (const callback of oldForegroundCompletion) callback({ event: 'run.completed', session_id: 'one', background_pending: 10 })
+      oldInitialResume({ session_id: 'one', messages: [], events: [], isWorking: true, backgroundPending: 10 })
+    }
+    replay()
+    await switching
+    expect(store.isSessionWorking('one')).toBe(false)
+    expect(socketState.sockets).toHaveLength(socketCount)
+
+    setApiKey('new-login-token')
+    await store.switchSession('one')
+    expect(store.isSessionWorking('one')).toBe(true)
+    expect(socketState.sockets.filter(socket => socket.connected).every(socket => socket.token === 'new-login-token')).toBe(true)
+    replay()
+    expect(socketState.sockets.filter(socket => socket.connected)).toHaveLength(2)
+    for (const socket of socketState.sockets) socket.__trigger('delegation.updated', {
+      event: 'delegation.updated', session_id: 'one', background_pending: 0,
+    })
+    expect(store.isSessionWorking('one')).toBe(false)
+    await store.sendMessage('fresh authenticated run')
+    const freshExecution = socketState.sockets[socketCount]
+    expect(freshExecution.token).toBe('new-login-token')
+    expect(freshExecution.emit).toHaveBeenCalledWith('run', expect.objectContaining({ session_id: 'one' }))
+    freshExecution.__trigger('run.completed', { event: 'run.completed', session_id: 'one', background_pending: 1 })
+    expect(store.isSessionWorking('one')).toBe(true)
+    freshExecution.__trigger('delegation.updated', { event: 'delegation.updated', session_id: 'one', background_pending: 0 })
+    expect(store.isSessionWorking('one')).toBe(false)
+    const settledSocketCount = socketState.sockets.length
+    replay()
+    expect(store.isSessionWorking('one')).toBe(false)
+    expect(socketState.sockets).toHaveLength(settledSocketCount)
+  })
+
+  it.each(['same-key', 'same-server', 'gateway401', 'forbidden403'])('preserves authenticated activity for %s', async (action) => {
+    socketState.pending.set('one', 1)
+    await store.switchSession('one')
+    const observer = socketState.sockets[1]
+    if (action === 'same-key') setApiKey('test-token')
+    else if (action === 'same-server') setServerUrl('')
+    else {
+      vi.stubGlobal('fetch', vi.fn(async () => new Response('Forbidden', { status: action === 'gateway401' ? 401 : 403 })))
+      await expect(request(action === 'gateway401' ? '/api/hermes/v1/models' : '/api/studio/sessions')).rejects.toThrow()
+    }
+    expect(getApiKey()).toBe('test-token')
+    expect(observer.connected).toBe(true)
+    expect(store.isSessionWorking('one')).toBe(true)
+    expect(socketState.sockets).toHaveLength(2)
+  })
+
+  it.each([0, undefined])('clears cached activity from a fresh resume snapshot (%s)', async (pending) => {
+    socketState.pending.set('one', 1)
+    await store.switchSession('one')
+    await store.switchSession('two')
+    if (pending === undefined) socketState.pending.delete('one')
+    else socketState.pending.set('one', pending)
+    await store.switchSession('one')
+    expect(store.isSessionWorking('one')).toBe(false)
+    expect(socketState.sockets[1].connected).toBe(false)
+  })
+
+  it('rejoins a still-pending observer room and receives subsequent completion', async () => {
+    socketState.pending.set('one', 1)
+    store.setRuntimeMode('global_agent')
+    store.sessions = [session('one')]
+    await store.switchSession('one')
+    const observer = socketState.sockets[1]
+    expect(observer.url).toBe('/global-agent')
+    observer.__trigger('disconnect', 'ping timeout')
+    observer.__trigger('connect')
+    await Promise.resolve()
+    expect(store.isSessionWorking('one')).toBe(true)
+    observer.__trigger('delegation.updated', {
+      event: 'delegation.updated', session_id: 'one', background_pending: 0,
+    })
+    expect(store.isSessionWorking('one')).toBe(false)
+    expect(observer.connected).toBe(false)
+  })
+
+  it('closes authenticated observers when chat disconnects for logout', async () => {
+    socketState.pending.set('one', 1)
+    await store.switchSession('one')
+    const { disconnectChatRun } = await import('@/api/studio/chat')
+    disconnectChatRun()
+    expect(socketState.sockets.every(socket => !socket.connected)).toBe(true)
+    expect(socketState.sockets.every(socket => socket.__listenerCount('resumed') === 0)).toBe(true)
+  })
+
+  it.each(['dispose', 'runtime', 'delete', 'archive'])('disposes background observers on %s and ignores retained callbacks', async (action) => {
+    socketState.pending.set('one', 1)
+    await store.switchSession('one')
+    const observer = socketState.sockets[1]
+    expect(observer.profile).toBe('default')
+    expect(observer.url).toBe('/chat-run')
+    const retained = observer.on.mock.calls.find((call: any[]) => call[0] === 'resumed')[1]
+    if (action === 'dispose') store.$dispose()
+    if (action === 'runtime') store.setRuntimeMode('global_agent')
+    if (action === 'delete' || action === 'archive') {
+      const api = await import('@/api/studio/sessions')
+      vi.mocked(action === 'delete' ? api.deleteSession : api.archiveSession).mockResolvedValueOnce(true)
+      await (action === 'delete' ? store.deleteSession('one') : store.archiveSession('one'))
+    }
+    expect(observer.connected).toBe(false)
+    for (const event of ['connect', 'resumed', 'delegation.updated', 'abort.completed']) {
+      expect(observer.__listenerCount(event)).toBe(0)
+    }
+    retained({ session_id: 'one', backgroundPending: 10 })
+    expect(store.isSessionWorking('one')).toBe(false)
+  })
+
+  it.each(['direct', 'passive'])('receives %s completion after the execution socket changes profile', async (mode) => {
+    socketState.pending.set('one', 1)
+    if (mode === 'direct') socketState.pending.set('one', 0)
+    await store.switchSession('one')
+    const executionSocket = socketState.sockets[0]
+    if (mode === 'direct') {
+      await store.sendMessage('delegate')
+      socketState.pending.set('one', 1)
+      executionSocket.__trigger('run.completed', {
+        event: 'run.completed', session_id: 'one', background_pending: 1,
+      })
+      await Promise.resolve()
+    }
+    await store.switchSession('two')
+    expect(executionSocket.connected).toBe(false)
+    expect(store.isSessionWorking('one')).toBe(true)
+    // Broadcast only reaches connected sockets which joined this session room.
+    for (const socket of socketState.sockets) socket.__trigger('delegation.updated', {
+      event: 'delegation.updated', session_id: 'one', background_pending: 0,
+    })
+    expect(store.isSessionWorking('one')).toBe(false)
+    expect(store.isSessionWorking('two')).toBe(false)
+  })
+
+  it('reconciles passive background activity after rooms are lost on reconnect', async () => {
+    socketState.pending.set('one', 1)
+    await store.switchSession('one')
+    expect(store.isSessionWorking('one')).toBe(true)
+    for (const socket of socketState.sockets) socket.__trigger('disconnect', 'transport close')
+    socketState.pending.set('one', 0) // Completed while offline; there is no event to replay.
+    for (const socket of socketState.sockets) socket.__trigger('connect')
+    await Promise.resolve()
+    expect(store.isSessionWorking('one')).toBe(false)
+    expect(store.isSessionLive('one')).toBe(false)
+    expect(store.isStreaming).toBe(false)
+  })
+
+  it.each(['direct', 'passive'])('clears %s activity on the server terminal abort payload', async (mode) => {
+    if (mode === 'passive') socketState.pending.set('one', 1)
+    await store.switchSession('one')
+    if (mode === 'direct') {
+      await store.sendMessage('delegate')
+      socketState.sockets[0].__trigger('run.completed', {
+        event: 'run.completed', session_id: 'one', background_pending: 1,
+      })
+    }
+    expect(store.isSessionWorking('one')).toBe(true)
+    socketState.sockets[0].__trigger('abort.completed', {
+      event: 'abort.completed', session_id: 'one', run_id: 'run-one', synced: true,
+    })
+    expect(store.isSessionWorking('one')).toBe(false)
+    expect(store.isSessionLive('one')).toBe(false)
+  })
+})

--- a/tests/e2e/chat-streaming.spec.ts
+++ b/tests/e2e/chat-streaming.spec.ts
@@ -203,7 +203,7 @@ test('freezes the current reasoning between the thinking animation and its tool 
   expect(api.unexpectedRequests).toEqual([])
 })
 
-test('shows one real subagent card and opens its live chat stream in the resizable preview panel', async ({ page }) => {
+test('shows one real subagent card and opens its live chat stream in the resizable preview panel', async ({ page }, testInfo) => {
   await authenticate(page, TEST_ACCESS_KEY, 'research')
   const api = await mockHermesApi(page)
   await mockChatSocket(page)
@@ -213,7 +213,7 @@ test('shows one real subagent card and opens its live chat stream in the resizab
   const { run } = await waitForRun(page)
 
   await page.evaluate((sid) => {
-    const socket = (window as any).__PW_CHAT_SOCKET__.latest
+    const socket = { __trigger: (window as any).__PW_CHAT_SOCKET__.broadcast }
     socket.__trigger('run.started', { event: 'run.started', session_id: sid, run_id: 'run-delegate' })
     socket.__trigger('reasoning.delta', {
       event: 'reasoning.delta',
@@ -253,9 +253,10 @@ test('shows one real subagent card and opens its live chat stream in the resizab
   const singleChatLiveReasoning = page.locator('.streaming-indicator > .live-reasoning-status')
   await expect(singleChatLiveReasoning).toBeVisible()
   const singleChatThinkingStyles = await singleChatLiveReasoning.evaluate(readLiveReasoningStyles)
+  await page.screenshot({ animations: 'disabled', path: testInfo.outputPath('01-mocked-foreground-working.png') })
 
   await page.evaluate((sid) => {
-    const socket = (window as any).__PW_CHAT_SOCKET__.latest
+    const socket = { __trigger: (window as any).__PW_CHAT_SOCKET__.broadcast }
     socket.__trigger('run.completed', {
       event: 'run.completed',
       session_id: sid,
@@ -266,9 +267,13 @@ test('shows one real subagent card and opens its live chat stream in the resizab
   }, run.session_id)
 
   await expect(page.locator('.subagent-entry')).toHaveCount(0)
+  // Parent has finished, but the existing sidebar working glow must stay on.
+  const workingLogos = page.locator('.session-item.active .session-item-agent-logo-wrap')
+  await expect(workingLogos).toHaveCount(2)
+  await expect(workingLogos).toHaveClass([/streaming/, /streaming/])
 
   await page.evaluate((sid) => {
-    const socket = (window as any).__PW_CHAT_SOCKET__.latest
+    const socket = { __trigger: (window as any).__PW_CHAT_SOCKET__.broadcast }
     socket.__trigger('subagent.start', {
       event: 'subagent.start',
       session_id: sid,
@@ -310,6 +315,9 @@ test('shows one real subagent card and opens its live chat stream in the resizab
   await expect(panel.locator('.subagent-run-indicator .live-reasoning-detail')).toContainText('Inspecting sources before searching.')
   await expect(panel.locator('.subagent-live-tool')).toContainText('search_web')
   await expect(panel.getByText('Waiting for live output...')).toHaveCount(0)
+  await expect(workingLogos).toHaveClass([/streaming/, /streaming/])
+  await expect(singleChatLiveReasoning).toHaveCount(0)
+  await page.screenshot({ animations: 'disabled', path: testInfo.outputPath('02-mocked-background-working.png') })
   await expect(panel.locator('.message-bubble.system')).toHaveCount(0)
   const subagentThinkingStyles = await panel
     .locator('.live-reasoning-status')
@@ -364,7 +372,7 @@ test('shows one real subagent card and opens its live chat stream in the resizab
   expect(backgrounds.transcript).toBe(backgrounds.chat)
 
   await page.evaluate((sid) => {
-    const socket = (window as any).__PW_CHAT_SOCKET__.latest
+    const socket = { __trigger: (window as any).__PW_CHAT_SOCKET__.broadcast }
     socket.__trigger('subagent.thinking', {
       event: 'subagent.thinking',
       session_id: sid,
@@ -387,7 +395,7 @@ test('shows one real subagent card and opens its live chat stream in the resizab
   await expect(panel.locator('.message.assistant .thinking-block')).toHaveCount(0)
 
   await page.evaluate((sid) => {
-    const socket = (window as any).__PW_CHAT_SOCKET__.latest
+    const socket = { __trigger: (window as any).__PW_CHAT_SOCKET__.broadcast }
     socket.__trigger('subagent.thinking', {
       event: 'subagent.thinking',
       session_id: sid,
@@ -401,7 +409,7 @@ test('shows one real subagent card and opens its live chat stream in the resizab
   await expect(panel.locator('.message.assistant .thinking-block')).toHaveCount(0)
 
   await page.evaluate((sid) => {
-    const socket = (window as any).__PW_CHAT_SOCKET__.latest
+    const socket = { __trigger: (window as any).__PW_CHAT_SOCKET__.broadcast }
     socket.__trigger('subagent.complete', {
       event: 'subagent.complete',
       session_id: sid,
@@ -418,6 +426,22 @@ test('shows one real subagent card and opens its live chat stream in the resizab
   await expect(panel.locator('.subagent-run-indicator')).toHaveCount(0)
   await expect(panel).toContainText('Research finished.')
   await expect(panel.locator('.message-bubble.system')).toHaveCount(0)
+
+  // A child completion is not the aggregate lifecycle: delivery can still be pending.
+  await page.setViewportSize({ width: 1280, height: 720 })
+  // Entering mobile closes the sessions pane; resizing does not reopen it.
+  await page.locator('.header-sidebar-toggle').click()
+  await expect(workingLogos).toHaveClass([/streaming/, /streaming/])
+  await page.evaluate((sid) => {
+    const socket = { __trigger: (window as any).__PW_CHAT_SOCKET__.broadcast }
+    socket.__trigger('delegation.updated', {
+      event: 'delegation.updated', session_id: sid, delegation_id: 'delegation-1',
+      status: 'completed', background_pending: 0,
+    })
+  }, run.session_id)
+  await expect(page.locator('.session-item.active .session-item-agent-logo-wrap.streaming')).toHaveCount(0)
+  await page.setViewportSize({ width: 1280, height: 720 })
+  await page.screenshot({ animations: 'disabled', path: testInfo.outputPath('03-mocked-all-terminal.png') })
 
   const completedTool = panel.locator('.message.tool').filter({ hasText: 'search_web' })
   await completedTool.locator('.tool-line').click()

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -977,12 +977,18 @@ export async function mockChatSocket(page: Page) {
       contentType: 'application/javascript',
       body: `
 const state = window.__PW_CHAT_SOCKET__ || (window.__PW_CHAT_SOCKET__ = { sockets: [], emitted: [] })
+state.broadcast = (event, payload) => {
+  for (const socket of [...state.sockets]) {
+    if (socket.connected && socket.rooms.has(payload.session_id)) socket.__trigger(event, payload)
+  }
+}
 function makeSocket(url, options) {
   const listeners = new Map()
   const onceListeners = new Map()
   const socketNumber = (state.socketCount = (state.socketCount || 0) + 1)
   const socket = {
     id: 'pw-socket-' + socketNumber,
+    rooms: new Set(),
     connected: true,
     url,
     options,
@@ -1014,6 +1020,7 @@ function makeSocket(url, options) {
     },
     emit(event, payload, ack) {
       state.emitted.push({ event, payload })
+      if ((event === 'run' || event === 'resume') && payload?.session_id) this.rooms.add(payload.session_id)
       if (typeof ack === 'function' && String(url).endsWith('/workflow')) {
         const data = event === 'workflow.status.subscribe'
           ? { statuses: [] }

--- a/tests/e2e/sidebar-working.spec.ts
+++ b/tests/e2e/sidebar-working.spec.ts
@@ -1,0 +1,69 @@
+import { expect, test } from '@playwright/test'
+import { authenticate, mockHermesApi, TEST_ACCESS_KEY } from './fixtures'
+
+// All session data and socket traffic in this test are fixtures, not live tasks.
+test('restores sidebar delegation activity on reload and keeps it scoped during navigation', async ({ page }, testInfo) => {
+  await authenticate(page, TEST_ACCESS_KEY, 'research')
+  const sessions = ['Delegated fixture', 'Idle fixture'].map((title, index) => ({
+    id: `sidebar-fixture-${index}`, title, profile: 'research', source: 'api_server',
+    model: 'test-model', provider: 'test-provider', started_at: 2 - index,
+    last_active: 2 - index, message_count: 1,
+  }))
+  await page.addInitScript(() => {
+    const pending = window.localStorage.getItem('fixture-background-finished') ? 0 : 2
+    ;(window as any).__PW_CHAT_SOCKET_RESUMES__ = Object.fromEntries([0, 1].map(index => {
+      const sid = `sidebar-fixture-${index}`
+      return [sid, {
+        session_id: sid, isWorking: false, backgroundPending: index === 0 ? pending : 0,
+        messages: [{ id: index + 1, role: 'assistant', content: `Fixture answer ${index}`, timestamp: 1, finish_reason: 'stop' }],
+        // Stale task history must never override the authoritative aggregate.
+        events: index === 0 ? [{ event: 'subagent.start', data: {
+          event: 'subagent.start', session_id: sid, subagent_id: 'historical-child',
+          goal: 'Historical fixture task', background_pending: 7,
+        } }] : [],
+      }]
+    }))
+  })
+  const api = await mockHermesApi(page, { sessions })
+  await page.goto('/#/hermes/chat')
+  const delegated = page.locator('.session-item').filter({ hasText: 'Delegated fixture' })
+  const idle = page.locator('.session-item').filter({ hasText: 'Idle fixture' })
+  const working = delegated.locator('.session-item-agent-logo-wrap.streaming')
+  await expect(working).toHaveCount(2)
+  await expect(page.getByPlaceholder('Type a message... (Enter to send, Shift+Enter for new line)')).toBeEnabled()
+  await expect(page.getByRole('button', { name: 'Stop', exact: true })).toHaveCount(0)
+
+  await idle.first().click()
+  await expect(page.getByText('Fixture answer 1', { exact: true })).toBeVisible()
+  await expect(working).toHaveCount(2)
+  await expect(idle.locator('.session-item-agent-logo-wrap.streaming')).toHaveCount(0)
+  await page.screenshot({ animations: 'disabled', path: testInfo.outputPath('04-mocked-navigated-background.png') })
+
+  await delegated.first().click()
+  await expect(page.getByText('Fixture answer 0', { exact: true })).toBeVisible()
+  await page.reload()
+  await expect(working).toHaveCount(2)
+  await page.screenshot({ animations: 'disabled', path: testInfo.outputPath('05-mocked-reloaded-background.png') })
+
+  await page.evaluate(() => {
+    const state = (window as any).__PW_CHAT_SOCKET__
+    state.broadcast('delegation.updated', {
+      event: 'delegation.updated', session_id: 'sidebar-fixture-0',
+      status: 'cancelled', background_pending: 1,
+    })
+  })
+  await expect(working).toHaveCount(2)
+  await page.evaluate(() => {
+    ;(window as any).__PW_CHAT_SOCKET__.broadcast('delegation.updated', {
+      event: 'delegation.updated', session_id: 'sidebar-fixture-0',
+      status: 'failed', background_pending: 0,
+    })
+    window.localStorage.setItem('fixture-background-finished', '1')
+  })
+  await expect(working).toHaveCount(0)
+  await page.reload()
+  await expect(page.getByText('Fixture answer 0', { exact: true })).toBeVisible()
+  await expect(working).toHaveCount(0)
+  await page.screenshot({ animations: 'disabled', path: testInfo.outputPath('06-mocked-reloaded-terminal.png') })
+  expect(api.unexpectedRequests).toEqual([])
+})


### PR DESCRIPTION
## Summary
- Keep the existing Agent-working indicator on a conversation while a delegated background task is still running, even after the parent Agent finishes its reply.
- Keep the composer and other foreground execution behavior unchanged.
- Restore the indicator from the server-reported background state after resume or reconnect.

## Problem
After the parent Agent finished its reply, a delegated task was still running, but the conversation in the left sidebar looked finished. The chat and Background task panel still showed the task running, so the same conversation displayed contradictory states and could lead to duplicate work.

## Expected behavior
Keep the sidebar working indicator until the delegated task actually finishes, while keeping the composer available for new messages.

## Implementation
Track the authoritative pending-delegation state per session and use a sidebar-only working predicate. The state is handled across resume, reconnect, profile changes, cancellation, and authentication cleanup, without inferring activity from old transcript rows or changing foreground queue and voice behavior.

## Related work
Related to #2625 and the open #2629. This is a focused alternative that keeps the existing sidebar affordance instead of adding a new banner or task-count UI. Browser coverage uses sanitized mocked sessions; the original screenshot is not included because it contains unrelated private content.

## Validation
Validated with full Vitest coverage (**5,178 passed, 6 skipped**), the production build, harness checks, independent review, and **22 Playwright tests** covering authentication, chat streaming, navigation/reload, background activity, and terminal states. GitHub Build and Playwright checks are also green.
