### PR TITLE
fix(desktop): preserve MCP and Windows startup after Ekko rename

### DIFF
--- a/.github/workflows/desktop-manual-build.yml
+++ b/.github/workflows/desktop-manual-build.yml
@@ -128,9 +128,9 @@ jobs:
           npm ci --ignore-scripts
           npm rebuild node-pty
 
-      - name: Test Windows CLI shim
+      - name: Test Windows CLI and startup compatibility
         if: needs.validate.outputs.target_os == 'win32'
-        run: npm run test -- tests/desktop/cli-shim.test.ts
+        run: npm run test -- tests/desktop/cli-shim.test.ts tests/desktop/mcp-cli.test.ts tests/desktop/login-item-migration.test.ts
 
       - name: Build web UI
         run: npm run build

--- a/packages/desktop/README.md
+++ b/packages/desktop/README.md
@@ -31,6 +31,12 @@ Use `ekko-studio cli -h` for Hermes Agent CLI help and
 
 ## Data directories
 
+On Windows, the first packaged launch after the rename updates the existing
+Studio startup entry from `Hermes Studio.exe` to `Ekko Studio.exe` in the same
+installation directory. Its Task Manager enabled/disabled state is preserved.
+No entry is created if startup was never enabled; custom entries and machine-wide
+entries are left alone. The migration is safe to retry on later launches.
+
 Hermes Agent data is stored in `~/.hermes` on Windows, macOS, and Linux.
 
 The desktop wrapper's own Web UI state is stored separately in

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -49,6 +49,7 @@ import type { BrowserBounds } from './browser/browser-types'
 import { migratePendingLegacyWindowsData } from './legacy-windows-data-migration'
 import { createDesktopAppLifecycle } from './app-lifecycle'
 import { configureDesktopIdentity } from './desktop-identity'
+import { migrateWindowsLoginItem } from './login-item-migration'
 
 configureDesktopIdentity(app)
 
@@ -1317,6 +1318,11 @@ function runDesktopApp() {
     // visual clutter. macOS keeps a menu (system requirement) but Electron's
     // default is fine there.
     if (process.platform !== 'darwin') Menu.setApplicationMenu(null)
+    try {
+      migrateWindowsLoginItem(app, APP_USER_MODEL_ID)
+    } catch (error) {
+      console.warn('[desktop] failed to migrate the Windows login item:', error)
+    }
     installMicrophonePermissionHandler()
     createTray()
     await createWindow()

--- a/packages/desktop/src/main/login-item-migration.ts
+++ b/packages/desktop/src/main/login-item-migration.ts
@@ -1,0 +1,34 @@
+import type { App } from 'electron'
+import { win32 } from 'node:path'
+
+// The AppUserModelId (and therefore the Run value name) did not change with
+// branding. Replace that one value in place; never enable a new startup item.
+export function migrateWindowsLoginItem(
+  app: Pick<App, 'isPackaged' | 'getLoginItemSettings' | 'setLoginItemSettings'>,
+  appUserModelId: string,
+  executablePath = process.execPath,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  if (platform !== 'win32' || !app.isPackaged) return false
+  if (win32.basename(executablePath).toLowerCase() !== 'ekko studio.exe') return false
+
+  const legacyPath = win32.join(win32.dirname(executablePath), 'Hermes Studio.exe')
+  const args = ['--hidden']
+  const settings = app.getLoginItemSettings({ path: legacyPath, args })
+  const legacyItem = settings.launchItems?.find(item => (
+    item.scope === 'user' && item.name === appUserModelId &&
+    win32.normalize(item.path).toLowerCase() === win32.normalize(legacyPath).toLowerCase() &&
+    item.args.length === 1 && item.args[0] === '--hidden' &&
+    typeof item.enabled === 'boolean'
+  ))
+  if (!legacyItem) return false
+
+  app.setLoginItemSettings({
+    name: appUserModelId,
+    path: executablePath,
+    args,
+    openAtLogin: true,
+    enabled: legacyItem.enabled,
+  })
+  return true
+}

--- a/packages/desktop/src/main/mcp-cli.ts
+++ b/packages/desktop/src/main/mcp-cli.ts
@@ -5,7 +5,7 @@ export function parseBundledMcpArgs(argv: string[], resourcesPath: string): stri
   const script = argv[1]
   if (!script) return null
   const bin = join(resourcesPath, 'webui', 'bin')
-  if (!['hermes-studio-mcp.mjs', 'hermes-web-ui-mcp.mjs'].some(name => resolve(script) === join(bin, name))) {
+  if (!['ekko-studio-mcp.mjs', 'hermes-studio-mcp.mjs', 'hermes-web-ui-mcp.mjs'].some(name => resolve(script) === join(bin, name))) {
     return null
   }
   return argv.slice(1)

--- a/packages/server/src/modules/hermes/services/runtime/version-manager.ts
+++ b/packages/server/src/modules/hermes/services/runtime/version-manager.ts
@@ -13,7 +13,7 @@ import { cleanupRuntimePath, removeRuntimePath, renameRuntimePath } from './runt
 
 const ACTIVE_VERSION_FILE = 'active-version.json'
 const DEFAULT_REMOTE_MANIFEST_URL = 'https://api.ekkostudio.xyz/api/studio/versions'
-const FALLBACK_REMOTE_MANIFEST_URL = 'https://hermes-studio.ai/versions.json'
+const FALLBACK_REMOTE_MANIFEST_URL = 'https://ekkostudio.xyz/versions.json'
 const DEFAULT_DOWNLOAD_BASE_URL = 'https://download.ekkolearnai.com'
 const DEFAULT_GITHUB_REPO = 'EKKOLearnAI/hermes-studio'
 

--- a/scripts/verify-desktop-mcp.mjs
+++ b/scripts/verify-desktop-mcp.mjs
@@ -11,40 +11,42 @@ if (!process.argv[2] || !resources) {
 }
 const state = await mkdtemp(join(tmpdir(), 'hermes-desktop-mcp-'))
 try {
-  for (const toolset of ['api', 'browser', 'devices', 'use']) {
-    const env = {
-      ...process.env,
-      HERMES_WEB_UI_HOME: state,
-      HERMES_WEBUI_STATE_DIR: state,
-      HERMES_HOME: state,
-    }
-    delete env.ELECTRON_RUN_AS_NODE
-    const child = spawn(executable, [join(resources, 'webui', 'bin', 'hermes-studio-mcp.mjs'), toolset], {
-      env, stdio: ['pipe', 'pipe', 'pipe'],
-    })
-    let output = ''
-    let stderr = ''
-    child.stdout.on('data', chunk => { output += chunk })
-    child.stderr.on('data', chunk => { stderr += chunk })
-    const timer = setTimeout(() => child.kill('SIGKILL'), 15_000)
-    try {
-      const closed = new Promise((resolveClose, reject) => {
-        child.once('error', reject)
-        child.once('close', (code, signal) => resolveClose({ code, signal }))
+  for (const scriptName of ['ekko-studio-mcp.mjs', 'hermes-studio-mcp.mjs', 'hermes-web-ui-mcp.mjs']) {
+    for (const toolset of ['api', 'browser', 'devices', 'use']) {
+      const env = {
+        ...process.env,
+        HERMES_WEB_UI_HOME: state,
+        HERMES_WEBUI_STATE_DIR: state,
+        HERMES_HOME: state,
+      }
+      delete env.ELECTRON_RUN_AS_NODE
+      const child = spawn(executable, [join(resources, 'webui', 'bin', scriptName), toolset], {
+        env, stdio: ['pipe', 'pipe', 'pipe'],
       })
-      child.stdin.end(JSON.stringify({
-        jsonrpc: '2.0', id: 1, method: 'initialize',
-        params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'desktop-regression', version: '1' } },
-      }) + '\n')
-      const result = await closed
-      assert.equal(result.code, 0, `${toolset} exit: ${JSON.stringify(result)} ${stderr}`)
-      const messages = output.trim().split('\n').map(line => JSON.parse(line))
-      assert.equal(messages.length, 1, `Unexpected GUI or updater output: ${output}`)
-      assert.equal(messages[0].id, 1)
-      assert.ok(messages[0].result?.serverInfo)
-      console.log(`PASS ${toolset}: packaged MCP initializes without ELECTRON_RUN_AS_NODE and exits on stdin EOF`)
-    } finally {
-      clearTimeout(timer)
+      let output = ''
+      let stderr = ''
+      child.stdout.on('data', chunk => { output += chunk })
+      child.stderr.on('data', chunk => { stderr += chunk })
+      const timer = setTimeout(() => child.kill('SIGKILL'), 15_000)
+      try {
+        const closed = new Promise((resolveClose, reject) => {
+          child.once('error', reject)
+          child.once('close', (code, signal) => resolveClose({ code, signal }))
+        })
+        child.stdin.end(JSON.stringify({
+          jsonrpc: '2.0', id: 1, method: 'initialize',
+          params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'desktop-regression', version: '1' } },
+        }) + '\n')
+        const result = await closed
+        assert.equal(result.code, 0, `${toolset} exit: ${JSON.stringify(result)} ${stderr}`)
+        const messages = output.trim().split('\n').map(line => JSON.parse(line))
+        assert.equal(messages.length, 1, `Unexpected GUI or updater output: ${output}`)
+        assert.equal(messages[0].id, 1)
+        assert.ok(messages[0].result?.serverInfo)
+        console.log(`PASS ${scriptName} ${toolset}: packaged MCP initializes without ELECTRON_RUN_AS_NODE and exits on stdin EOF`)
+      } finally {
+        clearTimeout(timer)
+      }
     }
   }
 } finally {

--- a/tests/desktop/login-item-migration.test.ts
+++ b/tests/desktop/login-item-migration.test.ts
@@ -1,0 +1,89 @@
+import type { LoginItemSettings } from 'electron'
+import { describe, expect, it, vi } from 'vitest'
+import { migrateWindowsLoginItem } from '../../packages/desktop/src/main/login-item-migration'
+
+const appId = 'com.hermeswebui.studio'
+const executable = 'D:\\Custom Apps\\Studio\\Ekko Studio.exe'
+const legacyPath = 'D:\\Custom Apps\\Studio\\Hermes Studio.exe'
+type LaunchItem = NonNullable<LoginItemSettings['launchItems']>[number]
+
+function fixture(overrides: Partial<LaunchItem> = {}) {
+  const item: LaunchItem = {
+    name: appId, path: legacyPath, args: ['--hidden'], scope: 'user', enabled: true,
+    ...overrides,
+  }
+  const settings = { launchItems: [item] } as LoginItemSettings
+  const app = {
+    isPackaged: true,
+    getLoginItemSettings: vi.fn(() => settings),
+    setLoginItemSettings: vi.fn(),
+  }
+  return { app, item, settings }
+}
+
+describe('Windows login item migration across the Studio rename', () => {
+  it.each([true, false])('preserves startup approval enabled=%s in a custom installation directory', enabled => {
+    const { app } = fixture({ enabled })
+    expect(migrateWindowsLoginItem(app, appId, executable, 'win32')).toBe(true)
+    expect(app.getLoginItemSettings).toHaveBeenCalledWith({ path: legacyPath, args: ['--hidden'] })
+    expect(app.setLoginItemSettings).toHaveBeenCalledWith({
+      name: appId, path: executable, args: ['--hidden'], openAtLogin: true, enabled,
+    })
+  })
+
+  it('does not create a login item when startup was never enabled or the item was removed', () => {
+    const { app, settings } = fixture()
+    settings.launchItems = []
+    expect(migrateWindowsLoginItem(app, appId, executable, 'win32')).toBe(false)
+    expect(app.setLoginItemSettings).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    { name: 'another-app' },
+    { path: 'D:\\Other Studio\\Hermes Studio.exe' },
+    { path: executable },
+    { args: [] },
+    { args: ['--hidden', '--custom-option'] },
+    { scope: 'machine' },
+  ])('preserves a nonmatching or already migrated entry: %j', overrides => {
+    const { app } = fixture(overrides)
+    expect(migrateWindowsLoginItem(app, appId, executable, 'win32')).toBe(false)
+    expect(app.setLoginItemSettings).not.toHaveBeenCalled()
+  })
+
+  it('matches Windows paths without case sensitivity', () => {
+    const { app } = fixture({ path: legacyPath.toUpperCase() })
+    expect(migrateWindowsLoginItem(app, appId, executable, 'win32')).toBe(true)
+  })
+
+  it('is idempotent after replacing the existing value', () => {
+    const { app, item } = fixture()
+    app.setLoginItemSettings.mockImplementation(() => { item.path = executable })
+    expect(migrateWindowsLoginItem(app, appId, executable, 'win32')).toBe(true)
+    expect(migrateWindowsLoginItem(app, appId, executable, 'win32')).toBe(false)
+    expect(app.setLoginItemSettings).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not access login items in development or on other platforms', () => {
+    const { app } = fixture()
+    for (const platform of ['darwin', 'linux'] as const) {
+      expect(migrateWindowsLoginItem(app, appId, executable, platform)).toBe(false)
+    }
+    app.isPackaged = false
+    expect(migrateWindowsLoginItem(app, appId, executable, 'win32')).toBe(false)
+    expect(app.getLoginItemSettings).not.toHaveBeenCalled()
+  })
+
+  it('does not migrate when running a differently named executable', () => {
+    const { app } = fixture()
+    expect(migrateWindowsLoginItem(app, appId, legacyPath, 'win32')).toBe(false)
+    expect(app.getLoginItemSettings).not.toHaveBeenCalled()
+  })
+
+  it('surfaces a write failure without deleting the old entry', () => {
+    const { app, item } = fixture()
+    app.setLoginItemSettings.mockImplementation(() => { throw new Error('registry unavailable') })
+    expect(() => migrateWindowsLoginItem(app, appId, executable, 'win32')).toThrow('registry unavailable')
+    expect(item.path).toBe(legacyPath)
+  })
+})

--- a/tests/desktop/mcp-cli.test.ts
+++ b/tests/desktop/mcp-cli.test.ts
@@ -2,16 +2,16 @@ import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { parseBundledMcpArgs } from '../../packages/desktop/src/main/mcp-cli'
 
-describe('legacy packaged MCP invocation', () => {
+describe('packaged MCP invocation across the Studio rename', () => {
   const resources = join(process.cwd(), 'test-app', 'Resources')
 
-  it.each(['hermes-studio-mcp.mjs', 'hermes-web-ui-mcp.mjs'])('preserves the arguments for %s', name => {
+  it.each(['ekko-studio-mcp.mjs', 'hermes-studio-mcp.mjs', 'hermes-web-ui-mcp.mjs'])('preserves the arguments for %s', name => {
     const script = join(resources, 'webui', 'bin', name)
     expect(parseBundledMcpArgs(['Hermes Studio', script, 'devices'], resources)).toEqual([script, 'devices'])
   })
 
   it('leaves ordinary desktop, CLI, and arbitrary script invocations alone', () => {
-    for (const args of [[], ['--hidden'], ['--quit'], ['--hermes-cli', 'status'], ['/tmp/hermes-studio-mcp.mjs']]) {
+    for (const args of [[], ['--hidden'], ['--quit'], ['--hermes-cli', 'status'], ['/tmp/hermes-studio-mcp.mjs'], ['/tmp/ekko-studio-mcp.mjs']]) {
       expect(parseBundledMcpArgs(['Hermes Studio', ...args], resources)).toBeNull()
     }
   })

--- a/tests/server/runtime-version-manager.test.ts
+++ b/tests/server/runtime-version-manager.test.ts
@@ -258,7 +258,7 @@ describe('runtime version manager storage migration', () => {
     )
     expect(fetchMock).toHaveBeenNthCalledWith(
       2,
-      'https://hermes-studio.ai/versions.json',
+      'https://ekkostudio.xyz/versions.json',
       expect.objectContaining({ signal: expect.any(AbortSignal) }),
     )
     expect(status.hermes.remoteVersions).toEqual(['0.19.1', '0.20.0'])


### PR DESCRIPTION
## Summary
- Recognize `ekko-studio-mcp.mjs` at the packaged desktop entrypoint so an Electron-based MCP invocation still initializes when `ELECTRON_RUN_AS_NODE` is missing. Preserve both legacy entrypoints and exercise all three names in the packaged-process verification script.
- On the first Windows launch after upgrading, replace the existing user startup entry pointing to `Hermes Studio.exe` with the current `Ekko Studio.exe` in the same installation directory. Reuse the stable AppUserModelId registry value and retain the Task Manager enabled/disabled state. Never create an entry for users who did not enable startup; leave custom arguments, other installations, and machine-wide entries alone. Repeated launches make no further change.
- Move the version manifest fallback to `https://ekkostudio.xyz/versions.json` and include the MCP/startup regression suites in manual Windows builds.

## Validation
- Focused desktop migration, MCP entrypoint, profile identity, CLI shim, and version-manager suites: 51 passed, 1 Windows-only test skipped on macOS.
- `npm run build:main --prefix packages/desktop`, `npm run build`, and `npm run harness:check`: passed.
- Real Electron 42.3.0 macOS ARM64 process verification: all 12 combinations (3 script names × 4 toolsets) initialized and exited cleanly without `ELECTRON_RUN_AS_NODE`. Used a disposable packaged probe containing the compiled production entrypoint/MCP module and bundled scripts; GUI fallback deliberately throws. This was not a full installer upgrade test.
- Workflow YAML parsed successfully; `actionlint` is not installed locally.
- New website version manifest returned HTTP 200 and JSON.
- Windows registry behavior is covered by mocked Electron API tests; a real installed Windows upgrade remains to be verified.
