### PR TITLE
fix: clarify Hermes settings entry

### DIFF
--- a/packages/client/src/i18n/locales/ar.ts
+++ b/packages/client/src/i18n/locales/ar.ts
@@ -399,6 +399,7 @@ export default {
     subtitle: 'اكتشاف الوكلاء المتاحين على هذا الجهاز وإدارتهم.',
     refresh: 'تحديث',
     hermesDescription: 'يمكن لـ Hermes استخدام Runtime يديره Studio أو CLI محلي يثبّته المستخدم.',
+    hermesSettings: 'إعداد Hermes',
     managedRuntime: 'Hermes Runtime',
     managedRuntimeHint: 'يثبّت Studio حزم Runtime الكاملة ويديرها فقط، ولا يثبّت Hermes CLI بشكل منفصل.',
     studioManaged: 'يديره Studio',

--- a/packages/client/src/i18n/locales/de.ts
+++ b/packages/client/src/i18n/locales/de.ts
@@ -411,6 +411,7 @@ export default {
     subtitle: 'Verfügbare Agents auf diesem Gerät erkennen und verwalten.',
     refresh: 'Aktualisieren',
     hermesDescription: 'Hermes kann eine von Studio verwaltete Runtime oder eine vom Benutzer installierte lokale CLI verwenden.',
+    hermesSettings: 'Hermes konfigurieren',
     managedRuntime: 'Hermes Runtime',
     managedRuntimeHint: 'Studio installiert und verwaltet nur vollständige Runtime-Pakete und installiert die Hermes CLI nicht separat.',
     studioManaged: 'Von Studio verwaltet',

--- a/packages/client/src/i18n/locales/en.ts
+++ b/packages/client/src/i18n/locales/en.ts
@@ -399,6 +399,7 @@ export default {
     subtitle: 'Discover and manage the Agents available on this device.',
     refresh: 'Refresh',
     hermesDescription: 'Hermes can come from a Studio-managed Runtime or a CLI installed by the user.',
+    hermesSettings: 'Configure Hermes',
     managedRuntime: 'Hermes Runtime',
     managedRuntimeHint: 'Studio installs and manages complete Runtime packages; it never installs the Hermes CLI separately.',
     studioManaged: 'Studio managed',

--- a/packages/client/src/i18n/locales/es.ts
+++ b/packages/client/src/i18n/locales/es.ts
@@ -411,6 +411,7 @@ export default {
     subtitle: 'Detecta y gestiona los agentes disponibles en este dispositivo.',
     refresh: 'Actualizar',
     hermesDescription: 'Hermes puede usar un Runtime gestionado por Studio o una CLI local instalada por el usuario.',
+    hermesSettings: 'Configurar Hermes',
     managedRuntime: 'Hermes Runtime',
     managedRuntimeHint: 'Studio solo instala y gestiona paquetes Runtime completos; nunca instala la CLI de Hermes por separado.',
     studioManaged: 'Gestionado por Studio',

--- a/packages/client/src/i18n/locales/fr.ts
+++ b/packages/client/src/i18n/locales/fr.ts
@@ -411,6 +411,7 @@ export default {
     subtitle: 'Détectez et gérez les agents disponibles sur cet appareil.',
     refresh: 'Actualiser',
     hermesDescription: 'Hermes peut utiliser un Runtime géré par Studio ou une CLI locale installée par l’utilisateur.',
+    hermesSettings: 'Configurer Hermes',
     managedRuntime: 'Hermes Runtime',
     managedRuntimeHint: 'Studio installe et gère uniquement des packages Runtime complets, jamais la CLI Hermes séparément.',
     studioManaged: 'Géré par Studio',

--- a/packages/client/src/i18n/locales/ja.ts
+++ b/packages/client/src/i18n/locales/ja.ts
@@ -411,6 +411,7 @@ export default {
     subtitle: 'このデバイスで利用可能なエージェントを検出・管理します。',
     refresh: '更新',
     hermesDescription: 'Hermes は、Studio 管理の Runtime またはユーザーがインストールしたローカル CLI を使用できます。',
+    hermesSettings: 'Hermes を設定',
     managedRuntime: 'Hermes Runtime',
     managedRuntimeHint: 'Studio は完全な Runtime パッケージのみをインストール・管理し、Hermes CLI を個別にはインストールしません。',
     studioManaged: 'Studio 管理',

--- a/packages/client/src/i18n/locales/ko.ts
+++ b/packages/client/src/i18n/locales/ko.ts
@@ -411,6 +411,7 @@ export default {
     subtitle: '이 기기에서 사용할 수 있는 에이전트를 검색하고 관리합니다.',
     refresh: '새로고침',
     hermesDescription: 'Hermes는 Studio가 관리하는 Runtime 또는 사용자가 설치한 로컬 CLI를 사용할 수 있습니다.',
+    hermesSettings: 'Hermes 설정',
     managedRuntime: 'Hermes Runtime',
     managedRuntimeHint: 'Studio는 전체 Runtime 패키지만 설치하고 관리하며 Hermes CLI를 별도로 설치하지 않습니다.',
     studioManaged: 'Studio 관리',

--- a/packages/client/src/i18n/locales/pt.ts
+++ b/packages/client/src/i18n/locales/pt.ts
@@ -411,6 +411,7 @@ export default {
     subtitle: 'Detecte e gerencie os agentes disponíveis neste dispositivo.',
     refresh: 'Atualizar',
     hermesDescription: 'O Hermes pode usar um Runtime gerenciado pelo Studio ou uma CLI local instalada pelo usuário.',
+    hermesSettings: 'Configurar o Hermes',
     managedRuntime: 'Hermes Runtime',
     managedRuntimeHint: 'O Studio instala e gerencia apenas pacotes Runtime completos; ele nunca instala a CLI do Hermes separadamente.',
     studioManaged: 'Gerenciado pelo Studio',

--- a/packages/client/src/i18n/locales/ru.ts
+++ b/packages/client/src/i18n/locales/ru.ts
@@ -321,6 +321,7 @@ export default {
     subtitle: 'Обнаружение и управление агентами, доступными на этом устройстве.',
     refresh: 'Обновить',
     hermesDescription: 'Hermes может использовать Runtime под управлением Studio или локальную CLI, установленную пользователем.',
+    hermesSettings: 'Настроить Hermes',
     managedRuntime: 'Hermes Runtime',
     managedRuntimeHint: 'Studio устанавливает и управляет только полными пакетами Runtime и не устанавливает Hermes CLI отдельно.',
     studioManaged: 'Управляется Studio',

--- a/packages/client/src/i18n/locales/zh-TW.ts
+++ b/packages/client/src/i18n/locales/zh-TW.ts
@@ -399,6 +399,7 @@ export default {
     subtitle: '統一探索及管理此裝置上的 Agent。',
     refresh: '重新整理',
     hermesDescription: 'Hermes 支援 Studio 託管的 Runtime，以及使用者自行安裝的本機 CLI。',
+    hermesSettings: '設定 Hermes',
     managedRuntime: 'Hermes Runtime',
     managedRuntimeHint: 'Studio 僅安裝及管理完整 Runtime 套件，不會單獨安裝 Hermes CLI。',
     studioManaged: 'Studio 管理',

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -399,6 +399,7 @@ export default {
     subtitle: '统一发现和管理这台设备上的 Agent。',
     refresh: '刷新',
     hermesDescription: 'Hermes 支持 Studio 托管的 Runtime，以及用户自行安装的本机 CLI。',
+    hermesSettings: '配置 Hermes',
     managedRuntime: 'Hermes Runtime',
     managedRuntimeHint: 'Studio 只安装和管理完整 Runtime 包，不单独安装 Hermes CLI。',
     studioManaged: 'Studio 管理',

--- a/packages/client/src/views/hermes/AgentManagerView.vue
+++ b/packages/client/src/views/hermes/AgentManagerView.vue
@@ -511,7 +511,7 @@ onMounted(() => {
                 size="small"
                 @click="router.push({ name: 'hermes.configSettings' })"
               >
-                {{ t('sidebar.settings') }}
+                {{ t('agentManager.hermesSettings') }}
               </NButton>
               <NButton
                 v-if="hermesDetected && hermesType === 'CLI'"

--- a/tests/client/agent-manager-page.test.ts
+++ b/tests/client/agent-manager-page.test.ts
@@ -272,7 +272,7 @@ describe('Agent Manager page', () => {
     expect(hermesCard.text()).not.toContain('/Users/test/.local/bin/hermes')
     expect(hermesCard.get('[data-testid="hermes-source-type"]').text()).toBe('Runtime')
     expect(hermesCard.findAll('button').map(button => button.text()))
-      .toEqual(['sidebar.settings', 'agentManager.manageRuntime'])
+      .toEqual(['agentManager.hermesSettings', 'agentManager.manageRuntime'])
     expect(wrapper.findComponent({ name: 'VersionManagementModal' }).exists()).toBe(true)
     expect(api.fetchAgentStatusSnapshot).toHaveBeenCalledOnce()
     expect(api.fetchRuntimeVersionStatus).not.toHaveBeenCalled()
@@ -322,7 +322,7 @@ describe('Agent Manager page', () => {
     expect(hermesCard.text()).not.toContain('/Users/test/.local/bin/hermes')
     expect(hermesCard.get('[data-testid="hermes-source-type"]').text()).toBe('CLI')
     expect(hermesCard.findAll('button').map(button => button.text()))
-      .toEqual(['sidebar.settings', 'runtimeVersions.viewCliDetails'])
+      .toEqual(['agentManager.hermesSettings', 'runtimeVersions.viewCliDetails'])
     expect(api.fetchRuntimeVersionStatus).not.toHaveBeenCalled()
     expect(wrapper.getComponent({ name: 'VersionManagementModal' }).props('show')).toBe(false)
 

--- a/tests/client/hermes-config-navigation.test.ts
+++ b/tests/client/hermes-config-navigation.test.ts
@@ -96,5 +96,6 @@ describe("Hermes configuration navigation", () => {
       "router.push({ name: 'hermes.configSettings' })",
     );
     expect(agentManager).toContain('v-if="hermesDetected"');
+    expect(agentManager).toContain("t('agentManager.hermesSettings')");
   });
 });


### PR DESCRIPTION
## Summary
- Clarify the Hermes card action in Agent Manager so it identifies Hermes-specific configuration.
- Preserve the existing Hermes configuration route and dedicated sidebar while updating the affected page expectations.

Closes #2841

## Validation
- `npm run test -- tests/client/agent-manager-page.test.ts --run`
- `npm run test -- tests/client/hermes-config-navigation.test.ts tests/client/agent-manager-locales.test.ts --run`
- `npm run harness:check`
- `npm run build`
- `git diff --check`