### PR TITLE
fix(chat): reconcile native Hermes compression continuations

### DIFF
--- a/packages/server/src/modules/studio/contracts/runs/session.ts
+++ b/packages/server/src/modules/studio/contracts/runs/session.ts
@@ -142,6 +142,8 @@ export interface SessionState {
    * first render.
    */
   runStartedAt?: number
+  /** Identifies the socket run whose pre-send history refresh owns isWorking. */
+  historyRefreshReservation?: string
   events: Array<{ event: string; data: any }>
   abortController?: AbortController
   runId?: string

--- a/packages/server/src/modules/studio/controllers/sessions.ts
+++ b/packages/server/src/modules/studio/controllers/sessions.ts
@@ -62,6 +62,7 @@ import {
   workspaceRelativePath,
 } from '../services/workspace/manager'
 import { getChatRunServer } from '../services/chat-run/server-registry'
+import { reconcileHermesSessionHistory } from '../services/history/reconcile-hermes-history'
 import { isSensitivePath, MAX_DOWNLOAD_SIZE, MAX_EDIT_SIZE } from '../services/files/file-policy'
 import { buildFileContentHeaders, getFilePreviewDescriptor } from '../services/files/file-preview'
 import { decorateWorkspaceEntries, getWorkspaceFileGitDiff } from '../services/files/workspace-git-status'
@@ -164,6 +165,15 @@ function requestedSessionSources(source?: string): string[] {
 
 function isHermesHistorySessionSource(source?: string | null): boolean {
   return source !== 'global_agent' && source !== 'workflow' && source !== 'group_chat'
+}
+
+async function reconcileLocalHermesHistory(sessionId: string, profile?: string): Promise<void> {
+  const chatRunServer = getChatRunServer()
+  await reconcileHermesSessionHistory(sessionId, {
+    profile,
+    isSessionActive: () => chatRunServer?.isSessionRunActive?.(sessionId) === true,
+    invalidateCachedHistory: () => chatRunServer?.invalidateSessionHistory?.(sessionId),
+  })
 }
 
 function sessionLastActive(session: any): number {
@@ -1103,10 +1113,14 @@ export async function getHermesSession(ctx: any) {
   // Prefer the Web UI local session store. Hermes state.db can lag behind or
   // miss messages for Bridge-backed runs, while the local store is the source
   // used by chat rendering and compression.
-  const localSession = localGetSessionDetail(ctx.params.id)
+  let localSession = localGetSessionDetail(ctx.params.id)
   const localSessionProfile = (localSession?.profile || 'default') as string
   if (localSession && isHermesHistorySessionSource(localSession.source) && (!profile || localSessionProfile === profile)) {
     if (denySessionAccess(ctx, localSession)) return
+    if (isHermesAgentAvailable()) {
+      await reconcileLocalHermesHistory(ctx.params.id, profile || localSessionProfile)
+      localSession = localGetSessionDetail(ctx.params.id) || localSession
+    }
     ctx.body = { session: localSession }
     return
   }
@@ -1167,7 +1181,9 @@ export async function importHermesSession(ctx: any) {
 
   const existing = localGetSessionDetail(sessionId)
   if (existing) {
-    ctx.body = { ok: true, imported: false, session: existing }
+    if (denySessionAccess(ctx, existing)) return
+    if (isHermesAgentAvailable()) await reconcileLocalHermesHistory(sessionId, profile)
+    ctx.body = { ok: true, imported: false, session: localGetSessionDetail(sessionId) || existing }
     return
   }
 
@@ -2074,6 +2090,17 @@ export async function getConversationMessagesPaginated(ctx: any) {
   const profile = requestedProfile(ctx)
 
   const { getSessionDetailPaginated } = await import('../public/sessions')
+  const localDetail = localGetSessionDetail(ctx.params.id)
+  const localProfile = String(localDetail?.profile || 'default')
+  if (
+    localDetail
+    && isHermesHistorySessionSource(localDetail.source)
+    && (!profile || profile === localProfile)
+    && isHermesAgentAvailable()
+  ) {
+    if (denySessionAccess(ctx, localDetail)) return
+    await reconcileLocalHermesHistory(ctx.params.id, profile || localProfile)
+  }
   const localResult = getSessionDetailPaginated(ctx.params.id, offset, limit)
   const result = localResult && (!profile || localResult.session.profile === profile)
     ? localResult

--- a/packages/server/src/modules/studio/services/history/reconcile-hermes-history.ts
+++ b/packages/server/src/modules/studio/services/history/reconcile-hermes-history.ts
@@ -1,0 +1,188 @@
+import { deleteCompressionSnapshot } from '../../repositories/compression-snapshot'
+import {
+  addMessages,
+  getSessionDetail,
+  updateSessionStats,
+  type HermesMessageRow,
+} from '../../repositories/session-store'
+import { logger } from '../../public/logging'
+import { getHermesSessionDetailForProfile } from '../../public/session-agent-runtime'
+
+const HERMES_LOCAL_SOURCES = new Set(['cli', 'api_server'])
+const IMPORTABLE_ROLES = new Set(['user', 'assistant', 'tool'])
+const NATIVE_LINEAGE_MARKER_PREFIX = 'hermes_lineage:'
+
+export interface HermesHistoryReconciliationOptions {
+  profile?: string
+  isSessionActive?: () => boolean
+  invalidateCachedHistory?: () => void
+}
+
+export interface HermesHistoryReconciliationResult {
+  changed: boolean
+  added: number
+}
+
+function text(value: unknown): string {
+  if (typeof value === 'string') return value
+  if (value == null) return ''
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return String(value)
+  }
+}
+
+function nullableText(value: unknown): string | null {
+  const normalized = text(value)
+  return normalized ? normalized : null
+}
+
+function normalizeToolCalls(value: unknown): any[] | null {
+  if (!Array.isArray(value)) return null
+  const calls = value
+    .map((call: any) => {
+      const id = String(call?.id || '').trim()
+      const fn = call?.function && typeof call.function === 'object' ? call.function : {}
+      const name = String(fn.name || call?.name || '').trim()
+      if (!id || !name) return null
+      const rawArguments = fn.arguments ?? call?.arguments ?? {}
+      return {
+        id,
+        type: String(call?.type || 'function'),
+        function: {
+          name,
+          arguments: typeof rawArguments === 'string' ? rawArguments : text(rawArguments || {}) || '{}',
+        },
+      }
+    })
+    .filter(Boolean)
+  return calls.length ? calls : null
+}
+
+function nativeMarker(message: any): string {
+  return `${NATIVE_LINEAGE_MARKER_PREFIX}${String(message.session_id)}:${String(message.id)}`
+}
+
+function comparableMessage(message: any): string {
+  return JSON.stringify({
+    role: String(message?.role || ''),
+    content: text(message?.content),
+    tool_call_id: nullableText(message?.tool_call_id),
+    tool_calls: normalizeToolCalls(message?.tool_calls),
+    tool_name: nullableText(message?.tool_name),
+    finish_reason: nullableText(message?.finish_reason),
+    reasoning: nullableText(message?.reasoning),
+    reasoning_details: nullableText(message?.reasoning_details),
+    reasoning_content: nullableText(message?.reasoning_content),
+    timestamp: Number(message?.timestamp || 0),
+  })
+}
+
+function buildContinuationMessages(sessionId: string, nativeMessages: any[]): Array<Omit<HermesMessageRow, 'id'>> {
+  const knownToolCallIds = new Set<string>()
+  for (const message of nativeMessages) {
+    if (String(message?.role || '') !== 'assistant') continue
+    for (const call of normalizeToolCalls(message?.tool_calls) || []) knownToolCallIds.add(call.id)
+  }
+
+  const result: Array<Omit<HermesMessageRow, 'id'>> = []
+  for (const message of nativeMessages) {
+    const nativeSessionId = String(message?.session_id || '')
+    if (!nativeSessionId || nativeSessionId === sessionId) continue
+    const role = String(message?.role || '').trim()
+    if (!IMPORTABLE_ROLES.has(role)) continue
+
+    const toolCalls = role === 'assistant' ? normalizeToolCalls(message?.tool_calls) : null
+    if (role === 'tool') {
+      const callId = String(message?.tool_call_id || '').trim()
+      if (!callId || !knownToolCallIds.has(callId)) continue
+    } else if (role === 'assistant' && !text(message?.content).trim() && !toolCalls) {
+      continue
+    }
+
+    result.push({
+      session_id: sessionId,
+      role,
+      content: text(message?.content),
+      display_role: nullableText(message?.display_role),
+      display_content: nullableText(message?.display_content),
+      tool_call_id: role === 'tool' ? nullableText(message?.tool_call_id) : null,
+      tool_calls: toolCalls,
+      tool_name: role === 'tool' ? nullableText(message?.tool_name) : null,
+      run_marker: nativeMarker(message),
+      timestamp: Number(message?.timestamp || 0),
+      token_count: message?.token_count == null ? null : Number(message.token_count),
+      finish_reason: nullableText(message?.finish_reason),
+      reasoning: role === 'assistant' ? nullableText(message?.reasoning) : null,
+      reasoning_details: role === 'assistant' ? nullableText(message?.reasoning_details) : null,
+      reasoning_content: role === 'assistant' ? nullableText(message?.reasoning_content) : null,
+    })
+  }
+  return result
+}
+
+/**
+ * Copy only messages from the native compression continuation selected by the
+ * Hermes lineage reader into Studio's stable public session id. Studio-only
+ * messages remain untouched.
+ */
+export async function reconcileHermesSessionHistory(
+  sessionId: string,
+  options: HermesHistoryReconciliationOptions = {},
+): Promise<HermesHistoryReconciliationResult> {
+  const local = getSessionDetail(sessionId)
+  if (!local || !HERMES_LOCAL_SOURCES.has(local.source)) return { changed: false, added: 0 }
+
+  const localProfile = String(local.profile || 'default')
+  const requestedProfile = String(options.profile || localProfile)
+  if (requestedProfile !== localProfile || options.isSessionActive?.()) return { changed: false, added: 0 }
+
+  try {
+    const native = await getHermesSessionDetailForProfile(sessionId, localProfile)
+    if (!native || Number(native.thread_session_count || 1) <= 1 || options.isSessionActive?.()) {
+      return { changed: false, added: 0 }
+    }
+
+    const candidates = buildContinuationMessages(sessionId, Array.isArray(native.messages) ? native.messages : [])
+    if (!candidates.length) return { changed: false, added: 0 }
+
+    // Re-read after the asynchronous native query so simultaneous callers and
+    // bridge writes participate in de-duplication before the synchronous insert.
+    const current = getSessionDetail(sessionId)
+    if (!current || String(current.profile || 'default') !== localProfile || options.isSessionActive?.()) {
+      return { changed: false, added: 0 }
+    }
+
+    const markers = new Set((current.messages || []).map(message => String(message.run_marker || '')).filter(Boolean))
+    const availableFingerprints = new Map<string, number>()
+    for (const message of current.messages || []) {
+      // Provenance-marked rows already match by native identity; never let them
+      // consume a different native turn with repeated text.
+      if (String(message.run_marker || '').startsWith(NATIVE_LINEAGE_MARKER_PREFIX)) continue
+      const fingerprint = comparableMessage(message)
+      availableFingerprints.set(fingerprint, (availableFingerprints.get(fingerprint) || 0) + 1)
+    }
+
+    const missing = candidates.filter((message) => {
+      if (markers.has(String(message.run_marker || ''))) return false
+      const fingerprint = comparableMessage(message)
+      const available = availableFingerprints.get(fingerprint) || 0
+      if (available > 0) {
+        availableFingerprints.set(fingerprint, available - 1)
+        return false
+      }
+      return true
+    })
+    if (!missing.length || options.isSessionActive?.()) return { changed: false, added: 0 }
+
+    addMessages(missing)
+    updateSessionStats(sessionId)
+    deleteCompressionSnapshot(sessionId)
+    options.invalidateCachedHistory?.()
+    return { changed: true, added: missing.length }
+  } catch (err) {
+    logger.warn({ err, sessionId, profile: localProfile }, 'Hermes history reconciliation failed')
+    return { changed: false, added: 0 }
+  }
+}

--- a/packages/server/src/modules/studio/sockets/chat-run.ts
+++ b/packages/server/src/modules/studio/sockets/chat-run.ts
@@ -59,6 +59,7 @@ import { userCanAccessProfile } from '../repositories/users-store'
 import { observeRunChatPetEvent } from '../public/pet-events'
 import { observeChatRunWebhookEvent, type ChatRunWebhookAgent } from '../services/webhooks'
 import { getAgentStatusSnapshot } from '../public/agent-status-registry'
+import { reconcileHermesSessionHistory } from '../services/history/reconcile-hermes-history'
 import {
   normalizeMobileCalendarRequest,
   normalizeMobileCalendarResponse,
@@ -405,6 +406,28 @@ export class ChatRunSocket {
     })
   }
 
+  isSessionRunActive(sessionId: string): boolean {
+    return this.sessionMap.get(sessionId)?.isWorking === true
+  }
+
+  invalidateSessionHistory(sessionId: string): boolean {
+    const state = this.sessionMap.get(sessionId)
+    if (!state || state.isWorking) return false
+    return this.sessionMap.delete(sessionId)
+  }
+
+  private refreshSessionHistory(state: SessionState, refreshed: SessionState): void {
+    state.messages = refreshed.messages
+    state.messageTotal = refreshed.messageTotal
+    state.messageLoadedCount = refreshed.messageLoadedCount
+    state.messagePageLimit = refreshed.messagePageLimit
+    state.messageStateBaselineCount = refreshed.messageStateBaselineCount
+    state.hasMoreBefore = refreshed.hasMoreBefore
+    state.inputTokens = refreshed.inputTokens
+    state.outputTokens = refreshed.outputTokens
+    state.contextTokens = refreshed.contextTokens
+  }
+
   requestMobileLocation(options: {
     sessionId: string
     profile: string
@@ -673,6 +696,7 @@ export class ChatRunSocket {
       push_enabled?: boolean
     }) => {
       let runProfile: string
+      let historyRefreshReservation: string | undefined
       try {
         runProfile = resolveRunProfile(data.session_id, data.profile)
       } catch (err) {
@@ -787,14 +811,16 @@ export class ChatRunSocket {
           logger.info('[chat-run-socket] queued run for session %s (queue: %d)', data.session_id, state.queue.length)
           return
         }
+        historyRefreshReservation = source === 'cli' ? randomUUID() : undefined
         state.events = []
         state.isWorking = !isCodingAgentExecution(source, data)
         state.runStartedAt = Date.now()
         state.profile = runProfile
         state.source = source
+        state.historyRefreshReservation = historyRefreshReservation
       }
       try {
-        await this.handleRun(socket, data, runProfile)
+        await this.handleRun(socket, data, runProfile, false, undefined, historyRefreshReservation)
       } catch (err) {
         const payload = {
           event: 'run.failed',
@@ -1233,8 +1259,43 @@ export class ChatRunSocket {
     profile: string,
     skipUserMessage = false,
     backgroundContinuationContext?: BackgroundContinuationContext,
+    historyRefreshReservation?: string,
   ) {
     const source = resolveRunSource(data.source, data.session_id)
+    if (data.session_id && isBridgeRunSource(source) && isSessionCommand(data.input) && data.allow_command_passthrough !== true) {
+      const state = this.sessionMap.get(data.session_id)
+      if (state && state.historyRefreshReservation === historyRefreshReservation) state.historyRefreshReservation = undefined
+      return
+    }
+    if (data.session_id && source === 'cli' && !backgroundContinuationContext) {
+      const sessionId = data.session_id
+      const reservation = historyRefreshReservation
+      const hasCompetingExecution = () => {
+        const current = this.sessionMap.get(sessionId)
+        return Boolean(
+          current?.activeRunMarker
+          || current?.runId
+          || current?.abortController
+          || (current?.isWorking && (!reservation || current.historyRefreshReservation !== reservation)),
+        )
+      }
+      try {
+        const reconciliation = await reconcileHermesSessionHistory(sessionId, {
+          profile,
+          isSessionActive: hasCompetingExecution,
+        })
+        if (reconciliation.changed && !hasCompetingExecution()) {
+          const refreshed = await loadSessionStateFromDb(sessionId, this.sessionMap)
+          const current = this.sessionMap.get(sessionId)
+          if (current && current.historyRefreshReservation === reservation && !hasCompetingExecution()) {
+            this.refreshSessionHistory(current, refreshed)
+          }
+        }
+      } finally {
+        const current = this.sessionMap.get(sessionId)
+        if (current && current.historyRefreshReservation === reservation) current.historyRefreshReservation = undefined
+      }
+    }
     if (data.session_id) {
       const target = socket.data?.mobileDeviceTarget as MobileDeviceTarget | undefined
       if (target && target.profile === profile && source !== 'workflow' && source !== 'group_chat' && !backgroundContinuationContext) {
@@ -1260,8 +1321,6 @@ export class ChatRunSocket {
       state.webhookWorkflowId = data.workflow_id
       state.webhookWorkflowNodeId = data.workflow_node_id
     }
-    if (data.session_id && isBridgeRunSource(source) && isSessionCommand(data.input) && data.allow_command_passthrough !== true) return
-
     if (!isCodingAgentExecution(source, data)) {
       const bridgeReady = await ensureBridgeReadyForChatRun()
       if (!bridgeReady.ok) {
@@ -1680,10 +1739,34 @@ export class ChatRunSocket {
   ) {
     let state = this.sessionMap.get(sid)
     if (!state) {
-      state = await loadSessionStateFromDb(sid, this.sessionMap)
-      this.sessionMap.set(sid, state)
+      const loaded = await loadSessionStateFromDb(sid, this.sessionMap)
+      state = this.sessionMap.get(sid)
+      if (!state) {
+        state = loaded
+        this.sessionMap.set(sid, state)
+      }
     }
     await this.reattachBridgeRun(socket, sid, state)
+    state = this.sessionMap.get(sid) || state
+    if (!state.isWorking) {
+      const profile = getSession(sid)?.profile || currentProfileFromSocket(socket)
+      const reconciliation = await reconcileHermesSessionHistory(sid, {
+        profile,
+        isSessionActive: () => this.sessionMap.get(sid)?.isWorking === true,
+      })
+      if (reconciliation.changed) {
+        const refreshed = await loadSessionStateFromDb(sid, this.sessionMap)
+        const current = this.sessionMap.get(sid)
+        if (current?.isWorking) state = current
+        else if (current) {
+          this.refreshSessionHistory(current, refreshed)
+          state = current
+        } else {
+          state = refreshed
+          this.sessionMap.set(sid, state)
+        }
+      }
+    }
     const resumeEvents = state.isWorking
       ? state.events
       : (state.events || []).filter(evt => evt?.event === 'run.reattach_failed')

--- a/tests/server/hermes-history-reconciliation.test.ts
+++ b/tests/server/hermes-history-reconciliation.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const getSessionDetailMock = vi.fn()
+const addMessagesMock = vi.fn()
+const updateSessionStatsMock = vi.fn()
+const deleteCompressionSnapshotMock = vi.fn()
+const getHermesSessionDetailForProfileMock = vi.fn()
+
+vi.mock('../../packages/server/src/modules/studio/repositories/session-store', () => ({
+  getSessionDetail: getSessionDetailMock,
+  addMessages: addMessagesMock,
+  updateSessionStats: updateSessionStatsMock,
+}))
+
+vi.mock('../../packages/server/src/modules/studio/repositories/compression-snapshot', () => ({
+  deleteCompressionSnapshot: deleteCompressionSnapshotMock,
+}))
+
+vi.mock('../../packages/server/src/modules/studio/public/session-agent-runtime', () => ({
+  getHermesSessionDetailForProfile: getHermesSessionDetailForProfileMock,
+}))
+
+vi.mock('../../packages/server/src/modules/studio/public/logging', () => ({
+  logger: { warn: vi.fn() },
+}))
+
+describe('Hermes native continuation history reconciliation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('preserves local-only messages and imports one native continuation tool turn idempotently', async () => {
+    let localMessages: any[] = [
+      { id: 10, session_id: 'studio-root', role: 'user', content: 'root request', timestamp: 10 },
+      { id: 11, session_id: 'studio-root', role: 'assistant', content: 'Studio-only bridge note', timestamp: 11 },
+    ]
+    getSessionDetailMock.mockImplementation(() => ({
+      id: 'studio-root', profile: 'research', source: 'cli', messages: localMessages,
+    }))
+    addMessagesMock.mockImplementation((messages: any[]) => {
+      localMessages = [...localMessages, ...messages.map((message, index) => ({ ...message, id: 20 + index }))]
+      return messages.map((_message, index) => 20 + index)
+    })
+    getHermesSessionDetailForProfileMock.mockResolvedValue({
+      id: 'studio-root',
+      thread_session_count: 2,
+      messages: [
+        { id: 1, session_id: 'studio-root', role: 'user', content: 'root request', timestamp: 10 },
+        {
+          id: 2,
+          session_id: 'native-tip',
+          role: 'assistant',
+          content: '',
+          tool_calls: [{ id: 'call-1', type: 'function', function: { name: 'lookup', arguments: '{"q":"x"}' } }],
+          timestamp: 20,
+        },
+        { id: 3, session_id: 'native-tip', role: 'tool', content: 'result', tool_call_id: 'call-1', tool_name: 'lookup', timestamp: 21 },
+        { id: 4, session_id: 'native-tip', role: 'assistant', content: 'continued answer', timestamp: 22 },
+      ],
+    })
+    const invalidate = vi.fn()
+    const { reconcileHermesSessionHistory } = await import(
+      '../../packages/server/src/modules/studio/services/history/reconcile-hermes-history'
+    )
+
+    await expect(reconcileHermesSessionHistory('studio-root', {
+      profile: 'research', invalidateCachedHistory: invalidate,
+    })).resolves.toEqual({ changed: true, added: 3 })
+    await expect(reconcileHermesSessionHistory('studio-root', {
+      profile: 'research', invalidateCachedHistory: invalidate,
+    })).resolves.toEqual({ changed: false, added: 0 })
+
+    expect(localMessages.map(message => message.content)).toEqual([
+      'root request',
+      'Studio-only bridge note',
+      '',
+      'result',
+      'continued answer',
+    ])
+    expect(localMessages.filter(message => message.role === 'tool')).toHaveLength(1)
+    expect(localMessages.filter(message => message.content === 'continued answer')).toHaveLength(1)
+    expect(localMessages.slice(2).map(message => message.run_marker)).toEqual([
+      'hermes_lineage:native-tip:2',
+      'hermes_lineage:native-tip:3',
+      'hermes_lineage:native-tip:4',
+    ])
+    expect(deleteCompressionSnapshotMock).toHaveBeenCalledTimes(1)
+    expect(updateSessionStatsMock).toHaveBeenCalledTimes(1)
+    expect(invalidate).toHaveBeenCalledTimes(1)
+  })
+
+  it('imports an incrementally appended identical native turn with a distinct timestamp and id exactly once', async () => {
+    let localMessages: any[] = [
+      { id: 10, session_id: 'incremental-root', role: 'user', content: 'repeat', timestamp: 10 },
+    ]
+    let nativeMessages: any[] = [
+      { id: 1, session_id: 'incremental-root', role: 'user', content: 'repeat', timestamp: 10 },
+      { id: 2, session_id: 'native-tip', role: 'assistant', content: 'same answer', timestamp: 20 },
+    ]
+    getSessionDetailMock.mockImplementation(() => ({
+      id: 'incremental-root', profile: 'default', source: 'cli', messages: localMessages,
+    }))
+    addMessagesMock.mockImplementation((messages: any[]) => {
+      localMessages = [...localMessages, ...messages.map((message, index) => ({ ...message, id: 20 + localMessages.length + index }))]
+      return messages.map((_message, index) => 20 + index)
+    })
+    getHermesSessionDetailForProfileMock.mockImplementation(async () => ({
+      id: 'incremental-root', thread_session_count: 2, messages: nativeMessages,
+    }))
+    const { reconcileHermesSessionHistory } = await import(
+      '../../packages/server/src/modules/studio/services/history/reconcile-hermes-history'
+    )
+
+    await expect(reconcileHermesSessionHistory('incremental-root')).resolves.toEqual({ changed: true, added: 1 })
+    nativeMessages = [
+      ...nativeMessages,
+      { id: 3, session_id: 'native-tip', role: 'assistant', content: 'same answer', timestamp: 21 },
+    ]
+    await expect(reconcileHermesSessionHistory('incremental-root')).resolves.toEqual({ changed: true, added: 1 })
+    await expect(reconcileHermesSessionHistory('incremental-root')).resolves.toEqual({ changed: false, added: 0 })
+
+    expect(localMessages.filter(message => message.content === 'same answer')).toHaveLength(2)
+    expect(localMessages.filter(message => message.run_marker === 'hermes_lineage:native-tip:3')).toHaveLength(1)
+  })
+
+  it('does not read another profile or rewrite an active session', async () => {
+    getSessionDetailMock.mockReturnValue({
+      id: 'isolated-root', profile: 'work', source: 'api_server', messages: [],
+    })
+    const { reconcileHermesSessionHistory } = await import(
+      '../../packages/server/src/modules/studio/services/history/reconcile-hermes-history'
+    )
+
+    await expect(reconcileHermesSessionHistory('isolated-root', { profile: 'personal' }))
+      .resolves.toEqual({ changed: false, added: 0 })
+    await expect(reconcileHermesSessionHistory('isolated-root', {
+      profile: 'work', isSessionActive: () => true,
+    })).resolves.toEqual({ changed: false, added: 0 })
+
+    expect(getHermesSessionDetailForProfileMock).not.toHaveBeenCalled()
+    expect(addMessagesMock).not.toHaveBeenCalled()
+  })
+
+  it('ignores native history without a lineage-selected compression continuation', async () => {
+    getSessionDetailMock.mockReturnValue({
+      id: 'plain-root', profile: 'default', source: 'cli', messages: [],
+    })
+    getHermesSessionDetailForProfileMock.mockResolvedValue({
+      id: 'plain-root',
+      thread_session_count: 1,
+      messages: [{ id: 1, session_id: 'plain-root', role: 'user', content: 'plain turn' }],
+    })
+    const { reconcileHermesSessionHistory } = await import(
+      '../../packages/server/src/modules/studio/services/history/reconcile-hermes-history'
+    )
+
+    await expect(reconcileHermesSessionHistory('plain-root', { profile: 'default' }))
+      .resolves.toEqual({ changed: false, added: 0 })
+    expect(addMessagesMock).not.toHaveBeenCalled()
+    expect(deleteCompressionSnapshotMock).not.toHaveBeenCalled()
+  })
+})

--- a/tests/server/run-chat-run-started-at.test.ts
+++ b/tests/server/run-chat-run-started-at.test.ts
@@ -7,6 +7,7 @@ const loadSessionStateFromDbMock = vi.hoisted(() => vi.fn())
 const ensureReadyMock = vi.hoisted(() => vi.fn())
 const getRuntimeStateMock = vi.hoisted(() => vi.fn())
 const userCanAccessProfileMock = vi.hoisted(() => vi.fn((_user: unknown, _profile: string) => true))
+const reconcileHermesSessionHistoryMock = vi.hoisted(() => vi.fn(async () => ({ changed: false, added: 0 })))
 const getSessionMock = vi.hoisted(() => vi.fn((sessionId?: string) => sessionId
   ? { id: sessionId, profile: 'default', source: 'cli', model: 'gpt-test', provider: 'openai' }
   : undefined))
@@ -37,6 +38,10 @@ vi.mock('../../packages/server/src/modules/studio/services/chat-run/session-comm
   handleSessionCommand: vi.fn(),
   isSessionCommand: vi.fn(() => false),
   parseSessionCommand: vi.fn(() => null),
+}))
+
+vi.mock('../../packages/server/src/modules/studio/services/history/reconcile-hermes-history', () => ({
+  reconcileHermesSessionHistory: reconcileHermesSessionHistoryMock,
 }))
 
 vi.mock('../../packages/server/src/modules/hermes/services/bridge/index', () => ({
@@ -82,6 +87,14 @@ vi.mock('../../packages/server/src/modules/studio/repositories/session-store', (
   getSession: getSessionMock,
   getSessionMetadata: getSessionMock,
   getSessionDetail: vi.fn(() => null),
+}))
+
+vi.mock('../../packages/server/src/modules/studio/services/task-plans', () => ({
+  getSessionTaskPlans: vi.fn(() => []),
+}))
+
+vi.mock('../../packages/server/src/modules/studio/repositories/workspace-run-changes-store', () => ({
+  listWorkspaceRunChangesForAssistantMessages: vi.fn(() => []),
 }))
 
 vi.mock('../../packages/server/src/modules/studio/public/profile-config', () => ({
@@ -137,6 +150,9 @@ describe('ChatRunSocket reports when the run started', () => {
     ensureReadyMock.mockReset()
     getRuntimeStateMock.mockReset()
     bridgeMock.statusIfLoaded.mockReset()
+    reconcileHermesSessionHistoryMock.mockReset().mockResolvedValue({ changed: false, added: 0 })
+    loadSessionStateFromDbMock.mockReset()
+    handleBridgeRunMock.mockClear()
     ensureReadyMock.mockResolvedValue({
       reachable: true,
       status: 'ready',
@@ -178,6 +194,158 @@ describe('ChatRunSocket reports when the run started', () => {
     const resumed = socket.emit.mock.calls.find((call: any[]) => call[0] === 'resumed')
     expect(resumed![1].isWorking).toBe(false)
     expect(resumed![1].runStartedAt).toBeUndefined()
+    expect(reconcileHermesSessionHistoryMock).toHaveBeenCalledWith('s2', expect.objectContaining({ profile: 'default' }))
+  })
+
+  it('reloads reconciled native continuation history before an idle resume', async () => {
+    const { ChatRunSocket } = await import('../../packages/server/src/modules/studio/sockets/chat-run')
+    const { handlers, io, socket } = makeServerHarness()
+    ;(socket.data as any).user = { id: 1, username: 'admin', role: 'super_admin' }
+    const server = new ChatRunSocket(io as any)
+    ;(server as any).sessionMap.set('resume-lineage', {
+      messages: [{ id: 1, role: 'user', content: 'stale root' }], events: [], queue: [], isWorking: false,
+    })
+    reconcileHermesSessionHistoryMock.mockResolvedValueOnce({ changed: true, added: 1 })
+    loadSessionStateFromDbMock.mockResolvedValueOnce({
+      messages: [
+        { id: 1, role: 'user', content: 'stale root' },
+        { id: 2, role: 'assistant', content: 'native continuation' },
+      ],
+      events: [], queue: [], isWorking: false,
+    })
+
+    ;(server as any).onConnection(socket)
+    await handlers.get('resume')?.({ session_id: 'resume-lineage' })
+
+    const resumed = socket.emit.mock.calls.find((call: any[]) => call[0] === 'resumed')
+    expect(resumed![1].messages.map((message: any) => message.content)).toEqual(['stale root', 'native continuation'])
+    expect(loadSessionStateFromDbMock).toHaveBeenCalledWith('resume-lineage', expect.any(Map))
+  })
+
+  it('reconciles and reloads idle history before a direct bridge send', async () => {
+    const { ChatRunSocket } = await import('../../packages/server/src/modules/studio/sockets/chat-run')
+    const { handlers, io, socket } = makeServerHarness()
+    ;(socket.data as any).user = { id: 1, username: 'admin', role: 'super_admin' }
+    const server = new ChatRunSocket(io as any)
+    reconcileHermesSessionHistoryMock.mockResolvedValueOnce({ changed: true, added: 1 })
+    loadSessionStateFromDbMock.mockResolvedValueOnce({
+      messages: [{ id: 2, role: 'assistant', content: 'native continuation' }],
+      events: [], queue: [], isWorking: false,
+    })
+
+    ;(server as any).onConnection(socket)
+    await handlers.get('run')?.({ session_id: 'pre-send-lineage', input: 'next turn', source: 'cli' })
+
+    expect(reconcileHermesSessionHistoryMock).toHaveBeenCalledWith(
+      'pre-send-lineage',
+      expect.objectContaining({ profile: 'default' }),
+    )
+    expect(loadSessionStateFromDbMock).toHaveBeenCalledWith('pre-send-lineage', expect.any(Map))
+    expect(handleBridgeRunMock).toHaveBeenCalled()
+    const sessionMap = handleBridgeRunMock.mock.calls[0][4] as Map<string, any>
+    expect(sessionMap.get('pre-send-lineage').messages[0].content).toBe('native continuation')
+  })
+
+  it('preserves a concurrently queued second send while the first send refreshes native history', async () => {
+    const { ChatRunSocket } = await import('../../packages/server/src/modules/studio/sockets/chat-run')
+    const { handlers, io, socket } = makeServerHarness()
+    ;(socket.data as any).user = { id: 1, username: 'admin', role: 'super_admin' }
+    const server = new ChatRunSocket(io as any)
+    let finishLookup!: () => void
+    const lookupPending = new Promise<void>(resolve => { finishLookup = resolve })
+    reconcileHermesSessionHistoryMock.mockImplementationOnce(async (_id, options) => {
+      await lookupPending
+      expect(options.isSessionActive()).toBe(false)
+      return { changed: true, added: 1 }
+    })
+    loadSessionStateFromDbMock.mockResolvedValueOnce({
+      messages: [{ id: 2, role: 'assistant', content: 'native continuation' }],
+      events: [], queue: [], isWorking: false,
+    })
+
+    ;(server as any).onConnection(socket)
+    const first = handlers.get('run')?.({ session_id: 'concurrent-send', input: 'first', source: 'cli' })
+    const reserved = (server as any).sessionMap.get('concurrent-send')
+    const startedAt = reserved.runStartedAt
+    const second = handlers.get('run')?.({ session_id: 'concurrent-send', input: 'second', source: 'cli' })
+
+    expect(reserved.isWorking).toBe(true)
+    expect(reserved.queue.map((item: any) => item.input)).toEqual(['second'])
+    reserved.events.push({ event: 'live.event', data: { value: 1 } })
+    finishLookup()
+    await Promise.all([first, second])
+
+    const current = (server as any).sessionMap.get('concurrent-send')
+    expect(current).toBe(reserved)
+    expect(current.messages.map((message: any) => message.content)).toEqual(['native continuation'])
+    expect(current.queue.map((item: any) => item.input)).toEqual(['second'])
+    expect(current.events).toEqual([{ event: 'live.event', data: { value: 1 } }])
+    expect(current.runStartedAt).toBe(startedAt)
+    expect(current.profile).toBe('default')
+    expect(handleBridgeRunMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps a live send state when an idle resume lookup finishes afterward', async () => {
+    const { ChatRunSocket } = await import('../../packages/server/src/modules/studio/sockets/chat-run')
+    const { handlers, io, socket } = makeServerHarness()
+    ;(socket.data as any).user = { id: 1, username: 'admin', role: 'super_admin' }
+    const server = new ChatRunSocket(io as any)
+    const idleState = {
+      messages: [{ id: 1, role: 'user', content: 'existing' }], events: [], queue: [], isWorking: false,
+    }
+    ;(server as any).sessionMap.set('resume-send-race', idleState)
+    let finishResumeLookup!: () => void
+    const resumeLookupPending = new Promise<void>(resolve => { finishResumeLookup = resolve })
+    let resumeSawActive = false
+    reconcileHermesSessionHistoryMock
+      .mockImplementationOnce(async (_id, options) => {
+        await resumeLookupPending
+        resumeSawActive = options.isSessionActive()
+        return { changed: false, added: 0 }
+      })
+      .mockResolvedValueOnce({ changed: false, added: 0 })
+
+    ;(server as any).onConnection(socket)
+    const resume = handlers.get('resume')?.({ session_id: 'resume-send-race' })
+    await vi.waitFor(() => expect(reconcileHermesSessionHistoryMock).toHaveBeenCalledTimes(1))
+    await handlers.get('run')?.({ session_id: 'resume-send-race', input: 'new run', source: 'cli' })
+    const liveState = (server as any).sessionMap.get('resume-send-race')
+    const startedAt = liveState.runStartedAt
+    finishResumeLookup()
+    await resume
+
+    expect(resumeSawActive).toBe(true)
+    expect((server as any).sessionMap.get('resume-send-race')).toBe(liveState)
+    expect(liveState.isWorking).toBe(true)
+    expect(liveState.runStartedAt).toBe(startedAt)
+    const resumed = socket.emit.mock.calls.find((call: any[]) => call[0] === 'resumed')
+    expect(resumed?.[1]).toMatchObject({ isWorking: true, runStartedAt: startedAt })
+  })
+
+  it('does not replace state created by a send while an initial resume load is pending', async () => {
+    const { ChatRunSocket } = await import('../../packages/server/src/modules/studio/sockets/chat-run')
+    const { handlers, io, socket } = makeServerHarness()
+    ;(socket.data as any).user = { id: 1, username: 'admin', role: 'super_admin' }
+    const server = new ChatRunSocket(io as any)
+    let finishLoad!: (state: any) => void
+    loadSessionStateFromDbMock.mockImplementationOnce(() => new Promise(resolve => { finishLoad = resolve }))
+
+    ;(server as any).onConnection(socket)
+    const resume = handlers.get('resume')?.({ session_id: 'initial-resume-send-race' })
+    await vi.waitFor(() => expect(loadSessionStateFromDbMock).toHaveBeenCalledTimes(1))
+    await handlers.get('run')?.({ session_id: 'initial-resume-send-race', input: 'new run', source: 'cli' })
+    const liveState = (server as any).sessionMap.get('initial-resume-send-race')
+    finishLoad({
+      messages: [{ id: 1, role: 'user', content: 'loaded before send' }],
+      events: [], queue: [], isWorking: false,
+    })
+    await resume
+
+    expect((server as any).sessionMap.get('initial-resume-send-race')).toBe(liveState)
+    expect(liveState.isWorking).toBe(true)
+    expect(handleBridgeRunMock).toHaveBeenCalledTimes(1)
+    const resumed = socket.emit.mock.calls.find((call: any[]) => call[0] === 'resumed')
+    expect(resumed?.[1].isWorking).toBe(true)
   })
 
   it('refreshes the start when a queued run becomes active', async () => {

--- a/tests/server/sessions-controller.test.ts
+++ b/tests/server/sessions-controller.test.ts
@@ -11,6 +11,7 @@ const listSessionSummariesMock = vi.fn()
 const listSessionSummaryGroupsMock = vi.fn()
 const getSessionDetailFromDbMock = vi.fn()
 const getSessionDetailFromDbWithProfileMock = vi.fn()
+const getSessionDetailPaginatedFromDbWithProfileMock = vi.fn()
 const getExactSessionDetailFromDbWithProfileMock = vi.fn()
 const getUsageStatsFromDbMock = vi.fn()
 const getSessionMock = vi.fn()
@@ -18,6 +19,7 @@ const deleteHermesSessionForProfileMock = vi.fn()
 const localListSessionsMock = vi.fn()
 const localCountSessionsMock = vi.fn()
 const localGetSessionDetailMock = vi.fn()
+const localGetSessionDetailPaginatedMock = vi.fn()
 const localSearchSessionsMock = vi.fn()
 const localDeleteSessionMock = vi.fn()
 const localRenameSessionMock = vi.fn()
@@ -40,12 +42,14 @@ const getRecordedUsageSessionIdsMock = vi.fn()
 const getActiveProfileNameMock = vi.fn()
 const loggerWarnMock = vi.fn()
 const getCompressionSnapshotMock = vi.fn()
+const deleteCompressionSnapshotMock = vi.fn()
 const buildDbExportHistoryMock = vi.fn()
 const listUserProfilesMock = vi.fn()
 const readConfigYamlForProfileMock = vi.fn()
 const bridgeSwitchSessionModelMock = vi.fn()
 const bridgeGetRuntimeStateMock = vi.fn()
 const emitSessionSettingsUpdatedMock = vi.fn()
+const invalidateSessionHistoryMock = vi.fn()
 const getChatRunServerMock = vi.fn()
 const agentStatusMocks = vi.hoisted(() => ({ hermesAvailable: true }))
 const codingAgentRunManagerMock = vi.hoisted(() => ({
@@ -90,6 +94,7 @@ vi.mock('../../packages/server/src/modules/hermes/services/history/sessions-db',
   searchSessionSummaries: vi.fn(),
   getSessionDetailFromDb: getSessionDetailFromDbMock,
   getSessionDetailFromDbWithProfile: getSessionDetailFromDbWithProfileMock,
+  getSessionDetailPaginatedFromDbWithProfile: getSessionDetailPaginatedFromDbWithProfileMock,
   getExactSessionDetailFromDbWithProfile: getExactSessionDetailFromDbWithProfileMock,
   getUsageStatsFromDb: getUsageStatsFromDbMock,
 }))
@@ -99,6 +104,7 @@ vi.mock('../../packages/server/src/modules/studio/repositories/session-store', (
   countSessions: localCountSessionsMock,
   searchSessions: localSearchSessionsMock,
   getSessionDetail: localGetSessionDetailMock,
+  getSessionDetailPaginated: localGetSessionDetailPaginatedMock,
   deleteSession: localDeleteSessionMock,
   renameSession: localRenameSessionMock,
   setSessionArchived: localSetSessionArchivedMock,
@@ -189,6 +195,18 @@ vi.mock('../../packages/server/src/modules/studio/services/chat-run/server-regis
 
 vi.mock('../../packages/server/src/modules/studio/repositories/compression-snapshot', () => ({
   getCompressionSnapshot: getCompressionSnapshotMock,
+  deleteCompressionSnapshot: deleteCompressionSnapshotMock,
+}))
+
+vi.mock('../../packages/server/src/modules/studio/services/task-plans', () => ({
+  getSessionTaskPlans: vi.fn(() => []),
+}))
+
+vi.mock('../../packages/server/src/modules/studio/repositories/workspace-run-changes-store', () => ({
+  deleteWorkspaceRunChangesForSession: vi.fn(),
+  getWorkspaceRunChangeFile: vi.fn(),
+  listWorkspaceRunChangesForAssistantMessages: vi.fn(() => []),
+  listWorkspaceRunChangesForSession: vi.fn(() => []),
 }))
 
 vi.mock('../../packages/server/src/modules/studio/services/context-compressor/export-compressor', () => ({
@@ -221,7 +239,7 @@ vi.mock('../../packages/server/src/modules/studio/public/session-agent-runtime',
   getHermesModelContextLength: vi.fn(),
   getHermesSessionDetail: getSessionDetailFromDbMock,
   getHermesSessionDetailForProfile: getSessionDetailFromDbWithProfileMock,
-  getHermesSessionDetailPaginatedForProfile: vi.fn(),
+  getHermesSessionDetailPaginatedForProfile: getSessionDetailPaginatedFromDbWithProfileMock,
   getExactHermesSessionDetailForProfile: getExactSessionDetailFromDbWithProfileMock,
   getHermesUsageStats: getUsageStatsFromDbMock,
   listHermesSessionSummaries: listSessionSummariesMock,
@@ -255,6 +273,7 @@ describe('session conversations controller', () => {
     listSessionSummaryGroupsMock.mockReset()
     getSessionDetailFromDbMock.mockReset()
     getSessionDetailFromDbWithProfileMock.mockReset()
+    getSessionDetailPaginatedFromDbWithProfileMock.mockReset()
     getExactSessionDetailFromDbWithProfileMock.mockReset()
     getUsageStatsFromDbMock.mockReset()
     getSessionMock.mockReset()
@@ -262,6 +281,7 @@ describe('session conversations controller', () => {
     localListSessionsMock.mockReset()
     localCountSessionsMock.mockReset().mockReturnValue(0)
     localGetSessionDetailMock.mockReset()
+    localGetSessionDetailPaginatedMock.mockReset()
     localSearchSessionsMock.mockReset()
     localDeleteSessionMock.mockReset()
     localRenameSessionMock.mockReset()
@@ -272,8 +292,13 @@ describe('session conversations controller', () => {
     localAddMessagesMock.mockReset()
     localUpdateSessionStatsMock.mockReset()
     emitSessionSettingsUpdatedMock.mockReset()
+    invalidateSessionHistoryMock.mockReset()
     getChatRunServerMock.mockReset()
-    getChatRunServerMock.mockReturnValue({ emitSessionSettingsUpdated: emitSessionSettingsUpdatedMock })
+    getChatRunServerMock.mockReturnValue({
+      emitSessionSettingsUpdated: emitSessionSettingsUpdatedMock,
+      isSessionRunActive: () => false,
+      invalidateSessionHistory: invalidateSessionHistoryMock,
+    })
     listSessionCategoriesMock.mockReset()
     createSessionCategoryMock.mockReset()
     deleteSessionCategoryMock.mockReset()
@@ -307,6 +332,7 @@ describe('session conversations controller', () => {
     getActiveProfileNameMock.mockReturnValue('default')
     loggerWarnMock.mockReset()
     getCompressionSnapshotMock.mockReset()
+    deleteCompressionSnapshotMock.mockReset()
     buildDbExportHistoryMock.mockReset()
     listUserProfilesMock.mockReset()
     listUserProfilesMock.mockReturnValue([])
@@ -1712,6 +1738,128 @@ describe('session conversations controller', () => {
     })
   })
 
+  it('reconciles a native compression continuation into local Hermes detail without replacing bridge-only messages', async () => {
+    let localDetail: any = {
+      id: 'studio-root',
+      profile: 'default',
+      source: 'api_server',
+      title: 'Stable Studio title',
+      messages: [
+        { id: 10, session_id: 'studio-root', role: 'user', content: 'shared root turn', timestamp: 100 },
+        { id: 11, session_id: 'studio-root', role: 'assistant', content: 'bridge-only commentary', timestamp: 110 },
+      ],
+    }
+    localGetSessionDetailMock.mockImplementation(() => localDetail)
+    localAddMessagesMock.mockImplementation((messages: any[]) => {
+      localDetail = {
+        ...localDetail,
+        messages: [
+          ...localDetail.messages,
+          ...messages.map((message, index) => ({ ...message, id: 20 + index })),
+        ],
+      }
+      return messages.map((_message, index) => 20 + index)
+    })
+    getSessionDetailFromDbWithProfileMock.mockResolvedValue({
+      id: 'studio-root',
+      source: 'cli',
+      thread_session_count: 2,
+      messages: [
+        { id: 1, session_id: 'studio-root', role: 'user', content: 'shared root turn', timestamp: 100 },
+        { id: 2, session_id: 'native-tip', role: 'assistant', content: 'native continuation turn', timestamp: 200 },
+      ],
+    })
+
+    const mod = await import('../../packages/server/src/modules/studio/controllers/sessions')
+    const ctx: any = { params: { id: 'studio-root' }, query: {}, state: {}, body: null }
+    await mod.getHermesSession(ctx)
+
+    expect(getSessionDetailFromDbWithProfileMock).toHaveBeenCalledWith('studio-root', 'default')
+    expect(localAddMessagesMock).toHaveBeenCalledWith([
+      expect.objectContaining({
+        session_id: 'studio-root',
+        role: 'assistant',
+        content: 'native continuation turn',
+        run_marker: expect.stringContaining('native-tip'),
+      }),
+    ])
+    expect(deleteCompressionSnapshotMock).toHaveBeenCalledWith('studio-root')
+    expect(invalidateSessionHistoryMock).toHaveBeenCalledWith('studio-root')
+    expect(ctx.body.session).toMatchObject({ id: 'studio-root', title: 'Stable Studio title' })
+    expect(ctx.body.session.messages.map((message: any) => message.content)).toEqual([
+      'shared root turn',
+      'bridge-only commentary',
+      'native continuation turn',
+    ])
+  })
+
+  it('reconciles before reading a local Hermes message page and keeps the public Studio id', async () => {
+    let messages: any[] = [
+      { id: 10, session_id: 'studio-page-root', role: 'user', content: 'root page turn', timestamp: 100 },
+    ]
+    const session = { id: 'studio-page-root', profile: 'travel', source: 'cli', title: 'Studio page' }
+    localGetSessionDetailMock.mockImplementation(() => ({ ...session, messages }))
+    localAddMessagesMock.mockImplementation((added: any[]) => {
+      messages = [...messages, ...added.map((message, index) => ({ ...message, id: 20 + index }))]
+      return added.map((_message, index) => 20 + index)
+    })
+    localGetSessionDetailPaginatedMock.mockImplementation((_id: string, offset: number, limit: number) => ({
+      session: { ...session, message_count: messages.length },
+      messages: messages.slice().reverse().slice(offset, offset + limit).reverse(),
+      total: messages.length,
+      offset,
+      limit,
+      hasMore: offset + limit < messages.length,
+    }))
+    getSessionDetailFromDbWithProfileMock.mockResolvedValue({
+      id: 'studio-page-root',
+      source: 'cli',
+      thread_session_count: 2,
+      messages: [
+        { id: 1, session_id: 'studio-page-root', role: 'user', content: 'root page turn', timestamp: 100 },
+        { id: 2, session_id: 'native-page-tip', role: 'assistant', content: 'continued page turn', timestamp: 200 },
+      ],
+    })
+
+    const mod = await import('../../packages/server/src/modules/studio/controllers/sessions')
+    const ctx: any = {
+      params: { id: 'studio-page-root' },
+      query: { profile: 'travel', offset: '0', limit: '20' },
+      state: {},
+      body: null,
+    }
+    await mod.getConversationMessagesPaginated(ctx)
+
+    expect(getSessionDetailFromDbWithProfileMock).toHaveBeenCalledWith('studio-page-root', 'travel')
+    expect(localGetSessionDetailPaginatedMock).toHaveBeenCalledWith('studio-page-root', 0, 20)
+    expect(ctx.body.session.id).toBe('studio-page-root')
+    expect(ctx.body.messages.map((message: any) => message.content)).toEqual([
+      'root page turn',
+      'continued page turn',
+    ])
+  })
+
+  it('denies a local Hermes message page before any native reconciliation read', async () => {
+    listUserProfilesMock.mockReturnValue([{ profile_name: 'travel' }])
+    localGetSessionDetailMock.mockReturnValue({
+      id: 'private-page', profile: 'private', source: 'cli', messages: [],
+    })
+    const mod = await import('../../packages/server/src/modules/studio/controllers/sessions')
+    const ctx: any = {
+      params: { id: 'private-page' },
+      query: { offset: '0', limit: '20' },
+      state: { user: { id: 7, role: 'user' } },
+      body: null,
+    }
+
+    await mod.getConversationMessagesPaginated(ctx)
+
+    expect(ctx.status).toBe(403)
+    expect(getSessionDetailFromDbWithProfileMock).not.toHaveBeenCalled()
+    expect(getSessionDetailPaginatedFromDbWithProfileMock).not.toHaveBeenCalled()
+    expect(localGetSessionDetailPaginatedMock).not.toHaveBeenCalled()
+  })
+
   it('falls back to Hermes state.db when local history detail is missing', async () => {
     localGetSessionDetailMock.mockReturnValue(null)
     getSessionDetailFromDbMock.mockResolvedValue({
@@ -2291,6 +2439,63 @@ describe('session conversations controller', () => {
     }))
     expect(localUpdateSessionMock.mock.calls.at(-1)?.[1].last_active).toBeGreaterThan(200)
     expect(ctx.body).toMatchObject({ ok: true, imported: true })
+  })
+
+  it('reconciles a continuation when importing an already-local Hermes session', async () => {
+    let localDetail: any = {
+      id: 'existing-import-root',
+      profile: 'travel',
+      source: 'cli',
+      title: 'Existing local session',
+      messages: [{ id: 10, session_id: 'existing-import-root', role: 'user', content: 'root turn', timestamp: 100 }],
+    }
+    localGetSessionDetailMock.mockImplementation(() => localDetail)
+    localAddMessagesMock.mockImplementation((messages: any[]) => {
+      localDetail = {
+        ...localDetail,
+        messages: [...localDetail.messages, ...messages.map((message, index) => ({ ...message, id: 20 + index }))],
+      }
+      return messages.map((_message, index) => 20 + index)
+    })
+    getSessionDetailFromDbWithProfileMock.mockResolvedValue({
+      id: 'existing-import-root',
+      source: 'cli',
+      thread_session_count: 2,
+      messages: [
+        { id: 1, session_id: 'existing-import-root', role: 'user', content: 'root turn', timestamp: 100 },
+        { id: 2, session_id: 'existing-import-tip', role: 'assistant', content: 'continued turn', timestamp: 200 },
+      ],
+    })
+
+    const mod = await import('../../packages/server/src/modules/studio/controllers/sessions')
+    const ctx: any = {
+      params: { id: 'existing-import-root' }, query: { profile: 'travel' }, state: {}, body: null,
+    }
+    await mod.importHermesSession(ctx)
+
+    expect(localCreateSessionMock).not.toHaveBeenCalled()
+    expect(ctx.body).toMatchObject({ ok: true, imported: false })
+    expect(ctx.body.session.messages.map((message: any) => message.content)).toEqual(['root turn', 'continued turn'])
+  })
+
+  it('denies an already-local import before any native reconciliation read', async () => {
+    listUserProfilesMock.mockReturnValue([{ profile_name: 'travel' }])
+    localGetSessionDetailMock.mockReturnValue({
+      id: 'private-import', profile: 'private', source: 'cli', messages: [],
+    })
+    const mod = await import('../../packages/server/src/modules/studio/controllers/sessions')
+    const ctx: any = {
+      params: { id: 'private-import' },
+      query: { profile: 'travel' },
+      state: { user: { id: 7, role: 'user' } },
+      body: null,
+    }
+
+    await mod.importHermesSession(ctx)
+
+    expect(ctx.status).toBe(403)
+    expect(getSessionDetailFromDbWithProfileMock).not.toHaveBeenCalled()
+    expect(localCreateSessionMock).not.toHaveBeenCalled()
   })
 
   describe('exportSession', () => {


### PR DESCRIPTION
## Summary
- Reconcile verified native Hermes compression continuations into an existing Studio conversation before loading history, resuming, or preparing the next direct Hermes run.
- Preserve the stable Studio session ID and Studio-only messages instead of replacing local history with a potentially lagging native snapshot. Deduplicate native turns/tool results using provenance markers and timestamp-aware matching, and invalidate stale compression context when new messages arrive.
- Authorize before reading/reconciling another profile, skip active runs, and preserve live socket state and queued turns across overlapping send/resume operations.

## Problem
An existing Studio-local conversation shadows newer Hermes history: detail and paginated endpoints return the local copy without reaching the native compression-lineage reader, and existing-session import is a no-op. Continuing that conversation in another Hermes surface can therefore leave Studio's displayed history and its next-turn context stale.

Hermes continuation traversal already exists. This change reuses it through the existing profile-scoped runtime interface rather than treating arbitrary parent/child links as continuations or making native history unconditionally authoritative.

Related: #2973 addresses Desktop-source list/search visibility; this PR addresses stale already-local histories and pre-send context, not the source allowlist.

## Validation
All execution used isolated temporary `HERMES_HOME`, `HERMES_WEB_UI_HOME`, `HERMES_WEBUI_STATE_DIR`, and `UPLOAD_DIR`; no live user history was used as fixtures or modified.
- `npm run test:coverage` — 5,278 passed, 6 skipped; coverage command passed.
- `npm run harness:check` — passed.
- `npm run build` — passed (existing bundle-size warnings).
- `npm run test:e2e -- --workers=2` — 179 passed; mocked browser/API suite.
- `git diff --check` — passed.
- Independent native Codex review: initial authorization and active-run race findings fixed with regressions; final commit review found no actionable defects.

Regression coverage includes local-only preservation, continuation tools, idempotency/repeated text, profile isolation, denied requests without native reads, detail/pagination/import, pre-send refresh, queued sends, and overlapping send/send and resume/send.

## Scope and limitations
- Reconciliation is triggered by history access/resume/send, not a background cross-surface synchronization daemon.
- This is intentionally limited to lineage-selected compression continuations for Hermes-backed local sessions. It does not merge arbitrary reset/fork branches or change coding-agent/global-agent workflows.
- Active Studio runs are not rewritten. This does not add cross-process locking between independent Hermes clients.
- No production deployment or manual live-Desktop/browser end-to-end mutation was performed.

## AI assistance disclosure
Implemented with AI assistance, independently reviewed, and validated with synthetic regression fixtures and the project test/build commands.
