### PR TITLE
fix(sessions): show Hermes Desktop history

### DIFF
--- a/packages/server/src/modules/studio/controllers/sessions.ts
+++ b/packages/server/src/modules/studio/controllers/sessions.ts
@@ -144,7 +144,7 @@ function denySessionAccess(ctx: any, session: any | null | undefined): boolean {
 }
 
 function isVisibleWebUiSessionSource(source?: string | null): boolean {
-  return source === 'api_server' || source === 'cli' || source === 'coding_agent' || source === 'global_agent'
+  return source === 'api_server' || source === 'cli' || source === 'desktop' || source === 'coding_agent' || source === 'global_agent'
 }
 
 function isRequestedSessionSource(source: string | undefined, sessionSource?: string | null): boolean {
@@ -158,7 +158,7 @@ function requestedSessionSources(source?: string): string[] {
   if (source === 'global_agent') return ['global_agent']
   if (source === 'workflow') return ['workflow']
   if (source === 'group_chat') return ['group_chat']
-  return ['api_server', 'cli', 'coding_agent', 'global_agent']
+  return ['api_server', 'cli', 'desktop', 'coding_agent', 'global_agent']
 }
 
 function isHermesHistorySessionSource(source?: string | null): boolean {

--- a/tests/server/sessions-controller.test.ts
+++ b/tests/server/sessions-controller.test.ts
@@ -931,6 +931,7 @@ describe('session conversations controller', () => {
         cost_status: '',
         preview: '',
       },
+      { id: 'desktop-session', profile: 'default', source: 'desktop' },
       {
         id: 'secret-session',
         profile: 'secret',
@@ -967,12 +968,12 @@ describe('session conversations controller', () => {
     await mod.list(ctx)
 
     expect(localListSessionsMock).toHaveBeenCalledWith(undefined, undefined, 2000, {
-      sources: ['api_server', 'cli', 'coding_agent', 'global_agent'],
+      sources: ['api_server', 'cli', 'desktop', 'coding_agent', 'global_agent'],
       profiles: ['default', 'travel'],
       includeArchived: false,
       excludeSessionIds: [],
     })
-    expect(ctx.body.sessions.map((session: any) => session.id)).toEqual(['default-session', 'travel-session'])
+    expect(ctx.body.sessions.map((session: any) => session.id)).toEqual(['default-session', 'travel-session', 'desktop-session'])
   })
 
   it('filters the single-chat session list when profile is explicitly provided', async () => {
@@ -987,7 +988,7 @@ describe('session conversations controller', () => {
     await mod.list(ctx)
 
     expect(localListSessionsMock).toHaveBeenCalledWith('travel', undefined, 2000, {
-      sources: ['api_server', 'cli', 'coding_agent', 'global_agent'],
+      sources: ['api_server', 'cli', 'desktop', 'coding_agent', 'global_agent'],
       profiles: undefined,
       includeArchived: false,
       excludeSessionIds: [],
@@ -1493,6 +1494,7 @@ describe('session conversations controller', () => {
     localSearchSessionsMock.mockReturnValue([
       { id: 'global-1', profile: 'default', source: 'global_agent' },
       { id: 'chat-1', profile: 'default', source: 'cli' },
+      { id: 'desktop-1', profile: 'travel', source: 'desktop' },
     ])
 
     const mod = await import('../../packages/server/src/modules/studio/controllers/sessions')
@@ -1504,7 +1506,7 @@ describe('session conversations controller', () => {
     await mod.search(ctx)
 
     expect(localSearchSessionsMock).toHaveBeenCalledWith(undefined, 'docker', 10, {
-      sources: ['api_server', 'cli', 'coding_agent', 'global_agent'],
+      sources: ['api_server', 'cli', 'desktop', 'coding_agent', 'global_agent'],
       profiles: ['default', 'travel'],
       includeArchived: false,
       excludeSessionIds: [],
@@ -1512,6 +1514,7 @@ describe('session conversations controller', () => {
     expect(ctx.body.results).toEqual([
       expect.objectContaining({ id: 'global-1', source: 'global_agent' }),
       expect.objectContaining({ id: 'chat-1', source: 'cli' }),
+      expect.objectContaining({ id: 'desktop-1', source: 'desktop' }),
     ])
   })
 


### PR DESCRIPTION
## Summary
- treat Hermes Agent sessions with `source=desktop` as visible single-chat sessions
- include Desktop sessions in both the default session list and session search source filters
- extend controller coverage for account-wide and explicit-profile listing plus search results

Fixes #2759

## Problem and root cause
Hermes Desktop writes sessions to the shared Hermes state database with `source=desktop`. Studio's single-chat controller only allowed `api_server`, `cli`, `coding_agent`, and `global_agent`, so Desktop rows were filtered before list/search results were returned.

## Approach and trade-offs
The existing visibility boundary remains intact for workflow and group-chat sessions. This change only adds the first-class `desktop` source to the two shared allowlists used by list and search; it does not alter persistence, import behavior, authentication, or other session-source semantics.

## Validation
- `npm run test -- tests/server/sessions-controller.test.ts` — passed (65 tests)
- sabotage run with the old source allowlists restored — failed the 3 updated controller assertions as expected
- `npm run harness:check` — passed
- `npm run test:e2e` — passed (177 tests)
- `npm run build` — passed
- `npm run test:coverage` — not green: 1 pre-existing/unrelated client TTS assertion failed on both attempts (`tests/client/use-speech-tts.test.ts`, cross-realm `Blob instanceof Blob`); 5,188 tests passed, 8 skipped

All commands used isolated temporary `HERMES_WEB_UI_HOME`, `HERMES_WEBUI_STATE_DIR`, and `UPLOAD_DIR` paths inside the worktree.

## Risk / compatibility
Low risk. The change broadens read visibility for an existing Hermes session source and leaves workflow/group-chat filtering unchanged. No schema, migration, API shape, or user data changes.

## Not covered
No manual official-Hermes-Desktop UI run was performed; controller tests exercise the exact list/search filtering path with `source=desktop` fixtures.

## AI assistance disclosure
This change was generated with AI assistance and was reviewed and validated against the repository's existing contribution and test guidance.
