### PR TITLE
[codex] support per-category session pagination for the App

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -15538,7 +15538,63 @@
         },
         "parameters": [
           {
+            "name": "category",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "none"
+                  ]
+                }
+              ]
+            },
+            "description": "Filter by category ID; none selects uncategorized sessions."
+          },
+          {
+            "name": "exclude",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "style": "form",
+            "explode": true,
+            "description": "Repeat this parameter for each session ID."
+          },
+          {
+            "name": "include",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "style": "form",
+            "explode": true,
+            "description": "Repeat this parameter for each session ID."
+          },
+          {
             "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "offset",
             "in": "query",
             "required": false,
             "schema": {

--- a/packages/server/src/modules/studio/controllers/sessions.ts
+++ b/packages/server/src/modules/studio/controllers/sessions.ts
@@ -474,23 +474,42 @@ export async function list(ctx: any) {
   const limit = ctx.query.limit ? parseInt(ctx.query.limit as string, 10) : undefined
   const profile = explicitProfileFilter(ctx)
   const effectiveLimit = limit && limit > 0 ? limit : 2000
+  const paginated = ctx.query.offset !== undefined
+  const requestedOffset = Number(ctx.query.offset)
+  const offset = Number.isSafeInteger(requestedOffset) && requestedOffset > 0 ? requestedOffset : 0
+  const category = ctx.query.category
+  const categoryId = category === 'none' ? null : category === undefined ? undefined : Number(category)
+  if (categoryId !== undefined && categoryId !== null && (!Number.isSafeInteger(categoryId) || categoryId <= 0)) {
+    ctx.status = 400
+    ctx.body = { error: 'category must be a positive integer or none' }
+    return
+  }
+  const readIds = (raw: unknown): string[] => (Array.isArray(raw) ? raw : raw ? [raw] : [])
+    .map(value => String(value).trim()).filter(Boolean)
+  const includedIds = ctx.query.include === undefined ? undefined : readIds(ctx.query.include)
+  const excludedIds = readIds(ctx.query.exclude)
 
   const knownProfiles = profile ? null : new Set(listProfileNamesFromDisk())
   const allowedProfiles = allowedProfileSet(ctx)
   const visibleProfiles = knownProfiles
     ? [...knownProfiles].filter(name => !allowedProfiles || allowedProfiles.has(name))
     : undefined
-  const allSessions = localListSessions(profile, source, effectiveLimit, {
+  const allSessions = localListSessions(profile, source, effectiveLimit + (paginated ? 1 : 0), {
+    ...(paginated ? { offset } : {}),
+    ...(categoryId !== undefined ? { categoryId } : {}),
+    ...(includedIds !== undefined ? { includeSessionIds: includedIds } : {}),
     sources: source ? undefined : requestedSessionSources(),
     profiles: visibleProfiles,
     includeArchived: false,
-    excludeSessionIds: [...getPendingDeletedSessionIds()],
+    excludeSessionIds: [...getPendingDeletedSessionIds(), ...excludedIds],
   })
-  ctx.body = {
-    sessions: filterPendingDeletedSessions(filterArchivedSessions(filterByAllowedProfiles(ctx, allSessions).filter(s =>
+  const sessions = filterPendingDeletedSessions(filterArchivedSessions(filterByAllowedProfiles(ctx, allSessions).filter(s =>
       isRequestedSessionSource(source, s.source) &&
       (!knownProfiles || knownProfiles.has(s.profile || 'default')),
-    ))),
+    )))
+  ctx.body = {
+    sessions: paginated ? sessions.slice(0, effectiveLimit) : sessions,
+    ...(paginated ? { hasMore: sessions.length > effectiveLimit, offset, limit: effectiveLimit } : {}),
   }
 }
 

--- a/packages/server/src/modules/studio/repositories/session-store.ts
+++ b/packages/server/src/modules/studio/repositories/session-store.ts
@@ -3,7 +3,7 @@
  * Uses the same ensureTable/getDb pattern as usage-store.ts.
  */
 import { isSqliteAvailable, getDb } from '../infrastructure/database'
-import { TASK_PLANS_TABLE, COMPRESSION_SNAPSHOT_TABLE, SESSIONS_TABLE, MESSAGES_TABLE } from '../infrastructure/database/schemas'
+import { TASK_PLANS_TABLE, COMPRESSION_SNAPSHOT_TABLE, SESSIONS_TABLE, MESSAGES_TABLE, SESSION_CATEGORIES_TABLE } from '../infrastructure/database/schemas'
 import { normalizeMessageContentForStorageRole } from './message-content'
 import { copyCompressionSnapshot } from './compression-snapshot'
 import { recordSkillUsageMessage } from './skill-usage-store'
@@ -77,6 +77,9 @@ export interface HermesSessionSearchRow extends HermesSessionRow {
 }
 
 export interface SessionListOptions {
+  offset?: number
+  categoryId?: number | null
+  includeSessionIds?: string[]
   sources?: string[]
   profiles?: string[]
   includeArchived?: boolean
@@ -562,11 +565,12 @@ export function listSessions(
     FROM ${SESSIONS_TABLE} s
     LEFT JOIN ${SESSIONS_TABLE} p ON p.id = s.parent_session_id
     WHERE ${filters.sql}
-    ORDER BY s.last_active DESC
-    LIMIT ?
+    ORDER BY s.last_active DESC, s.id DESC
+    LIMIT ? OFFSET ?
   `
 
-  const rows = db.prepare(sql).all(...filters.params, limit) as Record<string, unknown>[]
+  const offset = Number.isSafeInteger(options.offset) && options.offset! > 0 ? options.offset! : 0
+  const rows = db.prepare(sql).all(...filters.params, limit, offset) as Record<string, unknown>[]
   return rows.map(mapSessionRow)
 }
 
@@ -623,6 +627,18 @@ function sessionFilterSql(
   }
   if (options.includeArchived === false) {
     clauses.push('COALESCE(s.is_archived, 0) = 0')
+  }
+  if (options.categoryId === null) {
+    clauses.push(`(s.category_id IS NULL OR NOT EXISTS (SELECT 1 FROM ${SESSION_CATEGORIES_TABLE} c WHERE c.id = s.category_id))`)
+  } else if (options.categoryId !== undefined) {
+    clauses.push('s.category_id = ?')
+    params.push(String(options.categoryId))
+  }
+  if (options.includeSessionIds !== undefined) {
+    const includedIds = [...new Set(options.includeSessionIds.map(value => value.trim()).filter(Boolean))]
+    if (!includedIds.length) return null
+    clauses.push(`s.id IN (${includedIds.map(() => '?').join(', ')})`)
+    params.push(...includedIds)
   }
 
   const excludedIds = [...new Set((options.excludeSessionIds || []).map(value => value.trim()).filter(Boolean))]

--- a/scripts/generate-openapi.mjs
+++ b/scripts/generate-openapi.mjs
@@ -318,6 +318,19 @@ function addEndpoint(paths, method, path, controllerMethod, tagInfo, content, ma
   }
 
   const parameters = generateParameters(openapiPath, controllerSource)
+  if (openapiPath === '/api/studio/sessions' && method === 'get') {
+    for (const parameter of parameters) {
+      if (parameter.name === 'category') {
+        parameter.schema = { oneOf: [{ type: 'integer', minimum: 1 }, { type: 'string', enum: ['none'] }] }
+        parameter.description = 'Filter by category ID; none selects uncategorized sessions.'
+      } else if (parameter.name === 'include' || parameter.name === 'exclude') {
+        parameter.schema = { type: 'array', items: { type: 'string' } }
+        parameter.style = 'form'
+        parameter.explode = true
+        parameter.description = 'Repeat this parameter for each session ID.'
+      }
+    }
+  }
   if (parameters.length) operation.parameters = parameters
 
   const requestBody = generateRequestBody(method, controllerSource)

--- a/tests/server/session-store-search.test.ts
+++ b/tests/server/session-store-search.test.ts
@@ -107,6 +107,50 @@ describe('session store filtering', () => {
     expect(results[0]).toEqual(expect.objectContaining({ id: 'visible-chat', source: 'cli' }))
   })
 
+  it('paginates after visibility filters with stable ordering for equal activity times', async () => {
+    const { createSession, listSessions } = await import(
+      '../../packages/server/src/modules/studio/repositories/session-store'
+    )
+    for (const id of ['chat-a', 'chat-b', 'chat-c', 'archived', 'deleted']) {
+      createSession({ id, profile: 'default', source: 'cli' })
+    }
+    createSession({ id: 'other-profile', profile: 'travel', source: 'cli' })
+    createSession({ id: 'workflow', profile: 'default', source: 'workflow' })
+    db.prepare('UPDATE sessions SET last_active = 100').run()
+    db.prepare("UPDATE sessions SET is_archived = 1 WHERE id = 'archived'").run()
+    const options = {
+      profiles: ['default'], sources: ['cli'], includeArchived: false, excludeSessionIds: ['deleted'],
+    }
+    const first = listSessions(undefined, undefined, 2, options)
+    const second = listSessions(undefined, undefined, 2, { ...options, offset: 2 })
+    expect(first.map(session => session.id)).toEqual(['chat-c', 'chat-b'])
+    expect(second.map(session => session.id)).toEqual(['chat-a'])
+    expect(listSessions(undefined, undefined, 2, { ...options, offset: 3 })).toEqual([])
+  })
+
+  it('pages each category and pinned selection independently before applying the limit', async () => {
+    const { createSession, listSessions } = await import('../../packages/server/src/modules/studio/repositories/session-store')
+    const { createSessionCategory, setSessionCategory } = await import('../../packages/server/src/modules/studio/repositories/session-category-store')
+    const category = createSessionCategory('Work')
+    for (let index = 0; index < 25; index++) {
+      const id = `work-${String(index).padStart(2, '0')}`
+      createSession({ id, profile: 'default', source: 'cli' })
+      setSessionCategory(id, category.id)
+      createSession({ id: `none-${index}`, profile: 'default', source: 'cli' })
+    }
+    db.prepare('UPDATE sessions SET last_active = 100').run()
+    const options = { categoryId: category.id, excludeSessionIds: ['work-24'], includeArchived: false }
+    const first = listSessions(undefined, undefined, 10, options)
+    const next = listSessions(undefined, undefined, 10, { ...options, offset: 10 })
+    expect(first.map(row => row.id)).toEqual(Array.from({ length: 10 }, (_, i) => `work-${23 - i}`))
+    expect(next.map(row => row.id)).toEqual(Array.from({ length: 10 }, (_, i) => `work-${String(13 - i).padStart(2, '0')}`))
+    const none = listSessions(undefined, undefined, 10, { categoryId: null })
+    expect(none).toHaveLength(10)
+    expect(none.every(row => row.id.startsWith('none-'))).toBe(true)
+    expect(listSessions(undefined, undefined, 10, { includeSessionIds: ['work-24'] }).map(row => row.id)).toEqual(['work-24'])
+    expect(listSessions(undefined, undefined, 10, { includeSessionIds: [] })).toEqual([])
+  })
+
   it('updates display-only message content without changing model context content', async () => {
     const {
       addMessage,

--- a/tests/server/sessions-controller.test.ts
+++ b/tests/server/sessions-controller.test.ts
@@ -994,6 +994,61 @@ describe('session conversations controller', () => {
     })
   })
 
+  it('returns a single-chat page with a lookahead row without changing legacy list responses', async () => {
+    localListSessionsMock.mockReturnValue([
+      { id: 'chat-3', profile: 'travel', source: 'cli' },
+      { id: 'chat-2', profile: 'travel', source: 'cli' },
+      { id: 'chat-1', profile: 'travel', source: 'cli' },
+    ])
+    const mod = await import('../../packages/server/src/modules/studio/controllers/sessions')
+    const ctx: any = { query: { profile: 'travel', offset: '2', limit: '2' }, state: {}, body: null }
+    await mod.list(ctx)
+    expect(localListSessionsMock).toHaveBeenCalledWith('travel', undefined, 3, expect.objectContaining({ offset: 2 }))
+    expect(ctx.body).toEqual({
+      sessions: [
+        expect.objectContaining({ id: 'chat-3' }),
+        expect.objectContaining({ id: 'chat-2' }),
+      ],
+      hasMore: true, offset: 2, limit: 2,
+    })
+    localListSessionsMock.mockReturnValue([{ id: 'chat-1', profile: 'travel', source: 'cli' }])
+    ctx.query.offset = '4'
+    await mod.list(ctx)
+    expect(ctx.body).toMatchObject({ hasMore: false, offset: 4, limit: 2 })
+    delete ctx.query.offset
+    await mod.list(ctx)
+    expect(ctx.body).not.toHaveProperty('hasMore')
+  })
+
+  it.each(['-1', 'NaN', '1.5'])('normalizes invalid single-chat offsets (%s)', async (offset) => {
+    localListSessionsMock.mockReturnValue([])
+    const mod = await import('../../packages/server/src/modules/studio/controllers/sessions')
+    const ctx: any = { query: { offset, limit: '10' }, state: {}, body: null }
+    await mod.list(ctx)
+    expect(ctx.body).toEqual({ sessions: [], hasMore: false, offset: 0, limit: 10 })
+  })
+
+  it.each([['7', 7], ['none', null]])('passes category %s and pin filters into the paginated query', async (category, categoryId) => {
+    localListSessionsMock.mockReturnValue([])
+    const mod = await import('../../packages/server/src/modules/studio/controllers/sessions')
+    const ctx: any = { query: { category, offset: '10', limit: '10', exclude: ['pin-a', 'pin-b'] }, state: {}, body: null }
+    await mod.list(ctx)
+    expect(localListSessionsMock).toHaveBeenLastCalledWith(undefined, undefined, 11, expect.objectContaining({
+      categoryId, offset: 10, excludeSessionIds: ['pin-a', 'pin-b'],
+    }))
+    ctx.query = { include: 'pin-a', offset: '0', limit: '10' }
+    await mod.list(ctx)
+    expect(localListSessionsMock).toHaveBeenLastCalledWith(undefined, undefined, 11, expect.objectContaining({ includeSessionIds: ['pin-a'] }))
+  })
+
+  it.each(['invalid', '-1', '1.5'])('rejects invalid session category %s', async category => {
+    const mod = await import('../../packages/server/src/modules/studio/controllers/sessions')
+    const ctx: any = { query: { category, offset: '0' }, state: {}, body: null }
+    await mod.list(ctx)
+    expect(ctx.status).toBe(400)
+    expect(localListSessionsMock).not.toHaveBeenCalled()
+  })
+
   it('lists only global-agent sessions when requested by source', async () => {
     localListSessionsMock.mockReturnValue([
       { id: 'global-1', profile: 'default', source: 'global_agent' },


### PR DESCRIPTION
## Summary

The App session drawer needs to load each category independently, starting with 10 sessions and adding 10 at a time. The session-list endpoint previously only supported a single fixed-size list.

Add optional offset pagination and category filtering (including uncategorized sessions), plus session-ID inclusion/exclusion for the pinned group. Apply these filters before SQL pagination, use a stable ordering for equal activity times, and return `hasMore`, `offset`, and `limit` only when pagination is requested. Existing callers without an offset retain the previous response shape.

Update the OpenAPI generator and specification to document the new parameters. This PR changes the Studio backend only; the App implementation is in EKKOLearnAI/hermes-studio-app@50d2ed9 and requires this backend update.

## Validation

- `npm run test -- tests/server/sessions-controller.test.ts tests/server/session-store-search.test.ts` — 81 tests passed.
- `npm run harness:check` — passed.
- `npm run build` — passed.
- App pagination and session-switch tests passed; full App suite has two existing unrelated failures in theme initialization and manifest-version assertions.
