### PR TITLE
fix: return total session counts for category pagination

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -15527,7 +15527,42 @@
         ],
         "responses": {
           "200": {
-            "description": "Success"
+            "description": "Session list. Supplying offset also returns pagination metadata and the total matching the same visibility, category, and include/exclude filters before pagination.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "sessions"
+                  ],
+                  "properties": {
+                    "sessions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    },
+                    "total": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "description": "Total matching sessions, independent of offset and limit. Present when offset is supplied."
+                    },
+                    "hasMore": {
+                      "type": "boolean"
+                    },
+                    "offset": {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "limit": {
+                      "type": "integer",
+                      "minimum": 1
+                    }
+                  }
+                }
+              }
+            }
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"

--- a/packages/server/src/modules/studio/controllers/sessions.ts
+++ b/packages/server/src/modules/studio/controllers/sessions.ts
@@ -15,6 +15,7 @@ import {
 } from '../public/session-agent-runtime'
 import {
   listSessions as localListSessions,
+  countSessions as localCountSessions,
   searchSessions as localSearchSessions,
   getSession as localGetSession,
   getSessionDetail as localGetSessionDetail,
@@ -494,14 +495,17 @@ export async function list(ctx: any) {
   const visibleProfiles = knownProfiles
     ? [...knownProfiles].filter(name => !allowedProfiles || allowedProfiles.has(name))
     : undefined
-  const allSessions = localListSessions(profile, source, effectiveLimit + (paginated ? 1 : 0), {
-    ...(paginated ? { offset } : {}),
+  const listOptions = {
     ...(categoryId !== undefined ? { categoryId } : {}),
     ...(includedIds !== undefined ? { includeSessionIds: includedIds } : {}),
     sources: source ? undefined : requestedSessionSources(),
     profiles: visibleProfiles,
     includeArchived: false,
     excludeSessionIds: [...getPendingDeletedSessionIds(), ...excludedIds],
+  }
+  const allSessions = localListSessions(profile, source, effectiveLimit + (paginated ? 1 : 0), {
+    ...listOptions,
+    ...(paginated ? { offset } : {}),
   })
   const sessions = filterPendingDeletedSessions(filterArchivedSessions(filterByAllowedProfiles(ctx, allSessions).filter(s =>
       isRequestedSessionSource(source, s.source) &&
@@ -509,7 +513,11 @@ export async function list(ctx: any) {
     )))
   ctx.body = {
     sessions: paginated ? sessions.slice(0, effectiveLimit) : sessions,
-    ...(paginated ? { hasMore: sessions.length > effectiveLimit, offset, limit: effectiveLimit } : {}),
+    ...(paginated ? {
+      hasMore: sessions.length > effectiveLimit, offset, limit: effectiveLimit,
+      total: profile && allowedProfiles && !allowedProfiles.has(profile)
+        ? 0 : localCountSessions(profile, source, listOptions),
+    } : {}),
   }
 }
 

--- a/packages/server/src/modules/studio/repositories/session-store.ts
+++ b/packages/server/src/modules/studio/repositories/session-store.ts
@@ -574,6 +574,19 @@ export function listSessions(
   return rows.map(mapSessionRow)
 }
 
+export function countSessions(
+  profile?: string,
+  source?: string,
+  options: SessionListOptions = {},
+): number {
+  if (!isSqliteAvailable()) return 0
+  const filters = sessionFilterSql(profile, source ? { ...options, sources: [source] } : options)
+  if (!filters) return 0
+  const row = getDb()!.prepare(`SELECT COUNT(*) AS total FROM ${SESSIONS_TABLE} s WHERE ${filters.sql}`)
+    .get(...filters.params) as { total: number }
+  return Number(row.total)
+}
+
 function escapeSessionSearchLike(value: string): string {
   return value.replace(/[\\%_]/g, '\\$&')
 }

--- a/scripts/generate-openapi.mjs
+++ b/scripts/generate-openapi.mjs
@@ -319,6 +319,23 @@ function addEndpoint(paths, method, path, controllerMethod, tagInfo, content, ma
 
   const parameters = generateParameters(openapiPath, controllerSource)
   if (openapiPath === '/api/studio/sessions' && method === 'get') {
+    operation.responses['200'] = {
+      description: 'Session list. Supplying offset also returns pagination metadata and the total matching the same visibility, category, and include/exclude filters before pagination.',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object', required: ['sessions'],
+            properties: {
+              sessions: { type: 'array', items: { type: 'object', additionalProperties: true } },
+              total: { type: 'integer', minimum: 0, description: 'Total matching sessions, independent of offset and limit. Present when offset is supplied.' },
+              hasMore: { type: 'boolean' },
+              offset: { type: 'integer', minimum: 0 },
+              limit: { type: 'integer', minimum: 1 },
+            },
+          },
+        },
+      },
+    }
     for (const parameter of parameters) {
       if (parameter.name === 'category') {
         parameter.schema = { oneOf: [{ type: 'integer', minimum: 1 }, { type: 'string', enum: ['none'] }] }

--- a/tests/server/session-store-search.test.ts
+++ b/tests/server/session-store-search.test.ts
@@ -108,7 +108,7 @@ describe('session store filtering', () => {
   })
 
   it('paginates after visibility filters with stable ordering for equal activity times', async () => {
-    const { createSession, listSessions } = await import(
+    const { createSession, listSessions, countSessions } = await import(
       '../../packages/server/src/modules/studio/repositories/session-store'
     )
     for (const id of ['chat-a', 'chat-b', 'chat-c', 'archived', 'deleted']) {
@@ -126,10 +126,13 @@ describe('session store filtering', () => {
     expect(first.map(session => session.id)).toEqual(['chat-c', 'chat-b'])
     expect(second.map(session => session.id)).toEqual(['chat-a'])
     expect(listSessions(undefined, undefined, 2, { ...options, offset: 3 })).toEqual([])
+    expect(countSessions(undefined, undefined, { ...options, offset: 100 })).toBe(3)
+    expect(countSessions(undefined, undefined, { ...options, profiles: [] })).toBe(0)
+    expect(countSessions('travel', 'cli', { includeArchived: false })).toBe(1)
   })
 
   it('pages each category and pinned selection independently before applying the limit', async () => {
-    const { createSession, listSessions } = await import('../../packages/server/src/modules/studio/repositories/session-store')
+    const { createSession, listSessions, countSessions } = await import('../../packages/server/src/modules/studio/repositories/session-store')
     const { createSessionCategory, setSessionCategory } = await import('../../packages/server/src/modules/studio/repositories/session-category-store')
     const category = createSessionCategory('Work')
     for (let index = 0; index < 25; index++) {
@@ -149,6 +152,13 @@ describe('session store filtering', () => {
     expect(none.every(row => row.id.startsWith('none-'))).toBe(true)
     expect(listSessions(undefined, undefined, 10, { includeSessionIds: ['work-24'] }).map(row => row.id)).toEqual(['work-24'])
     expect(listSessions(undefined, undefined, 10, { includeSessionIds: [] })).toEqual([])
+    expect(countSessions(undefined, undefined, options)).toBe(24)
+    expect(countSessions(undefined, undefined, { ...options, offset: 20 })).toBe(24)
+    expect(countSessions(undefined, undefined, { categoryId: null })).toBe(25)
+    expect(countSessions(undefined, undefined, { includeSessionIds: ['work-24', 'missing'] })).toBe(1)
+    expect(countSessions(undefined, undefined, { includeSessionIds: [] })).toBe(0)
+    db.prepare("UPDATE sessions SET category_id = 999 WHERE id = 'work-00'").run()
+    expect(countSessions(undefined, undefined, { categoryId: null })).toBe(26)
   })
 
   it('updates display-only message content without changing model context content', async () => {

--- a/tests/server/sessions-controller.test.ts
+++ b/tests/server/sessions-controller.test.ts
@@ -16,6 +16,7 @@ const getUsageStatsFromDbMock = vi.fn()
 const getSessionMock = vi.fn()
 const deleteHermesSessionForProfileMock = vi.fn()
 const localListSessionsMock = vi.fn()
+const localCountSessionsMock = vi.fn()
 const localGetSessionDetailMock = vi.fn()
 const localSearchSessionsMock = vi.fn()
 const localDeleteSessionMock = vi.fn()
@@ -95,6 +96,7 @@ vi.mock('../../packages/server/src/modules/hermes/services/history/sessions-db',
 
 vi.mock('../../packages/server/src/modules/studio/repositories/session-store', () => ({
   listSessions: localListSessionsMock,
+  countSessions: localCountSessionsMock,
   searchSessions: localSearchSessionsMock,
   getSessionDetail: localGetSessionDetailMock,
   deleteSession: localDeleteSessionMock,
@@ -258,6 +260,7 @@ describe('session conversations controller', () => {
     getSessionMock.mockReset()
     deleteHermesSessionForProfileMock.mockReset()
     localListSessionsMock.mockReset()
+    localCountSessionsMock.mockReset().mockReturnValue(0)
     localGetSessionDetailMock.mockReset()
     localSearchSessionsMock.mockReset()
     localDeleteSessionMock.mockReset()
@@ -995,6 +998,7 @@ describe('session conversations controller', () => {
   })
 
   it('returns a single-chat page with a lookahead row without changing legacy list responses', async () => {
+    localCountSessionsMock.mockReturnValue(5)
     localListSessionsMock.mockReturnValue([
       { id: 'chat-3', profile: 'travel', source: 'cli' },
       { id: 'chat-2', profile: 'travel', source: 'cli' },
@@ -1009,15 +1013,18 @@ describe('session conversations controller', () => {
         expect.objectContaining({ id: 'chat-3' }),
         expect.objectContaining({ id: 'chat-2' }),
       ],
-      hasMore: true, offset: 2, limit: 2,
+      hasMore: true, offset: 2, limit: 2, total: 5,
     })
     localListSessionsMock.mockReturnValue([{ id: 'chat-1', profile: 'travel', source: 'cli' }])
     ctx.query.offset = '4'
     await mod.list(ctx)
-    expect(ctx.body).toMatchObject({ hasMore: false, offset: 4, limit: 2 })
+    expect(ctx.body).toMatchObject({ hasMore: false, offset: 4, limit: 2, total: 5 })
+    localCountSessionsMock.mockClear()
     delete ctx.query.offset
     await mod.list(ctx)
     expect(ctx.body).not.toHaveProperty('hasMore')
+    expect(ctx.body).not.toHaveProperty('total')
+    expect(localCountSessionsMock).not.toHaveBeenCalled()
   })
 
   it.each(['-1', 'NaN', '1.5'])('normalizes invalid single-chat offsets (%s)', async (offset) => {
@@ -1025,7 +1032,7 @@ describe('session conversations controller', () => {
     const mod = await import('../../packages/server/src/modules/studio/controllers/sessions')
     const ctx: any = { query: { offset, limit: '10' }, state: {}, body: null }
     await mod.list(ctx)
-    expect(ctx.body).toEqual({ sessions: [], hasMore: false, offset: 0, limit: 10 })
+    expect(ctx.body).toEqual({ sessions: [], hasMore: false, offset: 0, limit: 10, total: 0 })
   })
 
   it.each([['7', 7], ['none', null]])('passes category %s and pin filters into the paginated query', async (category, categoryId) => {
@@ -1036,9 +1043,29 @@ describe('session conversations controller', () => {
     expect(localListSessionsMock).toHaveBeenLastCalledWith(undefined, undefined, 11, expect.objectContaining({
       categoryId, offset: 10, excludeSessionIds: ['pin-a', 'pin-b'],
     }))
+    expect(localCountSessionsMock).toHaveBeenLastCalledWith(undefined, undefined, expect.objectContaining({
+      categoryId, excludeSessionIds: ['pin-a', 'pin-b'], includeArchived: false,
+    }))
     ctx.query = { include: 'pin-a', offset: '0', limit: '10' }
     await mod.list(ctx)
     expect(localListSessionsMock).toHaveBeenLastCalledWith(undefined, undefined, 11, expect.objectContaining({ includeSessionIds: ['pin-a'] }))
+    expect(localCountSessionsMock).toHaveBeenLastCalledWith(undefined, undefined, expect.objectContaining({ includeSessionIds: ['pin-a'] }))
+  })
+
+  it('counts only accessible profiles and does not reveal totals for a forbidden explicit profile', async () => {
+    localListSessionsMock.mockReturnValue([])
+    localCountSessionsMock.mockReturnValue(27)
+    listUserProfilesMock.mockReturnValue([{ profile_name: 'default' }])
+    const mod = await import('../../packages/server/src/modules/studio/controllers/sessions')
+    const ctx: any = { query: { offset: '0', limit: '10' }, state: { user: { id: 'user-1', role: 'user' } } }
+    await mod.list(ctx)
+    expect(ctx.body.total).toBe(27)
+    expect(localCountSessionsMock).toHaveBeenLastCalledWith(undefined, undefined, expect.objectContaining({ profiles: ['default'] }))
+    localCountSessionsMock.mockClear()
+    ctx.query.profile = 'travel'
+    await mod.list(ctx)
+    expect(ctx.body.total).toBe(0)
+    expect(localCountSessionsMock).not.toHaveBeenCalled()
   })
 
   it.each(['invalid', '-1', '1.5'])('rejects invalid session category %s', async category => {


### PR DESCRIPTION
## Summary
Paginated session lists now return the total matching session count, so App category badges can show 30 even when only the first 10 sessions are loaded.

The count reuses the list's database filters for categories, pinned selections, profiles, sources, archived sessions, and pending deletions. Requests without `offset` keep their existing response shape. The generated OpenAPI documentation describes the new pagination metadata.

## Validation
- `npm run test -- tests/server/session-store-search.test.ts tests/server/sessions-controller.test.ts tests/server/sessions-routes.test.ts` — 96 tests passed
- `npm run harness:check` — passed
- `npm run build` — passed

The App consumer change is committed separately to hermes-studio-app main as `4173ba8`.
