### PR TITLE
fix: handle unreadable Hermes auth files

### DIFF
--- a/packages/server/src/modules/hermes/services/providers/authorized-provider-credentials.ts
+++ b/packages/server/src/modules/hermes/services/providers/authorized-provider-credentials.ts
@@ -166,6 +166,11 @@ function authContainsProvider(auth: JsonRecord, provider: AuthorizedProvider): b
   })
 }
 
+function isPermissionError(error: unknown): boolean {
+  const code = (error as { code?: unknown } | null)?.code
+  return code === 'EACCES' || code === 'EPERM'
+}
+
 async function readJsonFile(path: string): Promise<JsonRecord> {
   try {
     const parsed = JSON.parse(await readFile(path, 'utf-8'))
@@ -349,14 +354,30 @@ async function locateAuthSnapshot(
 ): Promise<CredentialSnapshot | null> {
   const profileDir = dependencies.profileDir || getProfileDir
   const requestedPath = join(profileDir(profile), 'auth.json')
-  const requestedAuth = await readJsonFile(requestedPath)
+  let requestedAuth: JsonRecord
+  try {
+    requestedAuth = await readJsonFile(requestedPath)
+  } catch (error) {
+    if (isPermissionError(error)) {
+      throw missingCredentials(provider, `Cannot read Hermes auth file ${requestedPath}: permission denied`)
+    }
+    throw error
+  }
   if (authContainsProvider(requestedAuth, provider)) {
     return snapshotFromAuth(requestedPath, requestedAuth, provider, dependencies.env || process.env)
   }
 
   const defaultPath = join(profileDir('default'), 'auth.json')
   if (resolve(defaultPath) === resolve(requestedPath)) return null
-  const defaultAuth = await readJsonFile(defaultPath)
+  let defaultAuth: JsonRecord
+  try {
+    defaultAuth = await readJsonFile(defaultPath)
+  } catch (error) {
+    if (isPermissionError(error)) {
+      throw missingCredentials(provider, `Cannot read Hermes auth file ${defaultPath}: permission denied`)
+    }
+    throw error
+  }
   if (!authContainsProvider(defaultAuth, provider)) return null
   return snapshotFromAuth(defaultPath, defaultAuth, provider, dependencies.env || process.env)
 }

--- a/tests/server/authorized-provider-credentials.test.ts
+++ b/tests/server/authorized-provider-credentials.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import {
@@ -74,6 +74,49 @@ describe('Studio authorized provider runtime credentials', () => {
       lastRefresh: new Date(NOW).toISOString(),
     })
     expect(fetcher).not.toHaveBeenCalled()
+  })
+
+  it('treats an unreadable auth.json as an unauthenticated provider', async () => {
+    writeAuth({ providers: { 'xai-oauth': { access_token: 'hidden-token' } } })
+    chmodSync(hermesHome, 0o000)
+
+    try {
+      await expect(resolveAuthorizedProviderRuntimeCredentials({
+        profile: 'default',
+        provider: 'xai-oauth',
+      }, { profileDir })).rejects.toMatchObject({
+        code: 'AUTHORIZED_PROVIDER_AUTH_MISSING',
+        provider: 'xai-oauth',
+        reloginRequired: true,
+        message: expect.stringContaining('permission denied'),
+      })
+    } finally {
+      chmodSync(hermesHome, 0o700)
+    }
+  })
+
+  it('does not fall back to default credentials when a profile auth file is unreadable', async () => {
+    writeAuth({ providers: { 'xai-oauth': { access_token: 'default-token' } } })
+    const researchDir = join(hermesHome, 'profiles', 'research')
+    mkdirSync(researchDir, { recursive: true })
+    writeFileSync(join(researchDir, 'auth.json'), JSON.stringify({
+      providers: { 'xai-oauth': { access_token: 'research-token' } },
+    }))
+    chmodSync(researchDir, 0o000)
+
+    try {
+      await expect(resolveAuthorizedProviderRuntimeCredentials({
+        profile: 'research',
+        provider: 'xai-oauth',
+      }, { profileDir })).rejects.toMatchObject({
+        code: 'AUTHORIZED_PROVIDER_AUTH_MISSING',
+        provider: 'xai-oauth',
+        reloginRequired: true,
+        message: expect.stringContaining('permission denied'),
+      })
+    } finally {
+      chmodSync(researchDir, 0o700)
+    }
   })
 
   it('refreshes an expired xAI token in Studio and atomically updates provider and pool state', async () => {


### PR DESCRIPTION
## Summary
- Treat unreadable Hermes auth files as authentication failures with actionable permission detail.
- Prevent unreadable requested profiles from falling back to default credentials; the exact macOS Dock behavior still needs platform validation.

Closes #2924

## Validation
- `npm run test -- tests/server/authorized-provider-credentials.test.ts tests/server/nous-auth-controller.test.ts`
- `npm run harness:check`
- `npm run build`
- `git diff --check`