### PR TITLE
fix(tts): add Doubao speed control with profile settings sync

### DIFF
--- a/packages/client/src/components/hermes/chat/MessageItem.vue
+++ b/packages/client/src/components/hermes/chat/MessageItem.vue
@@ -778,6 +778,7 @@ function handleSpeechToggle() {
       model: voiceSettings.doubaoModel.value,
       voice: voiceSettings.doubaoVoice.value,
       stylePrompt: voiceSettings.doubaoStylePrompt.value || undefined,
+      speed: voiceSettings.doubaoSpeed.value || undefined,
     })
     return
   }
@@ -859,6 +860,7 @@ onMounted(() => {
           model: voiceSettings.doubaoModel.value,
           voice: voiceSettings.doubaoVoice.value,
           stylePrompt: voiceSettings.doubaoStylePrompt.value || undefined,
+          speed: voiceSettings.doubaoSpeed.value || undefined,
         }).catch(handleAutoplayTtsError)
       } else if (isServerTtsProvider(voiceSettings.provider.value)) {
         void speech.openaiPlay(props.message.id, content, {

--- a/packages/client/src/components/hermes/chat/RealtimeVoiceStage.vue
+++ b/packages/client/src/components/hermes/chat/RealtimeVoiceStage.vue
@@ -337,6 +337,7 @@ function currentSynthesisRequest(text: string, signal: AbortSignal) {
         model: voiceSettings.doubaoModel.value,
         voice: voiceSettings.doubaoVoice.value,
         stylePrompt: voiceSettings.doubaoStylePrompt.value || undefined,
+        speed: voiceSettings.doubaoSpeed.value || undefined,
       },
     })
   }

--- a/packages/client/src/components/hermes/group-chat/GroupMessageItem.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupMessageItem.vue
@@ -549,6 +549,7 @@ function playSpeech(content: string, autoplay = false, profileOverride = '') {
             model: voiceSettings.doubaoModel.value,
             voice: voiceSettings.doubaoVoice.value,
             stylePrompt: voiceSettings.doubaoStylePrompt.value || undefined,
+            speed: voiceSettings.doubaoSpeed.value || undefined,
         }
         if (autoplay) void speech.openaiPlay(props.message.id, content, options).catch(handleAutoplayTtsError)
         else speech.openaiToggle(props.message.id, content, options)

--- a/packages/client/src/components/hermes/settings/VoiceSettings.vue
+++ b/packages/client/src/components/hermes/settings/VoiceSettings.vue
@@ -175,6 +175,7 @@ function openaiOptionsFor(connection: VoiceApiConnection): OpenaiTtsOptions {
     pitch: connection.provider === 'edge' && Number.isFinite(edgePitch)
       ? hzToEdgePitch(edgePitch)
       : typeof options.pitch === 'string' ? options.pitch : undefined,
+    speed: typeof options.speed === 'string' || typeof options.speed === 'number' ? options.speed : undefined,
     stylePrompt: typeof options.stylePrompt === 'string' ? options.stylePrompt : undefined,
     provider,
   }

--- a/packages/client/src/composables/useSpeech.ts
+++ b/packages/client/src/composables/useSpeech.ts
@@ -19,6 +19,7 @@ export interface OpenaiTtsOptions {
   voice?: string
   rate?: string   // Edge TTS rate format, e.g. "+20%"
   pitch?: string  // Edge TTS pitch format, e.g. "-8Hz"
+  speed?: string | number
   stylePrompt?: string
   provider?: Exclude<TtsProviderId, 'mimo'>
 }

--- a/packages/client/src/composables/useVoiceApiConnections.ts
+++ b/packages/client/src/composables/useVoiceApiConnections.ts
@@ -132,7 +132,7 @@ export function useVoiceApiConnections() {
       vs.setDoubaoModel(connection.model || stringSetting(settings, 'model') || vs.doubaoModel.value)
       vs.setDoubaoVoice(connection.voice || stringSetting(settings, 'voice') || vs.doubaoVoice.value)
       vs.setDoubaoStylePrompt(stringSetting(settings, 'stylePrompt'))
-      vs.setDoubaoSpeed(stringSetting(settings, 'speed') || vs.doubaoSpeed.value)
+      vs.setDoubaoSpeed(stringSetting(settings, 'speed').trim() || '1')
     }
   }
 

--- a/packages/client/src/composables/useVoiceApiConnections.ts
+++ b/packages/client/src/composables/useVoiceApiConnections.ts
@@ -132,6 +132,7 @@ export function useVoiceApiConnections() {
       vs.setDoubaoModel(connection.model || stringSetting(settings, 'model') || vs.doubaoModel.value)
       vs.setDoubaoVoice(connection.voice || stringSetting(settings, 'voice') || vs.doubaoVoice.value)
       vs.setDoubaoStylePrompt(stringSetting(settings, 'stylePrompt'))
+      vs.setDoubaoSpeed(stringSetting(settings, 'speed') || vs.doubaoSpeed.value)
     }
   }
 

--- a/packages/client/src/composables/useVoiceSettings.ts
+++ b/packages/client/src/composables/useVoiceSettings.ts
@@ -58,6 +58,7 @@ export interface VoiceSettingsData {
   doubaoModel: string
   doubaoVoice: string
   doubaoStylePrompt: string
+  doubaoSpeed: string
 }
 
 const STORAGE_KEY = 'hermes-tts-settings-v2'
@@ -119,6 +120,7 @@ const DEFAULT: VoiceSettingsData = {
   doubaoModel: DOUBAO_TTS_2_RESOURCE_ID,
   doubaoVoice: DOUBAO_TTS_DEFAULT_VOICE,
   doubaoStylePrompt: '',
+  doubaoSpeed: '1',
 }
 
 function sanitize(data: VoiceSettingsData): VoiceSettingsData {
@@ -231,6 +233,7 @@ const doubaoBaseUrl = ref<string>(load().doubaoBaseUrl)
 const doubaoModel = ref<string>(load().doubaoModel)
 const doubaoVoice = ref<string>(load().doubaoVoice)
 const doubaoStylePrompt = ref<string>(load().doubaoStylePrompt)
+const doubaoSpeed = ref<string>(load().doubaoSpeed)
 
 // Auto-persist on change
 watch(
@@ -238,7 +241,7 @@ watch(
    customUrl, customApiKey, edgeUrl, edgeVoice, edgeRate, edgePitchHz,
    mimoApiKey, mimoAuthMode, mimoBaseUrl, mimoModel, mimoVoice, mimoVoiceDesignDesc,
    mimoVoiceCloneDataUri, mimoVoiceCloneFileName, mimoVoiceCloneFormat, mimoStylePrompt,
-   doubaoApiKey, doubaoBaseUrl, doubaoModel, doubaoVoice, doubaoStylePrompt],
+   doubaoApiKey, doubaoBaseUrl, doubaoModel, doubaoVoice, doubaoStylePrompt, doubaoSpeed],
   () => {
     try {
       localStorage.setItem(STORAGE_KEY, JSON.stringify({
@@ -269,6 +272,7 @@ watch(
         doubaoModel: doubaoModel.value,
         doubaoVoice: doubaoVoice.value,
         doubaoStylePrompt: doubaoStylePrompt.value,
+        doubaoSpeed: doubaoSpeed.value,
       }))
     } catch (err) {
       console.warn('[useVoiceSettings] Failed to persist voice settings:', err)
@@ -305,6 +309,7 @@ export function useVoiceSettings() {
     doubaoModel,
     doubaoVoice,
     doubaoStylePrompt,
+    doubaoSpeed,
 
     loadServerTtsSettings,
 
@@ -335,6 +340,7 @@ export function useVoiceSettings() {
     setDoubaoModel(v: string) { doubaoModel.value = v },
     setDoubaoVoice(v: string) { doubaoVoice.value = v },
     setDoubaoStylePrompt(v: string) { doubaoStylePrompt.value = v },
+    setDoubaoSpeed(v: string) { doubaoSpeed.value = v },
 
     reset() {
       provider.value = DEFAULT.provider
@@ -364,6 +370,7 @@ export function useVoiceSettings() {
       doubaoModel.value = DEFAULT.doubaoModel
       doubaoVoice.value = DEFAULT.doubaoVoice
       doubaoStylePrompt.value = DEFAULT.doubaoStylePrompt
+      doubaoSpeed.value = DEFAULT.doubaoSpeed
     },
   }
 }

--- a/packages/client/src/composables/useVoiceSettings.ts
+++ b/packages/client/src/composables/useVoiceSettings.ts
@@ -164,6 +164,8 @@ function applyServerTtsSettings(response: FetchTtsSettingsResponse) {
   if (response.activeProvider) {
     provider.value = response.activeProvider
   }
+  const doubao = response.providers.find(row => row.provider === 'doubao')
+  doubaoSpeed.value = doubao?.settings.speed?.trim() || DEFAULT.doubaoSpeed
 }
 
 export async function loadServerTtsSettings(force = false): Promise<void> {

--- a/packages/client/src/constants/voiceApiPresets.ts
+++ b/packages/client/src/constants/voiceApiPresets.ts
@@ -163,6 +163,7 @@ export const VOICE_API_PRESETS: VoiceApiPreset[] = [
       models: true,
       voices: true,
       stylePrompt: true,
+      speed: true,
     },
   },
   {

--- a/packages/server/src/modules/studio/services/voice/tts/providers/doubao.ts
+++ b/packages/server/src/modules/studio/services/voice/tts/providers/doubao.ts
@@ -63,17 +63,28 @@ function resolveSampleRate(opts: DoubaoTtsProviderOptions): number {
   return sampleRate
 }
 
+function resolveSpeechRate(speed: string | number | undefined): number | undefined {
+  if (speed === undefined || speed === null || String(speed).trim() === '') return undefined
+  const multiplier = Number(speed)
+  if (!Number.isFinite(multiplier) || multiplier < 0.5 || multiplier > 2) {
+    throw new Error('Doubao TTS speed must be between 0.5 and 2')
+  }
+  return Math.round((multiplier - 1) * 100)
+}
+
 function buildRequestBody(text: string, opts: DoubaoTtsProviderOptions): Record<string, unknown> {
   const speaker = trimOptional(opts.voice) || DEFAULT_SPEAKER
   const prompt = trimOptional(opts.stylePrompt)
   const format = resolveAudioFormat(opts)
   const sampleRate = resolveSampleRate(opts)
+  const speechRate = resolveSpeechRate(opts.speed)
   const reqParams: Record<string, unknown> = {
     text,
     speaker,
     audio_params: {
       format,
       sample_rate: sampleRate,
+      ...(speechRate === undefined ? {} : { speech_rate: speechRate }),
     },
   }
 

--- a/packages/server/src/modules/studio/services/voice/tts/providers/types.ts
+++ b/packages/server/src/modules/studio/services/voice/tts/providers/types.ts
@@ -80,6 +80,7 @@ export interface DoubaoTtsProviderOptions {
   model?: string
   voice?: string
   stylePrompt?: string
+  speed?: string | number
   format?: string
   sampleRate?: number
   sample_rate?: number

--- a/tests/client/use-voice-settings-doubao.test.ts
+++ b/tests/client/use-voice-settings-doubao.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+import { beforeEach, expect, it, vi } from 'vitest'
+
+const api = vi.hoisted(() => ({
+  fetchTtsSettings: vi.fn(),
+  saveActiveTtsProvider: vi.fn(),
+  getActiveProfileName: vi.fn(() => 'default'),
+}))
+vi.mock('@/api/studio/tts-settings', () => api)
+vi.mock('@/api/client', () => ({
+  hasApiKey: () => true,
+  getStoredUserId: () => 7,
+  getActiveProfileName: api.getActiveProfileName,
+}))
+vi.mock('@/api/studio/stt-settings', () => ({
+  fetchSttSettings: async () => ({ activeProvider: 'browser', providers: [] }),
+}))
+vi.mock('@/composables/useSttSettings', () => ({
+  useSttSettings: () => ({ provider: { value: 'browser' }, loadServerSttSettings: async () => {}, setProvider: () => {} }),
+}))
+vi.mock('@/composables/useLocalSttModel', () => ({ useLocalSttModel: () => ({ refresh: async () => null }) }))
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (key: string) => key }) }))
+
+beforeEach(() => {
+  vi.resetModules()
+  localStorage.clear()
+  api.getActiveProfileName.mockReturnValue('default')
+  api.saveActiveTtsProvider.mockResolvedValue('doubao')
+})
+
+it('uses server Doubao speed on a fresh client', async () => {
+  api.fetchTtsSettings.mockResolvedValue({
+    activeProvider: 'doubao',
+    providers: [{ provider: 'doubao', settings: { speed: '0.5' }, secrets: {} }],
+  })
+  const { useVoiceSettings, loadServerTtsSettings } = await import('@/composables/useVoiceSettings')
+  await loadServerTtsSettings()
+  const settings = useVoiceSettings()
+  expect(settings.provider.value).toBe('doubao')
+  expect(settings.doubaoSpeed.value).toBe('0.5')
+})
+
+it('resets stale local speed when activating a profile with no configured speed', async () => {
+  api.fetchTtsSettings.mockResolvedValue({
+    activeProvider: 'doubao',
+    providers: [{ provider: 'doubao', settings: {}, secrets: {} }],
+  })
+  const { useVoiceSettings } = await import('@/composables/useVoiceSettings')
+  const settings = useVoiceSettings()
+  settings.setDoubaoSpeed('0.5')
+  const { useVoiceApiConnections } = await import('@/composables/useVoiceApiConnections')
+  const connections = useVoiceApiConnections()
+  await connections.refresh()
+  await connections.setActiveConnection('tts', 'tts-doubao')
+  expect(settings.doubaoSpeed.value).toBe('1')
+})
+
+it('replaces persisted speed with the current profile speed and resets absent settings', async () => {
+  localStorage.setItem('hermes-tts-settings-v2', JSON.stringify({ doubaoSpeed: '1.8' }))
+  api.fetchTtsSettings
+    .mockResolvedValueOnce({
+      activeProvider: 'doubao',
+      providers: [{ provider: 'doubao', settings: { speed: '0.5' }, secrets: {} }],
+    })
+    .mockResolvedValueOnce({
+      activeProvider: 'doubao',
+      providers: [{ provider: 'doubao', settings: {}, secrets: {} }],
+    })
+    .mockResolvedValueOnce({ activeProvider: 'edge', providers: [] })
+  const { useVoiceSettings, loadServerTtsSettings } = await import('@/composables/useVoiceSettings')
+  const settings = useVoiceSettings()
+  await loadServerTtsSettings()
+  expect(settings.doubaoSpeed.value).toBe('0.5')
+  api.getActiveProfileName.mockReturnValue('work')
+  await loadServerTtsSettings()
+  expect(settings.doubaoSpeed.value).toBe('1')
+  settings.setDoubaoSpeed('0.7')
+  api.getActiveProfileName.mockReturnValue('personal')
+  await loadServerTtsSettings()
+  expect(settings.doubaoSpeed.value).toBe('1')
+})

--- a/tests/server/doubao-tts-provider.test.ts
+++ b/tests/server/doubao-tts-provider.test.ts
@@ -61,6 +61,31 @@ describe('doubaoTtsProvider', () => {
     })
   })
 
+  it('passes the configured speed to Doubao audio parameters', async () => {
+    const audio = Buffer.from('mp3-audio')
+    mockFetch.mockResolvedValueOnce(textResponse(JSON.stringify({
+      data: audio.toString('base64'),
+    })))
+
+    await doubaoTtsProvider.synthesize(
+      { text: '慢一点说。' },
+      { apiKey: 'secret', speed: 0.5 },
+    )
+
+    expect(getJsonBody().req_params.audio_params).toMatchObject({
+      speech_rate: -50,
+    })
+  })
+
+  it('rejects speeds outside Doubao limits before calling the provider', async () => {
+    await expect(doubaoTtsProvider.synthesize(
+      { text: '太快了。' },
+      { apiKey: 'secret', speed: 2.1 },
+    )).rejects.toThrow('Doubao TTS speed must be between 0.5 and 2')
+
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
   it('overrides audio format and sample rate when requested for MCU playback', async () => {
     const pcm = Buffer.from('pcm-audio')
     mockFetch.mockResolvedValueOnce(textResponse(JSON.stringify({


### PR DESCRIPTION
## Summary

Add a 0.5–2x speed control for Doubao TTS and pass it through preview, chat read-aloud, and realtime voice synthesis as Doubao's `speech_rate` parameter.

Hydrate the speed from the current profile's server settings on login and profile changes. A fresh client now uses the saved 0.5x speed instead of overriding it with its local 1x default. Activating a profile without a configured speed resets the local value to 1x instead of retaining the previous profile's speed.

Includes the original implementation from #2957 plus the settings synchronization fix and three regression tests.

Closes #2954
Refs #2957

## Validation

- Focused Vitest: 8 files, 93 tests passed (Doubao provider, TTS controller, voice settings, hydration, connections, speech playback, and dialogue controls).
- `PLAYWRIGHT_PORT=43257 PLAYWRIGHT_CHANNEL=chrome npx playwright test tests/e2e/voice-dialogue.spec.ts --workers=1`: 1 passed using isolated state and ports.
- `npm run harness:check`: passed.
- `npm run build`: passed.
- `git diff --check`: passed.
- No live Doubao API call; provider requests are mocked in tests.
