### PR TITLE
test: cover Runtime prompt access guard

### DIFF
--- a/tests/client/runtime-restart-prompt.test.ts
+++ b/tests/client/runtime-restart-prompt.test.ts
@@ -138,6 +138,15 @@ describe('RuntimeRestartPrompt', () => {
     wrapper.unmount()
   })
 
+  it('never queries jobs when no user role is stored', async () => {
+    auth.isStoredSuperAdmin.mockReturnValue(false)
+    const wrapper = mount(RuntimeRestartPrompt)
+    await flushPromises()
+    await vi.advanceTimersByTimeAsync(10000)
+    expect(api.fetchVersionDownloadJobs).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
   it('checks once on mount and stays idle when no Runtime download is active', async () => {
     api.fetchVersionDownloadJobs.mockResolvedValue({ jobs: [] })
     const wrapper = mount(RuntimeRestartPrompt)


### PR DESCRIPTION
## Summary
- Add coverage for the Runtime restart prompt when no user role is stored.
- Verify unauthorized clients do not query the protected Runtime download-jobs endpoint.

Refs #2880

## Validation
- `npm exec vitest run tests/client/runtime-restart-prompt.test.ts tests/client/app-web-pet.test.ts`
- `npm run harness:check`
- `npm run build`
- `git diff --check`

The production polling issue is already fixed on `main` by #2925; this change adds focused coverage for the missing-role access boundary. Browser E2E was not run locally because Chromium is unavailable.