### PR TITLE
docs: align repository descriptions with Ekko Studio

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,20 +11,20 @@ body:
   - type: input
     id: version
     attributes:
-      label: Hermes Web UI Version
-      description: What version of Hermes Web UI are you using?
+      label: Ekko Studio Version
+      description: What version of Ekko Studio are you using?
       placeholder: e.g., v0.5.8
     validations:
       required: true
 
   - type: input
-    id: hermes_version
+    id: agent_runtime
     attributes:
-      label: Hermes Agent Version
-      description: What version of Hermes Agent are you using?
-      placeholder: e.g., v0.12.0
+      label: Agent Runtime and Version (if applicable)
+      description: Which agent is affected (Ekko Agent, Hermes Agent, Claude Code, Codex, Pi, Grok, or OpenCode), and what version are you using?
+      placeholder: e.g., Hermes Agent v0.12.0, or N/A for a Studio-only issue
     validations:
-      required: true
+      required: false
 
   - type: textarea
     id: description
@@ -76,7 +76,7 @@ body:
     id: environment
     attributes:
       label: Environment
-      description: Where are you running Hermes Web UI?
+      description: Where are you running Ekko Studio?
       options:
         - Docker
         - macOS

--- a/.github/ISSUE_TEMPLATE/general_issue.md
+++ b/.github/ISSUE_TEMPLATE/general_issue.md
@@ -16,7 +16,7 @@ assignees: ''
 
 ## Environment (if applicable)
 
-- Hermes Web UI Version:
-- Hermes Agent Version:
+- Ekko Studio Version:
+- Agent Runtime and Version (if applicable):
 - Operating System:
 - Node Version:

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,7 +1,8 @@
 # Architecture
 
-Hermes Web UI is a TypeScript monorepo that ships a browser dashboard, a Koa
-backend, and an Electron desktop distribution around Hermes Agent.
+Ekko Studio is a TypeScript monorepo that ships a local-first AI workspace
+through a web console, a Koa backend, and an Electron desktop app. It integrates
+Ekko Agent, Hermes Agent, and coding agents for chat, coding, and workflows.
 
 ## Package Boundaries
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,6 +1,6 @@
 # Development Guidelines
 
-This document defines project-level development rules for Hermes Web UI. It is tool-agnostic and applies to all contributors and coding agents.
+This document defines project-level development rules for Ekko Studio. It is tool-agnostic and applies to all contributors and coding agents.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@
 </p>
 
 <p align="center">
-  A multi-agent desktop app, local runtime, and web console for<br/>
-  <a href="https://github.com/NousResearch/hermes-agent">Hermes Agent</a>, Ekko, Claude Code, Codex, and Pi.<br/>
-  Run chats, groups, workflows, coding tasks, voice, files, and devices from one local-first workspace.
+  A local-first AI workspace for multi-agent chat, coding, and visual workflows.<br/>
+  Available as a desktop app and self-hosted web console, with support for<br/>
+  <a href="https://github.com/NousResearch/hermes-agent">Hermes Agent</a>, Ekko Agent, Claude Code, Codex, Pi, Grok, and OpenCode.<br/>
+  Bring conversations, group collaboration, voice, files, and devices together in one place.
 </p>
 
 <p align="center">
@@ -27,27 +28,31 @@
   <a href="https://github.com/EKKOLearnAI/hermes-studio/stargazers"><img src="https://img.shields.io/github/stars/EKKOLearnAI/hermes-studio?style=flat-square" alt="stars"/></a>
 </p>
 
+Ekko Studio was previously named Hermes Studio / Hermes Web UI. The GitHub
+repository remains `EKKOLearnAI/hermes-studio`, and the npm package and server CLI
+remain `hermes-web-ui`; use these names in clone and installation commands.
+
 ## Core Capabilities
 
 | Area | What Ekko Studio does |
 | --- | --- |
-| Multi-agent runtime | Runs Hermes, Ekko, Claude Code, Codex, and Pi with streaming responses, tool traces, generated-file previews, persistent sessions, and standalone desktop chat windows. |
+| Multi-agent runtime | Runs Hermes, Ekko, Claude Code, Codex, Pi, Grok, and OpenCode with streaming responses, tool traces, generated-file previews, persistent sessions, and standalone desktop chat windows. |
 | Studio workspace | Provides shared chats, group chat, global-agent runs, workflows, files, voice, media, devices, themes, logs, usage, and App connectivity across agent runtimes. |
 | Agent control planes | Keeps Hermes profiles, providers, models, memory, skills, plugins, jobs, Kanban, channels, and runtime management in their owning agent module. |
-| Automation | Builds executable visual workflows and connects the five runtimes through schedules, approval gates, group-chat rooms, platform channels, and MCP servers. |
+| Automation | Builds executable visual workflows and connects the supported runtimes through schedules, approval gates, group-chat rooms, platform channels, and MCP servers. |
 | Workspace tools | Provides a file browser, web terminal, Desktop Agent Browser, voice input/output, coding-agent runners, device discovery, Journey graph, and performance views. |
 | Distribution | Ships as a desktop app for Windows/macOS/Linux, an npm CLI package, and a Docker image. |
 
 ## Agent and Platform Boundaries
 
-Ekko Studio is the shared product platform, not a sixth agent. It coordinates
-five concrete runtimes grouped into three agent families:
+Ekko Studio provides a shared workspace for its supported agent runtimes,
+grouped into three agent families:
 
 | Agent family | Runtime | Owned behavior |
 | --- | --- | --- |
 | Hermes | Hermes | Profiles, providers, models, skills, plugins, memory, jobs, Kanban, channels, MCP, terminal, and Hermes runtime integration. |
 | Ekko | Ekko | Ekko execution, approvals, clarifications, memory, MCP, and provider runtime behavior. |
-| Coding | Claude Code, Codex, Pi | Coding-agent installation, configuration, proxies, sessions, and process execution. |
+| Coding | Claude Code, Codex, Pi, Grok, OpenCode | Coding-agent installation, configuration, proxies, sessions, and process execution. |
 
 Studio owns capabilities shared by those families: single chat, group chat,
 global-agent orchestration, workflows, webhooks, sessions, files and uploads,
@@ -61,7 +66,7 @@ controllers.
 
 ### AI Chat
 
-- Real-time chat streaming over Socket.IO `/chat-run`; Studio dispatches each run to Hermes, Ekko, Claude Code, Codex, or Pi through runtime adapters
+- Real-time chat streaming over Socket.IO `/chat-run`; Studio dispatches each run to Hermes, Ekko, Claude Code, Codex, Pi, Grok, or OpenCode through runtime adapters
 - Multi-session management — create, rename, delete, switch between sessions
 - **Self-built session database** — local SQLite storage for Studio sessions; Hermes state.db remains a read-only source for Hermes history APIs
 - Session grouping by source (Telegram, Discord, Slack, etc.) with collapsible accordion
@@ -120,7 +125,7 @@ Unified configuration for **10 platforms** in one page:
 
 ### Visual Workflows
 
-- Vue Flow canvas for Hermes, Ekko, Claude Code, Codex, and Pi nodes with file/image attachments
+- Vue Flow canvas for Hermes, Ekko, Claude Code, Codex, Pi, Grok, and OpenCode nodes with file/image attachments
 - Directed edges, structured conditions, success/failure routes, loops, and approval gates
 - Import/export for portable workflow definitions and profile-aware workspaces
 - Run budgets, deadlines, stop/rerun controls, and persisted execution history
@@ -165,7 +170,7 @@ Unified configuration for **10 platforms** in one page:
 
 ### Coding Agents
 
-- Install, configure, launch, and monitor Claude Code, Codex, and Pi from the dashboard
+- Install, configure, launch, and monitor Claude Code, Codex, Pi, Grok, and OpenCode from the dashboard
 - Built-in coding-agent terminal, session history, workspace selection, images, and file diffs
 - Dedicated proxy routes and API modes for provider/model compatibility
 - Standalone desktop chat windows and persisted output/reasoning metadata

--- a/README_zh.md
+++ b/README_zh.md
@@ -4,9 +4,10 @@
 </p>
 
 <p align="center">
-  面向 <a href="https://github.com/NousResearch/hermes-agent">Hermes Agent</a>、Ekko、Claude Code、Codex 和 Pi 的<br/>
-  多 Agent 桌面应用、本地运行时和 Web 控制台。<br/>
-  在一个本地优先的工作区中完成聊天、群聊、工作流、编码任务、语音、文件和设备管理。
+  本地优先的 AI 工作区，支持多 Agent 聊天、编码和可视化工作流。<br/>
+  提供桌面应用和可自托管的 Web 控制台，支持<br/>
+  <a href="https://github.com/NousResearch/hermes-agent">Hermes Agent</a>、Ekko Agent、Claude Code、Codex、Pi、Grok 和 OpenCode。<br/>
+  在同一个工作区中管理对话、群组协作、语音、文件和设备。
 </p>
 
 <p align="center">
@@ -35,27 +36,31 @@
   <a href="https://github.com/EKKOLearnAI/hermes-studio/stargazers"><img src="https://img.shields.io/github/stars/EKKOLearnAI/hermes-studio?style=flat-square" alt="Star"/></a>
 </p>
 
+Ekko Studio 原名 Hermes Studio / Hermes Web UI。GitHub 仓库仍为
+`EKKOLearnAI/hermes-studio`，npm 包名和服务端 CLI 仍为 `hermes-web-ui`；
+克隆和安装时请继续使用这些名称。
+
 ## 核心能力
 
 | 模块 | Ekko Studio 能做什么 |
 |---|---|
-| 多 Agent 运行时 | 运行 Hermes、Ekko、Claude Code、Codex 和 Pi，支持流式回复、工具调用轨迹、生成文件预览、持久化会话和桌面独立聊天窗口。 |
+| 多 Agent 运行时 | 运行 Hermes、Ekko、Claude Code、Codex、Pi、Grok 和 OpenCode，支持流式回复、工具调用轨迹、生成文件预览、持久化会话和桌面独立聊天窗口。 |
 | Studio 工作区 | 为不同 Agent 运行时提供统一的单聊、群聊、Global Agent、工作流、文件、语音、媒体、设备、主题、日志、用量和 App 连接能力。 |
 | Agent 控制面 | 将 Hermes 的 Profile、Provider、模型、记忆、技能、插件、任务、Kanban、渠道和运行时管理保留在对应的 Agent 模块内。 |
-| 自动化 | 构建可执行的可视化工作流，通过定时任务、审批节点、群聊房间、平台渠道和 MCP Server 连接五种运行时。 |
+| 自动化 | 构建可执行的可视化工作流，通过定时任务、审批节点、群聊房间、平台渠道和 MCP Server 连接受支持的 Agent 运行时。 |
 | 工作区工具 | 提供文件浏览器、Web 终端、桌面 Agent 浏览器、语音输入输出、Coding Agent、设备发现、学习轨迹和性能视图。 |
 | 分发形态 | 支持 Windows/macOS/Linux 桌面应用、npm CLI 包和 Docker 镜像。 |
 
 ## Agent 与平台边界
 
-Ekko Studio 是所有 Agent 共用的产品平台，不是第六种 Agent。当前五种
-具体运行时归入三个 Agent Family：
+Ekko Studio 为受支持的 Agent 运行时提供统一工作区，
+这些运行时归入三个 Agent Family：
 
 | Agent Family | 运行时 | 负责的能力 |
 |---|---|---|
 | Hermes | Hermes | Profile、Provider、模型、技能、插件、记忆、任务、Kanban、渠道、MCP、终端和 Hermes Runtime 集成。 |
 | Ekko | Ekko | Ekko 执行、审批、澄清、记忆、MCP 和 Provider Runtime。 |
-| Coding | Claude Code、Codex、Pi | Coding Agent 的安装、配置、代理、会话和进程执行。 |
+| Coding | Claude Code、Codex、Pi、Grok、OpenCode | Coding Agent 的安装、配置、代理、会话和进程执行。 |
 
 Studio 负责三个 Family 共用的能力：单聊、群聊、Global Agent 编排、工作流、
 Webhook、会话、文件与上传、TTS/STT、媒体、宠物、主题、设备、网络、日志、
@@ -67,7 +72,7 @@ Hermes 控制面 API 使用 `/api/hermes/*`。已经发布的旧版移动 App �
 
 ### AI 聊天
 
-- 聊天前端通过 Socket.IO `/chat-run` 实时流式更新；Studio 通过运行时适配器将任务分发给 Hermes、Ekko、Claude Code、Codex 或 Pi
+- 聊天前端通过 Socket.IO `/chat-run` 实时流式更新；Studio 通过运行时适配器将任务分发给 Hermes、Ekko、Claude Code、Codex、Pi、Grok 或 OpenCode
 - 多会话管理 — 创建、重命名、删除、切换会话
 - **自建会话数据库** — Studio 会话使用本地 SQLite；Hermes state.db 仅作为只读来源用于 Hermes 历史 API
 - 按来源分组会话（Telegram、Discord、Slack 等），可折叠手风琴面板
@@ -126,7 +131,7 @@ Hermes 控制面 API 使用 `/api/hermes/*`。已经发布的旧版移动 App �
 
 ### 可视化工作流
 
-- 基于 Vue Flow 的画布，支持 Hermes、Ekko、Claude Code、Codex、Pi 节点以及文件/图片附件
+- 基于 Vue Flow 的画布，支持 Hermes、Ekko、Claude Code、Codex、Pi、Grok、OpenCode 节点以及文件/图片附件
 - 支持有向连线、结构化条件、成功/失败路由、循环和审批门
 - 工作流定义可导入/导出，并支持按 Profile 管理工作区
 - 支持运行预算、截止时间、停止、重跑和持久化执行历史
@@ -171,7 +176,7 @@ Hermes 控制面 API 使用 `/api/hermes/*`。已经发布的旧版移动 App �
 
 ### Coding Agents
 
-- 在仪表盘中安装、配置、启动和监控 Claude Code、Codex 与 Pi
+- 在仪表盘中安装、配置、启动和监控 Claude Code、Codex、Pi、Grok 与 OpenCode
 - 内置 Coding Agent 终端、会话历史、工作区选择、图片输入和文件 Diff
 - 提供独立代理路由和 API 模式，适配不同 Provider/模型
 - 支持桌面独立聊天窗口，并持久化输出和 reasoning 元数据

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hermes-web-ui",
   "version": "0.7.18",
-  "description": "Self-hosted AI chat dashboard for Hermes Agent — multi-model web UI with multi-platform integration",
+  "description": "Ekko Studio is a local-first AI workspace for multi-agent chat, coding, and visual workflows, available on desktop and the web.",
   "repository": {
     "type": "git",
     "url": "https://github.com/EKKOLearnAI/hermes-studio.git"
@@ -12,6 +12,11 @@
     "node": ">=23.0.0"
   },
   "keywords": [
+    "ekko-studio",
+    "ekko-agent",
+    "multi-agent",
+    "coding-agents",
+    "workflow-automation",
     "hermes",
     "hermes-agent",
     "hermes-web",

--- a/packages/client/public/manifest.webmanifest
+++ b/packages/client/public/manifest.webmanifest
@@ -1,7 +1,7 @@
 {
   "name": "Ekko Studio",
   "short_name": "Ekko Studio",
-  "description": "Self-hosted AI chat dashboard for Hermes Agent",
+  "description": "Ekko Studio is a local-first AI workspace for multi-agent chat, coding, and visual workflows, available on desktop and the web.",
   "start_url": "/#/hermes/chat",
   "scope": "/",
   "display": "standalone",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hermes-studio",
   "version": "0.7.18",
-  "description": "Ekko Studio desktop distribution with bundled Python runtime and hermes-agent",
+  "description": "Ekko Studio desktop app for multi-agent chat, coding, and visual workflows, with bundled local runtimes.",
   "homepage": "https://ekkostudio.xyz",
   "author": {
     "name": "Ekko Studio Contributors",


### PR DESCRIPTION
## Summary

Ekko Studio still had package and PWA descriptions presenting it as a Hermes Agent dashboard, and issue templates required a Hermes version even for other agents. Update the product descriptions to a local-first AI workspace for multi-agent chat, coding, and visual workflows.

- Refresh English and Chinese README introductions, include the supported Grok and OpenCode runtimes, and explain the existing repository/npm names used for installation.
- Update npm/desktop/PWA metadata, discovery keywords, contributor introductions, and issue templates to use Ekko Studio and accept the affected agent runtime.
- GitHub About description, homepage (`https://ekkostudio.xyz`), and relevant topics were updated separately and verified. Package names, executable names, and repository URLs remain compatible.

## Validation

- `npm ci --ignore-scripts --include=dev --no-audit --no-fund`
- `npm run harness:check`
- `npm run build`
- Parsed package/PWA JSON and issue-form YAML; checked bilingual README runtime coverage.
- `git diff --check`
