### PR TITLE
fix(codex): 正确保留多行顶层 TOML 配置值

### DIFF
--- a/packages/server/src/modules/coding-agents/services/index.ts
+++ b/packages/server/src/modules/coding-agents/services/index.ts
@@ -1299,6 +1299,57 @@ function parseCodexExternalMcpBlocks(...contents: Array<string | null | undefine
   return Array.from(blockByServer.values()).filter(Boolean)
 }
 
+interface TomlArrayScanState {
+  quote: '"' | "'" | null
+  multiline: boolean
+}
+
+function scanTomlArrayBrackets(line: string, state: TomlArrayScanState): number {
+  let delta = 0
+  let escaped = false
+  for (let index = 0; index < line.length; index += 1) {
+    const char = line[index]
+    if (state.quote) {
+      if (state.multiline) {
+        if (state.quote === '"' && char === '\\') {
+          escaped = !escaped
+          continue
+        }
+        if (char === state.quote && !escaped) {
+          let quoteCount = 1
+          while (line[index + quoteCount] === state.quote) quoteCount += 1
+          if (quoteCount >= 3) {
+            state.quote = null
+            state.multiline = false
+            index += quoteCount - 1
+          }
+        }
+        escaped = false
+        continue
+      }
+      if (state.quote === '"' && char === '\\' && !escaped) {
+        escaped = true
+        continue
+      }
+      if (char === state.quote && !escaped) {
+        state.quote = null
+      }
+      escaped = false
+      continue
+    }
+    if (char === '#') break
+    if (char === '"' || char === "'") {
+      state.quote = char
+      state.multiline = line.slice(index, index + 3) === char.repeat(3)
+      if (state.multiline) index += 2
+      continue
+    }
+    if (char === '[') delta += 1
+    else if (char === ']') delta -= 1
+  }
+  return delta
+}
+
 function codexRuntimeUserConfig(...contents: Array<string | null | undefined>): {
   topLevelLines: string[]
   sectionBlocks: string[]
@@ -1348,14 +1399,13 @@ function codexRuntimeUserConfig(...contents: Array<string | null | undefined>): 
       if (!section) {
         if (assignment && !runtimeKeys.has(assignment[1])) {
           let mergedLine = line
-          let bracketDepth = (line.slice(line.indexOf('=') + 1).match(/\[/g) || []).length
-            - (line.slice(line.indexOf('=') + 1).match(/\]/g) || []).length
-          while (bracketDepth > 0 && lineIndex + 1 < lines.length) {
+          const scanState: TomlArrayScanState = { quote: null, multiline: false }
+          let bracketDepth = scanTomlArrayBrackets(line.slice(line.indexOf('=') + 1), scanState)
+          while ((bracketDepth > 0 || scanState.multiline) && lineIndex + 1 < lines.length) {
             lineIndex += 1
             const nextLine = lines[lineIndex]
             mergedLine += `\n${nextLine}`
-            bracketDepth += (nextLine.match(/\[/g) || []).length
-              - (nextLine.match(/\]/g) || []).length
+            bracketDepth += scanTomlArrayBrackets(nextLine, scanState)
           }
           topLevel.set(assignment[1], mergedLine)
         }
@@ -1381,8 +1431,10 @@ function codexRuntimeUserConfig(...contents: Array<string | null | undefined>): 
   }
 
   const sectionBlocks: string[] = []
-  for (const { header, lines } of sections.values()) {
-    if (lines.length) sectionBlocks.push(`${header}\n${lines.join('\n')}`)
+  for (const [key, { header, lines }] of sections) {
+    if (lines.length || key.startsWith('array:')) {
+      sectionBlocks.push(lines.length ? `${header}\n${lines.join('\n')}` : header)
+    }
   }
   return {
     topLevelLines: [...topLevel.values()],

--- a/packages/server/src/modules/coding-agents/services/index.ts
+++ b/packages/server/src/modules/coding-agents/services/index.ts
@@ -1350,6 +1350,17 @@ function scanTomlArrayBrackets(line: string, state: TomlArrayScanState): number 
   return delta
 }
 
+function isManagedCodexSection(section: string): boolean {
+  return section === 'models'
+    || section.startsWith('model.')
+    || section.startsWith('model_providers.')
+    || section.startsWith('mcp_servers.')
+    || section === 'auth'
+    || section.startsWith('auth.')
+    || section === 'account'
+    || section.startsWith('account.')
+}
+
 function codexRuntimeUserConfig(...contents: Array<string | null | undefined>): {
   topLevelLines: string[]
   sectionBlocks: string[]
@@ -1378,9 +1389,18 @@ function codexRuntimeUserConfig(...contents: Array<string | null | undefined>): 
     if (!content?.trim()) continue
     let section = ''
     let sectionKey = ''
+    const sectionScanState: TomlArrayScanState = { quote: null, multiline: false }
     const lines = content.split(/\r?\n/)
     for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
       const line = lines[lineIndex]
+      if (sectionScanState.multiline) {
+        const sectionBlock = sections.get(sectionKey)
+        if (sectionBlock && section !== 'features' && !isManagedCodexSection(section)) {
+          sectionBlock.lines.push(line)
+        }
+        scanTomlArrayBrackets(line, sectionScanState)
+        continue
+      }
       const arrayHeader = line.match(/^\s*\[\[([^\]]+)\]\]\s*$/)
       if (arrayHeader) {
         section = arrayHeader[1].trim()
@@ -1413,20 +1433,16 @@ function codexRuntimeUserConfig(...contents: Array<string | null | undefined>): 
       }
       if (section === 'features') {
         if (assignment && !runtimeFeatures.has(assignment[1])) featureLines.set(assignment[1], line)
+        scanTomlArrayBrackets(line, sectionScanState)
         continue
       }
-      if (
-        section === 'models'
-        || section.startsWith('model.')
-        || section.startsWith('model_providers.')
-        || section.startsWith('mcp_servers.')
-        || section === 'auth'
-        || section.startsWith('auth.')
-        || section === 'account'
-        || section.startsWith('account.')
-      ) continue
+      if (isManagedCodexSection(section)) {
+        scanTomlArrayBrackets(line, sectionScanState)
+        continue
+      }
       const sectionBlock = sections.get(sectionKey)
       if (sectionBlock && line.trim()) sectionBlock.lines.push(line)
+      scanTomlArrayBrackets(line, sectionScanState)
     }
   }
 

--- a/packages/server/src/modules/coding-agents/services/index.ts
+++ b/packages/server/src/modules/coding-agents/services/index.ts
@@ -1305,7 +1305,7 @@ function codexRuntimeUserConfig(...contents: Array<string | null | undefined>): 
   featureLines: string[]
 } {
   const topLevel = new Map<string, string>()
-  const sections = new Map<string, string[]>()
+  const sections = new Map<string, { header: string; lines: string[] }>()
   const featureLines = new Map<string, string>()
   const runtimeKeys = new Set([
     'model',
@@ -1322,15 +1322,26 @@ function codexRuntimeUserConfig(...contents: Array<string | null | undefined>): 
   ])
   const runtimeFeatures = new Set(['tool_search', 'tool_search_always_defer_mcp_tools'])
 
+  let arraySectionIndex = 0
   for (const content of contents) {
     if (!content?.trim()) continue
     let section = ''
+    let sectionKey = ''
     const lines = content.split(/\r?\n/)
     for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
       const line = lines[lineIndex]
-      const header = line.match(/^\s*\[([^\]]+)\]\s*$/)
-      if (header) {
-        section = header[1].trim()
+      const arrayHeader = line.match(/^\s*\[\[([^\]]+)\]\]\s*$/)
+      if (arrayHeader) {
+        section = arrayHeader[1].trim()
+        sectionKey = `array:${arraySectionIndex++}`
+        sections.set(sectionKey, { header: line.trim(), lines: [] })
+        continue
+      }
+      const tableHeader = line.match(/^\s*\[([^\]]+)\]\s*$/)
+      if (tableHeader) {
+        section = tableHeader[1].trim()
+        sectionKey = `table:${section}`
+        if (!sections.has(sectionKey)) sections.set(sectionKey, { header: line.trim(), lines: [] })
         continue
       }
       const assignment = line.match(/^\s*([A-Za-z0-9_.-]+)\s*=/)
@@ -1364,15 +1375,14 @@ function codexRuntimeUserConfig(...contents: Array<string | null | undefined>): 
         || section === 'account'
         || section.startsWith('account.')
       ) continue
-      const sectionLines = sections.get(section) || []
-      if (line.trim()) sectionLines.push(line)
-      sections.set(section, sectionLines)
+      const sectionBlock = sections.get(sectionKey)
+      if (sectionBlock && line.trim()) sectionBlock.lines.push(line)
     }
   }
 
   const sectionBlocks: string[] = []
-  for (const [section, lines] of sections) {
-    if (lines.length) sectionBlocks.push(`[${section}]\n${lines.join('\n')}`)
+  for (const { header, lines } of sections.values()) {
+    if (lines.length) sectionBlocks.push(`${header}\n${lines.join('\n')}`)
   }
   return {
     topLevelLines: [...topLevel.values()],

--- a/packages/server/src/modules/coding-agents/services/index.ts
+++ b/packages/server/src/modules/coding-agents/services/index.ts
@@ -1325,7 +1325,9 @@ function codexRuntimeUserConfig(...contents: Array<string | null | undefined>): 
   for (const content of contents) {
     if (!content?.trim()) continue
     let section = ''
-    for (const line of content.split(/\r?\n/)) {
+    const lines = content.split(/\r?\n/)
+    for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
+      const line = lines[lineIndex]
       const header = line.match(/^\s*\[([^\]]+)\]\s*$/)
       if (header) {
         section = header[1].trim()
@@ -1333,7 +1335,19 @@ function codexRuntimeUserConfig(...contents: Array<string | null | undefined>): 
       }
       const assignment = line.match(/^\s*([A-Za-z0-9_.-]+)\s*=/)
       if (!section) {
-        if (assignment && !runtimeKeys.has(assignment[1])) topLevel.set(assignment[1], line)
+        if (assignment && !runtimeKeys.has(assignment[1])) {
+          let mergedLine = line
+          let bracketDepth = (line.slice(line.indexOf('=') + 1).match(/\[/g) || []).length
+            - (line.slice(line.indexOf('=') + 1).match(/\]/g) || []).length
+          while (bracketDepth > 0 && lineIndex + 1 < lines.length) {
+            lineIndex += 1
+            const nextLine = lines[lineIndex]
+            mergedLine += `\n${nextLine}`
+            bracketDepth += (nextLine.match(/\[/g) || []).length
+              - (nextLine.match(/\]/g) || []).length
+          }
+          topLevel.set(assignment[1], mergedLine)
+        }
         continue
       }
       if (section === 'features') {
@@ -1350,9 +1364,9 @@ function codexRuntimeUserConfig(...contents: Array<string | null | undefined>): 
         || section === 'account'
         || section.startsWith('account.')
       ) continue
-      const lines = sections.get(section) || []
-      if (line.trim()) lines.push(line)
-      sections.set(section, lines)
+      const sectionLines = sections.get(section) || []
+      if (line.trim()) sectionLines.push(line)
+      sections.set(section, sectionLines)
     }
   }
 

--- a/tests/server/coding-agents-launch.test.ts
+++ b/tests/server/coding-agents-launch.test.ts
@@ -262,6 +262,47 @@ describe('coding agent launch preparation', () => {
     expect(config.slice(0, config.indexOf('\n['))).toContain('model = "codex-model"')
   })
 
+  it('keeps Codex array-of-table hooks out of the features table', async () => {
+    const home = makeHome()
+    const globalConfigPath = join(home, 'global-home', '.codex', 'config.toml')
+    mkdirSync(dirname(globalConfigPath), { recursive: true })
+    writeFileSync(globalConfigPath, [
+      '[features]',
+      'goals = true',
+      'hooks = true',
+      'js_repl = false',
+      '',
+      '[[hooks.SessionStart]]',
+      'matcher = "startup|resume|clear|compact"',
+      '',
+      '[[hooks.SessionStart.hooks]]',
+      'command = \'node "C:/Users/Lenovo/.agent-extensions/token-saver/agent-token-saver-hook.mjs"\'',
+      'timeout = 5',
+      'type = "command"',
+      '',
+    ].join('\n'))
+
+    const launch = await prepareCodingAgentLaunch('codex', {
+      profile: 'default',
+      provider: 'custom:test',
+      model: 'codex-model',
+      baseUrl: 'https://api.example.com/v1',
+      apiKey: 'test-key',
+      apiMode: 'codex_responses',
+      sessionId: 'codex-array-table-session',
+      agentSessionId: 'codex-array-table-agent-session',
+    })
+    const config = readFileSync(join(launch.rootDir, 'config.toml'), 'utf-8')
+    const featureIndex = config.indexOf('[features]')
+    const featureBlock = config.slice(featureIndex)
+
+    expect(config).toContain('[[hooks.SessionStart]]')
+    expect(config).toContain('[[hooks.SessionStart.hooks]]')
+    expect(featureBlock).toContain('goals = true')
+    expect(featureBlock).not.toContain('matcher = "startup|resume|clear|compact"')
+    expect(featureBlock).not.toContain('type = "command"')
+  })
+
   it('invalidates all scoped runtimes when a shared Coding Agent config changes', async () => {
     makeHome()
     const matched: string[] = []

--- a/tests/server/coding-agents-launch.test.ts
+++ b/tests/server/coding-agents-launch.test.ts
@@ -3,6 +3,7 @@ import { createCipheriv, randomBytes } from 'crypto'
 import { tmpdir } from 'os'
 import { dirname, join } from 'path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { parse as parseToml } from 'smol-toml'
 import { claudeProxyMessages, claudeProxyModels, registerClaudeCodeProxyTarget } from '../../packages/server/src/modules/coding-agents/services/claude-code/proxy'
 import {
   revokeCodexProxyTargets,
@@ -262,6 +263,100 @@ describe('coding agent launch preparation', () => {
     expect(config.slice(0, config.indexOf('\n['))).toContain('model = "codex-model"')
   })
 
+  it('preserves complete multiline top-level arrays when strings and comments contain brackets', async () => {
+    const home = makeHome()
+    const globalConfigPath = join(home, 'global-home', '.codex', 'config.toml')
+    mkdirSync(dirname(globalConfigPath), { recursive: true })
+    writeFileSync(globalConfigPath, [
+      'notify = [',
+      '  "first item contains ]",',
+      '  "second item", # comment contains [',
+      ']',
+      '',
+      '[features]',
+      'goals = true',
+      '',
+    ].join('\n'))
+
+    const launch = await prepareCodingAgentLaunch('codex', {
+      profile: 'default',
+      provider: 'custom:test',
+      model: 'codex-model',
+      baseUrl: 'https://api.example.com/v1',
+      apiKey: 'test-key',
+      apiMode: 'codex_responses',
+      sessionId: 'codex-multiline-array-session',
+      agentSessionId: 'codex-multiline-array-agent-session',
+    })
+    const config = readFileSync(join(launch.rootDir, 'config.toml'), 'utf-8')
+    const parsed = parseToml(config)
+
+    expect(parsed.notify).toEqual(['first item contains ]', 'second item'])
+    expect(config).toContain('  "second item", # comment contains [\n]')
+  })
+
+  it('preserves arrays containing multiline strings that end with a quote', async () => {
+    const home = makeHome()
+    const globalConfigPath = join(home, 'global-home', '.codex', 'config.toml')
+    mkdirSync(dirname(globalConfigPath), { recursive: true })
+    writeFileSync(globalConfigPath, [
+      'notify = [',
+      '  """first line contains ]',
+      'second line contains [ and ends with a quote"""",',
+      ']',
+      '',
+      '[features]',
+      'goals = true',
+      '',
+    ].join('\n'))
+
+    const launch = await prepareCodingAgentLaunch('codex', {
+      profile: 'default',
+      provider: 'custom:test',
+      model: 'codex-model',
+      baseUrl: 'https://api.example.com/v1',
+      apiKey: 'test-key',
+      apiMode: 'codex_responses',
+      sessionId: 'codex-multiline-string-array-session',
+      agentSessionId: 'codex-multiline-string-array-agent-session',
+    })
+    const config = readFileSync(join(launch.rootDir, 'config.toml'), 'utf-8')
+    const parsed = parseToml(config)
+
+    expect(parsed.notify).toEqual(['first line contains ]\nsecond line contains [ and ends with a quote"'])
+    expect(config).toContain('second line contains [ and ends with a quote"""",\n]')
+  })
+
+  it('preserves top-level multiline string values', async () => {
+    const home = makeHome()
+    const globalConfigPath = join(home, 'global-home', '.codex', 'config.toml')
+    mkdirSync(dirname(globalConfigPath), { recursive: true })
+    writeFileSync(globalConfigPath, [
+      'custom_instructions = """first line',
+      'second line contains [ and ]',
+      'third line"""',
+      '',
+      '[features]',
+      'goals = true',
+      '',
+    ].join('\n'))
+
+    const launch = await prepareCodingAgentLaunch('codex', {
+      profile: 'default',
+      provider: 'custom:test',
+      model: 'codex-model',
+      baseUrl: 'https://api.example.com/v1',
+      apiKey: 'test-key',
+      apiMode: 'codex_responses',
+      sessionId: 'codex-multiline-string-session',
+      agentSessionId: 'codex-multiline-string-agent-session',
+    })
+    const config = readFileSync(join(launch.rootDir, 'config.toml'), 'utf-8')
+    const parsed = parseToml(config)
+
+    expect(parsed.custom_instructions).toBe('first line\nsecond line contains [ and ]\nthird line')
+  })
+
   it('keeps Codex array-of-table hooks out of the features table', async () => {
     const home = makeHome()
     const globalConfigPath = join(home, 'global-home', '.codex', 'config.toml')
@@ -301,6 +396,36 @@ describe('coding agent launch preparation', () => {
     expect(featureBlock).toContain('goals = true')
     expect(featureBlock).not.toContain('matcher = "startup|resume|clear|compact"')
     expect(featureBlock).not.toContain('type = "command"')
+  })
+
+  it('preserves empty Codex array-of-table instances', async () => {
+    const home = makeHome()
+    const globalConfigPath = join(home, 'global-home', '.codex', 'config.toml')
+    mkdirSync(dirname(globalConfigPath), { recursive: true })
+    writeFileSync(globalConfigPath, [
+      '[[hooks.SessionStart]]',
+      '',
+      '[[hooks.SessionStart]]',
+      'matcher = "resume"',
+      '',
+    ].join('\n'))
+
+    const launch = await prepareCodingAgentLaunch('codex', {
+      profile: 'default',
+      provider: 'custom:test',
+      model: 'codex-model',
+      baseUrl: 'https://api.example.com/v1',
+      apiKey: 'test-key',
+      apiMode: 'codex_responses',
+      sessionId: 'codex-empty-array-table-session',
+      agentSessionId: 'codex-empty-array-table-agent-session',
+    })
+    const config = readFileSync(join(launch.rootDir, 'config.toml'), 'utf-8')
+
+    expect(config.match(/\[\[hooks\.SessionStart\]\]/g)).toHaveLength(2)
+    expect(parseToml(config)).toMatchObject({
+      hooks: { SessionStart: [{}, { matcher: 'resume' }] },
+    })
   })
 
   it('invalidates all scoped runtimes when a shared Coding Agent config changes', async () => {

--- a/tests/server/coding-agents-launch.test.ts
+++ b/tests/server/coding-agents-launch.test.ts
@@ -357,6 +357,39 @@ describe('coding agent launch preparation', () => {
     expect(parsed.custom_instructions).toBe('first line\nsecond line contains [ and ]\nthird line')
   })
 
+  it('does not treat table headers inside multiline strings as real sections', async () => {
+    const home = makeHome()
+    const globalConfigPath = join(home, 'global-home', '.codex', 'config.toml')
+    mkdirSync(dirname(globalConfigPath), { recursive: true })
+    writeFileSync(globalConfigPath, [
+      '[custom]',
+      'template = """first line',
+      '[features]',
+      'this remains string content',
+      '"""',
+      '',
+      '[features]',
+      'goals = true',
+      '',
+    ].join('\n'))
+
+    const launch = await prepareCodingAgentLaunch('codex', {
+      profile: 'default',
+      provider: 'custom:test',
+      model: 'codex-model',
+      baseUrl: 'https://api.example.com/v1',
+      apiKey: 'test-key',
+      apiMode: 'codex_responses',
+      sessionId: 'codex-multiline-table-string-session',
+      agentSessionId: 'codex-multiline-table-string-agent-session',
+    })
+    const parsed = parseToml(readFileSync(join(launch.rootDir, 'config.toml'), 'utf-8'))
+
+    expect(parsed.custom).toEqual({
+      template: 'first line\n[features]\nthis remains string content\n',
+    })
+  })
+
   it('keeps Codex array-of-table hooks out of the features table', async () => {
     const home = makeHome()
     const globalConfigPath = join(home, 'global-home', '.codex', 'config.toml')


### PR DESCRIPTION
## 问题

Hermes Studio 重建 Codex `config.toml` 时存在两个独立的配置合并问题：

1. 顶层多行数组（例如 `notify = [...]`）只保留首行，生成未闭合数组，导致 Codex 启动失败；
2. TOML `[[array-of-table]]` 表头未被识别。`[features]` 后的 `[[hooks.SessionStart]]` 和 `[[hooks.SessionStart.hooks]]` 被错误地当作仍在 `features` 表中，导致 Codex 报：

```text
invalid type: string "startup|resume|clear|compact", expected a boolean in `features`
```

## 修复

- 追踪顶层数组的方括号深度，将数组闭合前的后续行作为同一个值保留；
- 分别识别普通 `[table]` 与 `[[array-of-table]]`；
- 保留数组表的原始 `[[...]]` 表头；
- 每个数组表实例单独保留，避免多个 hook 实例互相覆盖；
- 普通表仍按表名合并；
- 不改变 Studio 管理的模型、provider 或 MCP 配置生成逻辑。

## 验证

- `node_modules/.bin/tsc --noEmit -p packages/server/tsconfig.json` 通过；
- 目标回归测试：`2 passed | 82 skipped`：
  - `keeps Studio-managed Codex settings at TOML root when user config contains tables`；
  - `keeps Codex array-of-table hooks out of the features table`；
- 新增测试在修复前按预期失败，修复后通过；
- 生成配置通过 Python `tomllib` 解析；
- Codex CLI `0.153.4` 对生成配置执行 `codex doctor`，配置项显示 `config loaded`，无 config failure；
- Windows Hermes Studio bundle 对应逻辑通过 `node --check`；
- `git diff --check` 通过。

完整 `coding-agents-launch.test.ts` 仍包含本机环境/fixture 相关失败，未将完整套件声称为全绿。

## 说明

本 PR 只修改 `codexRuntimeUserConfig` 的配置值和表块收集逻辑。生产安装目录的本地 bundle 修复已单独备份并验证；运行中的 Hermes Studio 尚未由维护者重启，因此端到端新会话验证需要重启后进行。
