### PR TITLE
fix(desktop): preserve existing profile across Ekko Studio rename

### DIFF
--- a/packages/desktop/src/main/desktop-identity.ts
+++ b/packages/desktop/src/main/desktop-identity.ts
@@ -1,0 +1,9 @@
+import type { App } from 'electron'
+
+export function configureDesktopIdentity(app: Pick<App, 'getPath' | 'setPath' | 'setName'>) {
+  // Electron derives this path from package.json's name, not the installer display
+  // name. Pin the existing profile before changing the name used by the UI.
+  const existingUserData = app.getPath('userData')
+  app.setPath('userData', existingUserData)
+  app.setName('Ekko Studio')
+}

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -48,13 +48,9 @@ import { BrowserBroker } from './browser/browser-broker'
 import type { BrowserBounds } from './browser/browser-types'
 import { migratePendingLegacyWindowsData } from './legacy-windows-data-migration'
 import { createDesktopAppLifecycle } from './app-lifecycle'
+import { configureDesktopIdentity } from './desktop-identity'
 
-// Keep the existing Chromium profile (cookies and browser storage) across the rename.
-const existingUserData = app.isPackaged
-  ? join(app.getPath('appData'), 'Hermes Studio')
-  : app.getPath('userData')
-app.setPath('userData', existingUserData)
-app.setName('Ekko Studio')
+configureDesktopIdentity(app)
 
 const PORT = Number(process.env.HERMES_DESKTOP_PORT) || 8748
 const START_HIDDEN = process.argv.includes('--hidden')

--- a/tests/desktop/desktop-identity.test.ts
+++ b/tests/desktop/desktop-identity.test.ts
@@ -1,0 +1,46 @@
+import { posix, win32 } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { configureDesktopIdentity } from '../../packages/desktop/src/main/desktop-identity'
+
+describe('desktop identity across the Ekko Studio rename', () => {
+  it.each([
+    { platform: 'macOS', paths: posix, appData: '/Users/test/Library/Application Support' },
+    { platform: 'Windows', paths: win32, appData: 'C:\\Users\\test\\AppData\\Roaming' },
+    { platform: 'Linux', paths: posix, appData: '/home/test/.config' },
+  ])('keeps the existing $platform Chromium profile after changing the display name', ({ paths, appData }) => {
+    let name = 'hermes-studio'
+    let pinnedUserData: string | undefined
+    const app = {
+      getPath: (key: string) => {
+        if (key !== 'userData') throw new Error(`Unexpected path: ${key}`)
+        return pinnedUserData ?? paths.join(appData, name)
+      },
+      setPath: (key: string, value: string) => {
+        if (key !== 'userData') throw new Error(`Unexpected path: ${key}`)
+        pinnedUserData = value
+      },
+      setName: (value: string) => { name = value },
+    }
+    const oldProfile = paths.join(appData, 'hermes-studio')
+
+    configureDesktopIdentity(app)
+
+    expect(name).toBe('Ekko Studio')
+    expect(app.getPath('userData')).toBe(oldProfile)
+    configureDesktopIdentity(app)
+    expect(app.getPath('userData')).toBe(oldProfile)
+  })
+
+  it('preserves an explicitly configured profile path', () => {
+    let userData = '/custom/studio-profile'
+    const app = {
+      getPath: () => userData,
+      setPath: (_key: string, value: string) => { userData = value },
+      setName: () => {},
+    }
+
+    configureDesktopIdentity(app)
+
+    expect(userData).toBe('/custom/studio-profile')
+  })
+})


### PR DESCRIPTION
## Summary
- Packaged desktop upgrades currently force Chromium storage into `Hermes Studio`, but the installed app uses `hermes-studio` from its package metadata. This makes existing cookies and local storage appear missing after the Ekko Studio rename.
- Preserve Electron's existing `userData` path before setting the display name to `Ekko Studio`, including custom profile paths. Application IDs, updater URLs, and Web UI data paths stay compatible.
- Add regression coverage for macOS, Windows, Linux, and an explicitly configured profile directory.

## Validation
- `npm run test -- tests/desktop`: 184 passed, 1 skipped.
- `npm run harness:check`: passed.
- `npm run build`: passed.
- `npm run build:main --prefix packages/desktop`: passed.
- Confirmed the installed macOS app's package metadata uses `name: hermes-studio` and its existing Chromium profile is under `~/Library/Application Support/hermes-studio`.
- A signed old-to-new installer or automatic update has not been exercised; platform coverage here is unit-level path behavior.
