### PR TITLE
feat: add latest-announcement dialog to Studio

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -209,6 +209,10 @@
       "description": "Per-user appearance settings and background image"
     },
     {
+      "name": "Announcements",
+      "description": "Published Studio desktop announcements, newest first"
+    },
+    {
       "name": "API Docs",
       "description": "OpenAPI route catalog"
     },
@@ -10865,6 +10869,42 @@
             "description": "Not found"
           }
         }
+      }
+    },
+    "/api/studio/announcements": {
+      "get": {
+        "tags": [
+          "Announcements"
+        ],
+        "summary": "Get announcements",
+        "description": "GET /api/studio/announcements",
+        "operationId": "getAnnouncements",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        },
+        "parameters": [
+          {
+            "name": "locale",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
     },
     "/api/studio/app-uploads": {

--- a/packages/client/src/App.vue
+++ b/packages/client/src/App.vue
@@ -71,6 +71,9 @@ const RuntimeRestartPrompt = defineAsyncComponent(
   async () =>
     (await import("@/components/layout/RuntimeRestartPrompt.vue")).default,
 );
+const StudioAnnouncementPrompt = defineAsyncComponent(
+  async () => (await import('@/components/layout/StudioAnnouncementPrompt.vue')).default,
+);
 
 const {
   isDark,
@@ -343,6 +346,9 @@ useKeyboard();
           />
           <RuntimeRestartPrompt
             v-if="!isLoginPage && !isDesktopPetRoute && !isStandaloneChatPage && isStoredSuperAdmin()"
+          />
+          <StudioAnnouncementPrompt
+            v-if="!isLoginPage && !isInviteOnlyPage && !isDesktopPetRoute && !isStandaloneChatPage"
           />
         </NNotificationProvider>
       </NDialogProvider>

--- a/packages/client/src/api/studio/announcements.ts
+++ b/packages/client/src/api/studio/announcements.ts
@@ -1,0 +1,18 @@
+import { request } from '@/api/client'
+
+export interface StudioAnnouncement {
+  id: number
+  updateTime: number
+  title: string
+  content: string
+  type: 'info' | 'success' | 'warning' | 'critical'
+  dismissible: boolean
+  actionUrl: string | null
+}
+
+export function fetchStudioAnnouncements(locale: string) {
+  const language = /^zh(?:[-_]|$)/i.test(locale) ? 'zh-CN' : 'en'
+  return request<{ ok: boolean; platform: 'desktop'; list: StudioAnnouncement[] }>(
+    `/api/studio/announcements?locale=${language}`, { cache: 'no-store' },
+  )
+}

--- a/packages/client/src/components/layout/StudioAnnouncementPrompt.vue
+++ b/packages/client/src/components/layout/StudioAnnouncementPrompt.vue
@@ -1,0 +1,142 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { NButton, NCard, NModal } from 'naive-ui'
+import { useI18n } from 'vue-i18n'
+import { fetchStudioAnnouncements, type StudioAnnouncement } from '@/api/studio/announcements'
+import { openUrlInDesktopBrowser } from '@/utils/desktop-browser'
+
+const STORAGE_KEY = 'hermes-studio:seen-announcements:v1'
+const { t, locale } = useI18n()
+const announcement = ref<StudioAnnouncement | null>(null)
+const seen = new Map<number, number>()
+let mounted = false
+let checking = false
+
+const actionUrl = computed(() => {
+  try {
+    const url = new URL(announcement.value?.actionUrl || '')
+    return ['https:', 'http:'].includes(url.protocol) ? url.href : null
+  } catch {
+    return null
+  }
+})
+
+function restoreSeen() {
+  try {
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}')
+    if (stored.version !== 1 || !stored.entries || typeof stored.entries !== 'object') return
+    for (const [id, time] of Object.entries(stored.entries)) {
+      if (Number.isSafeInteger(Number(id)) && Number(id) > 0
+        && Number.isSafeInteger(Number(time)) && Number(time) > 0) {
+        seen.set(Number(id), Math.max(seen.get(Number(id)) || 0, Number(time)))
+      }
+    }
+  } catch {
+    // Keep in-memory deduplication when storage is unavailable.
+  }
+}
+
+function isPageVisible() {
+  return document.visibilityState !== 'hidden'
+}
+
+async function checkAnnouncements() {
+  if (!mounted || checking || announcement.value || !isPageVisible()) return
+  checking = true
+  try {
+    const response = await fetchStudioAnnouncements(locale.value)
+    if (!mounted || !isPageVisible() || response.ok !== true || response.platform !== 'desktop') return
+    // Select the latest before checking read state: never drain older notices.
+    const latest = Array.isArray(response.list) ? response.list[0] : null
+    if (!latest || !Number.isSafeInteger(latest.id) || latest.id <= 0
+      || !Number.isSafeInteger(latest.updateTime) || latest.updateTime <= 0
+      || typeof latest.title !== 'string' || !latest.title.trim()
+      || typeof latest.content !== 'string' || !latest.content.trim()) return
+    restoreSeen()
+    if ((seen.get(latest.id) || 0) >= latest.updateTime) return
+    announcement.value = latest
+  } catch {
+    // Announcements are optional; network failures must not interrupt Studio.
+  } finally {
+    checking = false
+  }
+}
+
+function dismiss() {
+  const current = announcement.value
+  if (!current) return
+  restoreSeen()
+  seen.set(current.id, current.updateTime)
+  try {
+    const entries = Object.fromEntries([...seen].sort((a, b) => b[1] - a[1]).slice(0, 200))
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ version: 1, entries }))
+  } catch {
+    // The in-memory marker still prevents repeated prompts in this page.
+  }
+  announcement.value = null
+}
+
+function confirm() {
+  const url = actionUrl.value
+  if (url) {
+    void openUrlInDesktopBrowser(url).then(opened => {
+      if (!opened) window.open(url, '_blank', 'noopener,noreferrer')
+    }).catch(() => undefined)
+  }
+  dismiss()
+}
+
+onMounted(() => {
+  mounted = true
+  void checkAnnouncements()
+  window.addEventListener('focus', checkAnnouncements)
+  document.addEventListener('visibilitychange', checkAnnouncements)
+})
+
+onBeforeUnmount(() => {
+  mounted = false
+  window.removeEventListener('focus', checkAnnouncements)
+  document.removeEventListener('visibilitychange', checkAnnouncements)
+})
+</script>
+
+<template>
+  <NModal v-if="announcement" :show="true" :mask-closable="false" :close-on-esc="false">
+    <NCard
+      data-testid="studio-announcement"
+      role="dialog"
+      aria-modal="true"
+      :aria-label="announcement.title"
+      :title="announcement.title"
+      :bordered="false"
+      style="width: min(520px, calc(100vw - 32px))"
+    >
+      <div class="announcement-content">{{ announcement.content }}</div>
+      <template #footer>
+        <div class="actions">
+          <NButton v-if="actionUrl && announcement.dismissible" @click="dismiss">
+            {{ t('announcements.later') }}
+          </NButton>
+          <NButton type="primary" @click="confirm">
+            {{ t(actionUrl ? 'announcements.details' : 'announcements.gotIt') }}
+          </NButton>
+        </div>
+      </template>
+    </NCard>
+  </NModal>
+</template>
+
+<style scoped lang="scss">
+.announcement-content {
+  max-height: min(50vh, 480px);
+  overflow-y: auto;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  line-height: 1.7;
+}
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+</style>

--- a/packages/client/src/i18n/locales/ar.ts
+++ b/packages/client/src/i18n/locales/ar.ts
@@ -1,6 +1,7 @@
 import { socialMessagesAr } from '../social-messages-locales'
 
 export default {
+  announcements: {"later": "لاحقًا", "details": "عرض التفاصيل", "gotIt": "فهمت"},
   taskPlan: {"title": "خطة المهام", "progress": "اكتمل {completed}/{total}", "pending": "غير مكتمل", "in_progress": "قيد التقدم", "completed": "مكتمل", "running": "قيد التنفيذ", "ended": "انتهى التنفيذ؛ توجد خطوات غير مكتملة", "interrupted": "تمت المقاطعة؛ توجد خطوات غير مكتملة", "failed": "فشل التنفيذ؛ توجد خطوات غير مكتملة"},
   agentAutoUpdate: { label: 'التحديثات التلقائية' },
   ekkoConfig: {

--- a/packages/client/src/i18n/locales/de.ts
+++ b/packages/client/src/i18n/locales/de.ts
@@ -1,6 +1,7 @@
 import { socialMessagesDe } from '../social-messages-locales'
 
 export default {
+  announcements: {"later": "Später", "details": "Details ansehen", "gotIt": "Verstanden"},
   taskPlan: {"title": "Aufgabenplan", "progress": "{completed}/{total} abgeschlossen", "pending": "Nicht abgeschlossen", "in_progress": "In Bearbeitung", "completed": "Abgeschlossen", "running": "Wird ausgeführt", "ended": "Lauf beendet; Schritte bleiben offen", "interrupted": "Unterbrochen; Schritte bleiben offen", "failed": "Lauf fehlgeschlagen; Schritte bleiben offen"},
   agentAutoUpdate: { label: 'Automatische Updates' },
   ekkoConfig: {

--- a/packages/client/src/i18n/locales/en.ts
+++ b/packages/client/src/i18n/locales/en.ts
@@ -1,6 +1,7 @@
 import { socialMessagesEn } from '../social-messages'
 
 export default {
+  announcements: {"later": "Later", "details": "View details", "gotIt": "Got it"},
   taskPlan: {"title": "Task plan", "progress": "{completed}/{total} completed", "pending": "Not completed", "in_progress": "In progress", "completed": "Completed", "running": "Running", "ended": "Run ended; unfinished steps remain", "interrupted": "Interrupted; unfinished steps remain", "failed": "Run failed; unfinished steps remain"},
   agentAutoUpdate: { label: 'Automatic updates' },
   ekkoConfig: {

--- a/packages/client/src/i18n/locales/es.ts
+++ b/packages/client/src/i18n/locales/es.ts
@@ -1,6 +1,7 @@
 import { socialMessagesEs } from '../social-messages-locales'
 
 export default {
+  announcements: {"later": "Más tarde", "details": "Ver detalles", "gotIt": "Entendido"},
   taskPlan: {"title": "Plan de tareas", "progress": "{completed}/{total} completadas", "pending": "Pendiente", "in_progress": "En curso", "completed": "Completado", "running": "En ejecución", "ended": "Ejecución finalizada; quedan pasos pendientes", "interrupted": "Interrumpido; quedan pasos pendientes", "failed": "Ejecución fallida; quedan pasos pendientes"},
   agentAutoUpdate: { label: 'Actualizaciones automáticas' },
   ekkoConfig: {

--- a/packages/client/src/i18n/locales/fr.ts
+++ b/packages/client/src/i18n/locales/fr.ts
@@ -1,6 +1,7 @@
 import { socialMessagesFr } from '../social-messages-locales'
 
 export default {
+  announcements: {"later": "Plus tard", "details": "Voir les détails", "gotIt": "Compris"},
   taskPlan: {"title": "Plan des tâches", "progress": "{completed}/{total} terminées", "pending": "Non terminé", "in_progress": "En cours", "completed": "Terminé", "running": "Exécution en cours", "ended": "Exécution terminée ; des étapes restent à faire", "interrupted": "Interrompu ; des étapes restent à faire", "failed": "Échec ; des étapes restent à faire"},
   agentAutoUpdate: { label: 'Mises à jour automatiques' },
   ekkoConfig: {

--- a/packages/client/src/i18n/locales/ja.ts
+++ b/packages/client/src/i18n/locales/ja.ts
@@ -1,6 +1,7 @@
 import { socialMessagesJa } from '../social-messages-locales'
 
 export default {
+  announcements: {"later": "後で", "details": "詳細を見る", "gotIt": "確認しました"},
   taskPlan: {"title": "タスク計画", "progress": "{completed}/{total} 完了", "pending": "未完了", "in_progress": "進行中", "completed": "完了", "running": "実行中", "ended": "実行終了・未完了の手順があります", "interrupted": "中断・未完了の手順があります", "failed": "実行失敗・未完了の手順があります"},
   agentAutoUpdate: { label: '自動更新' },
   ekkoConfig: {

--- a/packages/client/src/i18n/locales/ko.ts
+++ b/packages/client/src/i18n/locales/ko.ts
@@ -1,6 +1,7 @@
 import { socialMessagesKo } from '../social-messages-locales'
 
 export default {
+  announcements: {"later": "나중에", "details": "자세히 보기", "gotIt": "확인"},
   taskPlan: {"title": "작업 계획", "progress": "{completed}/{total} 완료", "pending": "미완료", "in_progress": "진행 중", "completed": "완료", "running": "실행 중", "ended": "실행 종료 · 미완료 단계가 있습니다", "interrupted": "중단됨 · 미완료 단계가 있습니다", "failed": "실행 실패 · 미완료 단계가 있습니다"},
   agentAutoUpdate: { label: '자동 업데이트' },
   ekkoConfig: {

--- a/packages/client/src/i18n/locales/pt.ts
+++ b/packages/client/src/i18n/locales/pt.ts
@@ -1,6 +1,7 @@
 import { socialMessagesPt } from '../social-messages-locales'
 
 export default {
+  announcements: {"later": "Mais tarde", "details": "Ver detalhes", "gotIt": "Entendido"},
   taskPlan: {"title": "Plano de tarefas", "progress": "{completed}/{total} concluídas", "pending": "Pendente", "in_progress": "Em andamento", "completed": "Concluído", "running": "Em execução", "ended": "Execução encerrada; há etapas pendentes", "interrupted": "Interrompido; há etapas pendentes", "failed": "Falha na execução; há etapas pendentes"},
   agentAutoUpdate: { label: 'Atualizações automáticas' },
   ekkoConfig: {

--- a/packages/client/src/i18n/locales/ru.ts
+++ b/packages/client/src/i18n/locales/ru.ts
@@ -1,6 +1,7 @@
 import { socialMessagesRu } from '../social-messages-locales'
 
 export default {
+  announcements: {"later": "Позже", "details": "Подробнее", "gotIt": "Понятно"},
   taskPlan: {"title": "План задач", "progress": "Завершено: {completed}/{total}", "pending": "Не завершено", "in_progress": "В процессе", "completed": "Завершено", "running": "Выполняется", "ended": "Запуск завершён; остались незавершённые шаги", "interrupted": "Прервано; остались незавершённые шаги", "failed": "Ошибка выполнения; остались незавершённые шаги"},
   agentAutoUpdate: { label: 'Автоматические обновления' },
   ekkoConfig: {

--- a/packages/client/src/i18n/locales/zh-TW.ts
+++ b/packages/client/src/i18n/locales/zh-TW.ts
@@ -1,6 +1,7 @@
 import { socialMessagesZhTw } from '../social-messages'
 
 export default {
+  announcements: {"later": "稍後", "details": "查看詳情", "gotIt": "知道了"},
   taskPlan: {"title": "任務計畫", "progress": "{completed}/{total} 已完成", "pending": "未完成", "in_progress": "進行中", "completed": "已完成", "running": "執行中", "ended": "本次執行已結束，其餘步驟未完成", "interrupted": "已中斷，其餘步驟未完成", "failed": "執行失敗，其餘步驟未完成"},
   agentAutoUpdate: { label: '自動更新' },
   ekkoConfig: {

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -1,6 +1,7 @@
 import { socialMessagesZh } from '../social-messages'
 
 export default {
+  announcements: {"later": "稍后", "details": "查看详情", "gotIt": "知道了"},
   taskPlan: {"title": "任务计划", "progress": "{completed}/{total} 已完成", "pending": "未完成", "in_progress": "进行中", "completed": "已完成", "running": "执行中", "ended": "本次运行已结束，剩余步骤未完成", "interrupted": "已中断，剩余步骤未完成", "failed": "运行失败，剩余步骤未完成"},
   agentAutoUpdate: { label: '自动更新' },
   ekkoConfig: {

--- a/packages/server/src/bootstrap/routes.ts
+++ b/packages/server/src/bootstrap/routes.ts
@@ -10,6 +10,7 @@ import { apiDocsRoutes } from '../modules/studio'
 import { healthRoutes } from './health'
 import { updateRoutes } from './update'
 import { themeRoutes } from '../modules/studio/routes/theme'
+import { announcementRoutes } from '../modules/studio/routes/announcements'
 import { appConnectionRoutes, appRelayRoutes } from './app-relay'
 import { devicePublicRoutes, deviceRoutes } from './devices'
 import { socialMessageRoutes } from '../modules/studio/routes/social-messages'
@@ -104,6 +105,7 @@ export function registerRoutes(app: any, authMiddleware: Array<(ctx: Context, ne
   app.use(codingAgentRoutes.routes())
   app.use(agentStatusRoutes.routes())
   app.use(themeRoutes.routes())
+  app.use(announcementRoutes.routes())
   app.use(appRelayRoutes.routes())
   app.use(socialMessageRoutes.routes())
   app.use(sessionRoutes.routes())

--- a/packages/server/src/modules/studio/controllers/announcements.ts
+++ b/packages/server/src/modules/studio/controllers/announcements.ts
@@ -1,0 +1,12 @@
+import type { Context } from 'koa'
+import { fetchStudioAnnouncements } from '../services/notifications/announcements'
+
+export async function getAnnouncements(ctx: Context): Promise<void> {
+  ctx.set('Cache-Control', 'no-store')
+  try {
+    ctx.body = await fetchStudioAnnouncements(ctx.query.locale)
+  } catch {
+    ctx.status = 502
+    ctx.body = { ok: false, error: 'announcement_fetch_failed' }
+  }
+}

--- a/packages/server/src/modules/studio/routes/announcements.ts
+++ b/packages/server/src/modules/studio/routes/announcements.ts
@@ -1,0 +1,5 @@
+import Router from '@koa/router'
+import * as ctrl from '../controllers/announcements'
+
+export const announcementRoutes = new Router()
+announcementRoutes.get('/api/studio/announcements', ctrl.getAnnouncements)

--- a/packages/server/src/modules/studio/services/notifications/announcements.ts
+++ b/packages/server/src/modules/studio/services/notifications/announcements.ts
@@ -1,0 +1,17 @@
+const ANNOUNCEMENTS_URL = 'https://api.ekkostudio.xyz/api/studio/announcements'
+
+export async function fetchStudioAnnouncements(localeInput: unknown): Promise<unknown> {
+  const locale = /^zh(?:[-_]|$)/i.test(String(localeInput || 'en')) ? 'zh-CN' : 'en'
+  const url = new URL(ANNOUNCEMENTS_URL)
+  url.searchParams.set('locale', locale)
+  const response = await fetch(url.toString(), {
+    headers: { Accept: 'application/json' },
+    signal: AbortSignal.timeout(10_000),
+  })
+  if (!response.ok) throw new Error('announcement_fetch_failed')
+  const data = await response.json() as { ok?: boolean; platform?: string; list?: unknown }
+  if (!data || data.ok !== true || data.platform !== 'desktop' || !Array.isArray(data.list)) {
+    throw new Error('invalid_announcement_response')
+  }
+  return data
+}

--- a/scripts/generate-openapi.mjs
+++ b/scripts/generate-openapi.mjs
@@ -96,6 +96,7 @@ const tagMappings = {
   'modules/studio/routes/mcu-devices.ts': { name: 'MCU Devices', description: 'Microcontroller device management' },
   'modules/studio/routes/mcu-firmware.ts': { name: 'MCU Firmware', description: 'Microcontroller firmware distribution' },
   'modules/studio/routes/theme.ts': { name: 'Theme', description: 'Per-user appearance settings and background image' },
+  'modules/studio/routes/announcements.ts': { name: 'Announcements', description: 'Published Studio desktop announcements, newest first' },
   'modules/studio/routes/api-docs.ts': { name: 'API Docs', description: 'OpenAPI route catalog' },
   'modules/studio/routes/agent-status.ts': { name: 'Agent Status', description: 'In-memory Agent installation, version, and source status' },
   'modules/coding-agents/routes/agents.ts': { name: 'Coding Agents', description: 'Coding agent installation, config, and runs' },

--- a/tests/client/studio-announcements.test.ts
+++ b/tests/client/studio-announcements.test.ts
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import type { StudioAnnouncement } from '@/api/studio/announcements'
+
+const api = vi.hoisted(() => ({ fetchStudioAnnouncements: vi.fn() }))
+const browser = vi.hoisted(() => ({ openUrlInDesktopBrowser: vi.fn() }))
+vi.mock('@/api/studio/announcements', () => api)
+vi.mock('@/utils/desktop-browser', () => browser)
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (key: string) => key, locale: ref('zh-TW') }) }))
+vi.mock('naive-ui', () => ({
+  NButton: { template: '<button><slot /></button>' },
+  NCard: { props: ['title'], template: '<section><h1>{{ title }}</h1><slot /><slot name="footer" /></section>' },
+  NModal: { props: ['show'], template: '<div v-if="show"><slot /></div>' },
+}))
+
+import StudioAnnouncementPrompt from '@/components/layout/StudioAnnouncementPrompt.vue'
+
+const latest: StudioAnnouncement = { id: 3, updateTime: 100, title: 'Latest news', content: '<b>Plain text</b>', type: 'info', dismissible: true, actionUrl: null }
+const response = (list = [latest, { ...latest, id: 2, title: 'Old news' }]) => ({ ok: true, platform: 'desktop', list })
+let wrapper: VueWrapper | undefined
+const start = async () => { wrapper = mount(StudioAnnouncementPrompt); await flushPromises(); return wrapper }
+const focus = async () => { window.dispatchEvent(new Event('focus')); await flushPromises() }
+
+beforeEach(() => {
+  localStorage.clear()
+  vi.clearAllMocks()
+  api.fetchStudioAnnouncements.mockResolvedValue(response())
+  browser.openUrlInDesktopBrowser.mockResolvedValue(true)
+})
+afterEach(() => { wrapper?.unmount(); vi.restoreAllMocks() })
+
+describe('Studio announcement prompt', () => {
+  it('shows only the latest, renders content as text, and persists dismissal across mounts', async () => {
+    const ui = await start()
+    expect(api.fetchStudioAnnouncements).toHaveBeenCalledWith('zh-TW')
+    expect(ui.text()).toContain('Latest news')
+    expect(ui.text()).not.toContain('Old news')
+    expect(ui.find('b').exists()).toBe(false)
+    await ui.get('button').trigger('click')
+    await focus()
+    expect(ui.find('section').exists()).toBe(false)
+    ui.unmount()
+    await start()
+    expect(wrapper!.find('section').exists()).toBe(false)
+  })
+
+  it('allows a new announcement and an updated latest version to appear', async () => {
+    const ui = await start()
+    await ui.get('button').trigger('click')
+    api.fetchStudioAnnouncements.mockResolvedValue(response([{ ...latest, updateTime: 200 }]))
+    await focus()
+    expect(ui.find('section').exists()).toBe(true)
+    await ui.get('button').trigger('click')
+    api.fetchStudioAnnouncements.mockResolvedValue(response([{ ...latest, id: 4 }]))
+    await focus()
+    expect(ui.find('section').exists()).toBe(true)
+  })
+
+  it('ignores overlapping checks and discards requests resolved after unmount', async () => {
+    let resolve!: (value: unknown) => void
+    api.fetchStudioAnnouncements.mockReturnValue(new Promise(done => { resolve = done }))
+    const ui = await start()
+    await focus()
+    expect(api.fetchStudioAnnouncements).toHaveBeenCalledTimes(1)
+    ui.unmount()
+    resolve(response())
+    await flushPromises()
+    await focus()
+    expect(api.fetchStudioAnnouncements).toHaveBeenCalledTimes(1)
+    expect(localStorage.length).toBe(0)
+  })
+
+  it('recovers from network failure on a foreground check', async () => {
+    api.fetchStudioAnnouncements.mockRejectedValueOnce(new Error('offline'))
+    const ui = await start()
+    expect(ui.find('section').exists()).toBe(false)
+    await focus()
+    expect(ui.find('section').exists()).toBe(true)
+  })
+
+  it('opens a valid action through the existing browser helper', async () => {
+    api.fetchStudioAnnouncements.mockResolvedValue(response([{ ...latest, actionUrl: 'https://example.com/news' }]))
+    const ui = await start()
+    expect(ui.findAll('button')).toHaveLength(2)
+    await ui.findAll('button')[1].trigger('click')
+    await flushPromises()
+    expect(browser.openUrlInDesktopBrowser).toHaveBeenCalledWith('https://example.com/news')
+    expect(ui.find('section').exists()).toBe(false)
+  })
+
+  it('rejects unsafe action URLs and still allows acknowledgement', async () => {
+    api.fetchStudioAnnouncements.mockResolvedValue(response([{ ...latest, actionUrl: 'javascript:alert(1)' }]))
+    const ui = await start()
+    expect(ui.findAll('button')).toHaveLength(1)
+    await ui.get('button').trigger('click')
+    expect(browser.openUrlInDesktopBrowser).not.toHaveBeenCalled()
+  })
+
+  it('keeps dismissal in memory if local storage is unavailable', async () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => { throw new Error('unavailable') })
+    const ui = await start()
+    await ui.get('button').trigger('click')
+    await focus()
+    expect(ui.find('section').exists()).toBe(false)
+  })
+})

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -204,6 +204,11 @@ export async function mockHermesApi(page: Page, options: MockHermesApiOptions = 
 
     requests.push(recordRequest(request))
 
+    if (pathname === '/api/studio/announcements') {
+      await route.fulfill(jsonResponse({ ok: true, platform: 'desktop', list: [] }))
+      return
+    }
+
     if (pathname === '/health') {
       await route.fulfill(jsonResponse({ status: 'ok', webui_version: '0.5.23', node_version: '23.0.0' }))
       return

--- a/tests/e2e/studio-announcements.spec.ts
+++ b/tests/e2e/studio-announcements.spec.ts
@@ -1,0 +1,38 @@
+import { expect, test } from '@playwright/test'
+import { authenticate, mockHermesApi } from './fixtures'
+
+test('only the latest Studio announcement is shown, including after reload and foreground checks', async ({ page }) => {
+  await authenticate(page)
+  const api = await mockHermesApi(page)
+  const latest = { id: 3, updateTime: 100, title: 'Latest Studio news', content: 'A new Studio release is ready.\nEnjoy!', type: 'info', dismissible: true, actionUrl: null }
+  let requests = 0
+  await page.route('**/api/studio/announcements?*', async route => {
+    requests++
+    await route.fulfill({ json: { ok: true, platform: 'desktop', list: [latest, { ...latest, id: 2, title: 'Older Studio news' }] } })
+  })
+  await page.goto('/#/hermes/connections?view=download')
+  const dialog = page.getByTestId('studio-announcement')
+  await expect(dialog).toBeVisible()
+  await expect(dialog).toContainText(latest.title)
+  await expect(page.getByText('Older Studio news', { exact: true })).toHaveCount(0)
+  await dialog.getByRole('button', { name: 'Got it', exact: true }).click()
+  await expect(dialog).toHaveCount(0)
+  await page.reload()
+  await expect.poll(() => requests).toBeGreaterThanOrEqual(2)
+  await expect(dialog).toHaveCount(0)
+  latest.updateTime = 200
+  await page.evaluate(() => window.dispatchEvent(new Event('focus')))
+  await expect(dialog).toBeVisible()
+  await dialog.getByRole('button', { name: 'Got it', exact: true }).click()
+  await expect(dialog).toHaveCount(0)
+  expect(api.unexpectedRequests).toEqual([])
+})
+
+test('announcement errors do not block the Studio shell', async ({ page }) => {
+  await authenticate(page)
+  await mockHermesApi(page)
+  await page.route('**/api/studio/announcements?*', route => route.fulfill({ status: 502, json: { ok: false } }))
+  await page.goto('/#/hermes/connections?view=download')
+  await expect(page.getByText('APK v1.0.0', { exact: true })).toBeVisible()
+  await expect(page.getByTestId('studio-announcement')).toHaveCount(0)
+})

--- a/tests/server/studio-announcements.test.ts
+++ b/tests/server/studio-announcements.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { fetchStudioAnnouncements } from '../../packages/server/src/modules/studio/services/notifications/announcements'
+import { getAnnouncements } from '../../packages/server/src/modules/studio/controllers/announcements'
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe('Studio announcement delivery', () => {
+  it.each([['zh-TW', 'zh-CN'], ['zh', 'zh-CN'], ['en', 'en'], ['ja', 'en']])('fetches desktop announcements for %s', async (input, expectedLocale) => {
+    const data = { ok: true, platform: 'desktop', list: [{ id: 2 }, { id: 1 }] }
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify(data)))
+    vi.stubGlobal('fetch', fetchMock)
+    expect(await fetchStudioAnnouncements(input)).toEqual(data)
+    expect(fetchMock).toHaveBeenCalledWith(`https://api.ekkostudio.xyz/api/studio/announcements?locale=${expectedLocale}`, {
+      headers: { Accept: 'application/json' }, signal: expect.any(AbortSignal),
+    })
+  })
+
+  it.each([
+    { ok: true, platform: 'app', list: [] },
+    { ok: false, platform: 'desktop', list: [] },
+    { ok: true, platform: 'desktop', list: null },
+    null,
+  ])('rejects a malformed or wrong-platform response', async data => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify(data))))
+    await expect(fetchStudioAnnouncements('en')).rejects.toThrow()
+  })
+
+  it('returns a non-auth error for an unavailable announcement service', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('', { status: 401 })))
+    const ctx = { query: { locale: 'en' }, set: vi.fn() } as any
+    await getAnnouncements(ctx)
+    expect(ctx.status).toBe(502)
+    expect(ctx.body).toEqual({ ok: false, error: 'announcement_fetch_failed' })
+    expect(ctx.set).toHaveBeenCalledWith('Cache-Control', 'no-store')
+  })
+})


### PR DESCRIPTION
## Summary
Studio had no UI for the desktop announcements already published by the cloud service. Add an announcement dialog to the authenticated desktop and browser main interface, checked on entry and when the window or tab returns to the foreground.

Only the latest announcement is considered. Dismissal is remembered locally by ID and update time, so older unread announcements are never replayed; a new announcement or updated latest version can appear again. Optional HTTP/HTTPS detail links follow the existing Studio browser preference. Login, invite-only, standalone chat, and pet windows are excluded.

The authenticated local endpoint proxies `https://api.ekkostudio.xyz/api/studio/announcements` without forwarding user credentials. Fetch failures do not interrupt the interface. Includes localized action labels, OpenAPI registration, and regression coverage.

## Validation
- `npm run test -- tests/server/studio-announcements.test.ts tests/client/studio-announcements.test.ts` — 16 passed.
- `npm run test -- tests/client/studio-announcements.test.ts tests/client/i18n-coverage.test.ts tests/server/api-docs-controller.test.ts` — 26 passed.
- `npm run test:e2e -- tests/e2e/studio-announcements.spec.ts tests/e2e/authenticated-shell.spec.ts` — 3 passed.
- `npm run harness:check` — passed.
- `npm run build` — passed.
- `git diff --check` — passed.

Cloud responses were mocked in automated tests; no production announcement was published or changed.
