### PR TITLE
fix: send OpenCode session headers from Studio providers

### DIFF
--- a/docs/opencode-session.md
+++ b/docs/opencode-session.md
@@ -1,0 +1,26 @@
+# OpenCode session header
+
+Studio's Node provider requests send `x-opencode-session` to OpenCode Zen,
+Go, and Free. Custom providers using an `opencode.ai` host are also detected.
+Named OpenCode providers retain this behavior when configured through a proxy.
+
+Ekko derives an opaque key from the runtime conversation context, so turns,
+tool loops, retries, and background skill reviews keep the same key. Direct
+model-client callers should pass `metadata.session_id` on each request in a
+conversation. Requests without a session get an independent temporary scope.
+
+Studio-managed Claude Code, Codex, Pi, Grok, and OpenCode Coding Agent requests
+go through the Coding Agent proxies. They use the Studio chat session ID,
+falling back to the agent session ID or registered target scope. External CLI
+instances launched outside Studio do not use these proxies.
+
+Model catalog and connection probes
+have no conversation; each probe gets its own key, reused across redirects.
+API authentication headers remain in place. Unrelated providers receive no
+additional header.
+
+Hermes Python requests are handled upstream. Install a Hermes runtime containing
+NousResearch/hermes-agent PR #101864 (merged September 3, 2026), then restart the
+runtime. This Studio change does not upgrade an installed Hermes runtime or
+patch the bundled upstream source. The currently pinned August 27 source
+predates that fix.

--- a/packages/ekko-agent/docs/API.md
+++ b/packages/ekko-agent/docs/API.md
@@ -2054,6 +2054,8 @@ export function isRetryableStatus(statusCode: number): boolean
 ### `src/model/http.ts`
 
 ```ts
+export function modelRequestHeaders( config: ModelProviderConfig, request: ModelRequest, defaults: Record<string, string> = {}, ): HeadersInit
+
 export function requestHeaders(config: ModelProviderConfig, defaults: Record<string, string> = {}): HeadersInit
 
 export function abortSignal(timeoutMs?: number, signal?: AbortSignal): AbortSignal | undefined
@@ -2155,6 +2157,11 @@ export function agentReasoningText(reasoning: AgentReasoning | string | null | u
 export function agentReasoningEstimatedTokens(reasoning: AgentReasoning | undefined): number | undefined
 
 export function serializeAgentReasoningDetails(reasoning: AgentReasoning | undefined): string | null
+```
+### `src/model/opencode-session.ts`
+
+```ts
+export function openCodeSessionHeaders( baseUrl: string, sessionId?: string, provider?: string, ): Record<string, string>
 ```
 ### `src/model/provider-config.ts`
 
@@ -2883,6 +2890,7 @@ export interface SkillReviewScheduleInput {
   requestLogger?: EkkoRuntimeLogger
   requestLogContext?: EkkoRuntimeLogContext
   requestRunId?: string
+  sessionId?: string
   onUsage?: (event: SkillReviewUsageEvent) => void
   onStarted?: (reviewId: string) => void
   onCompleted?: (reviewId: string, mutations: number) => void

--- a/packages/ekko-agent/src/model/http.ts
+++ b/packages/ekko-agent/src/model/http.ts
@@ -1,5 +1,25 @@
 import { ModelProviderError, isRetryableStatus } from './errors'
-import type { ModelProviderConfig } from './types'
+import { randomUUID } from 'node:crypto'
+import { openCodeSessionHeaders } from './opencode-session'
+import type { ModelProviderConfig, ModelRequest } from './types'
+
+const requestSessions = new WeakMap<ModelRequest, string>()
+
+export function modelRequestHeaders(
+  config: ModelProviderConfig,
+  request: ModelRequest,
+  defaults: Record<string, string> = {},
+): HeadersInit {
+  let sessionId = typeof request.metadata?.session_id === 'string' ? request.metadata.session_id.trim() : ''
+  if (!sessionId) {
+    sessionId = requestSessions.get(request) || randomUUID()
+    requestSessions.set(request, sessionId)
+  }
+  return requestHeaders(config, {
+    ...openCodeSessionHeaders(config.baseUrl || '', sessionId, config.id),
+    ...defaults,
+  })
+}
 
 export function requestHeaders(config: ModelProviderConfig, defaults: Record<string, string> = {}): HeadersInit {
   const headers: Record<string, string> = {

--- a/packages/ekko-agent/src/model/opencode-session.ts
+++ b/packages/ekko-agent/src/model/opencode-session.ts
@@ -1,0 +1,20 @@
+import { createHash, randomUUID } from 'node:crypto'
+
+/** Opaque affinity key; never send a profile path or proxy routing key upstream. */
+export function openCodeSessionHeaders(
+  baseUrl: string,
+  sessionId?: string,
+  provider?: string,
+): Record<string, string> {
+  let hostname = ''
+  try { hostname = new URL(baseUrl).hostname.toLowerCase() } catch { /* Provider ID may identify a proxy. */ }
+  const providerId = provider?.replace(/^custom[:_]/, '').toLowerCase()
+  if (
+    hostname !== 'opencode.ai' && !hostname.endsWith('.opencode.ai') &&
+    !['opencode', 'opencode-go', 'opencode-zen', 'opencode-free'].includes(providerId || '')
+  ) return {}
+
+  return {
+    'x-opencode-session': createHash('sha256').update(sessionId?.trim() || randomUUID()).digest('hex'),
+  }
+}

--- a/packages/ekko-agent/src/model/providers/anthropic.ts
+++ b/packages/ekko-agent/src/model/providers/anthropic.ts
@@ -13,7 +13,7 @@ import type {
   ModelUsage,
 } from '../types'
 import { ModelProviderError } from '../errors'
-import { isPlainRecord, parseJson, postJson, postStream, providerUrl, readServerSentEvents, requestHeaders } from '../http'
+import { isPlainRecord, parseJson, postJson, postStream, providerUrl, readServerSentEvents, modelRequestHeaders } from '../http'
 import { agentReasoningText, normalizeAgentReasoning } from '../messages'
 
 interface AnthropicPayload {
@@ -92,7 +92,7 @@ export class AnthropicMessagesModelClient implements ModelClient {
       this.fetchImpl,
       anthropicUrl(this.config),
       toAnthropicMessagesPayload(this.config, { ...request, stream: false }),
-      anthropicHeaders(this.config),
+      anthropicHeaders(this.config, request),
       request.signal,
     )
     assertAnthropicSuccess(this.config, response)
@@ -105,7 +105,7 @@ export class AnthropicMessagesModelClient implements ModelClient {
       this.fetchImpl,
       anthropicUrl(this.config),
       toAnthropicMessagesPayload(this.config, { ...request, stream: true }),
-      anthropicHeaders(this.config),
+      anthropicHeaders(this.config, request),
       request.signal,
     )
 
@@ -390,8 +390,8 @@ function anthropicUrl(config: ModelProviderConfig): string {
   return providerUrl(config, 'https://api.anthropic.com/v1', config.endpointPath ?? defaultAnthropicEndpointPath(config))
 }
 
-function anthropicHeaders(config: ModelProviderConfig): HeadersInit {
-  const headers = requestHeaders(config, { 'anthropic-version': '2023-06-01' }) as Record<string, string>
+function anthropicHeaders(config: ModelProviderConfig, request: ModelRequest): HeadersInit {
+  const headers = modelRequestHeaders(config, request, { 'anthropic-version': '2023-06-01' }) as Record<string, string>
   const usesBearerAuth = ['claude-oauth', 'minimax-oauth'].includes(config.id)
   if (isOfficialAnthropicBaseUrl(config.baseUrl) && !usesBearerAuth) delete headers.authorization
   if (config.apiKey && !usesBearerAuth) headers['x-api-key'] = config.apiKey

--- a/packages/ekko-agent/src/model/providers/openai-compatible.ts
+++ b/packages/ekko-agent/src/model/providers/openai-compatible.ts
@@ -8,7 +8,7 @@ import {
   parseServerSentEventLine,
   providerHttpError,
   providerUrl,
-  requestHeaders,
+  modelRequestHeaders,
 } from '../http'
 import type {
   AgentMessage,
@@ -152,12 +152,12 @@ export class OpenAICompatibleModelClient implements ModelClient {
   }
 
   async create(request: ModelRequest): Promise<ModelResponse> {
-    const response = await this.postWithImageFallback({ ...request, stream: false }, request.signal)
+    const response = await this.postWithImageFallback(request, false, request.signal)
     return normalizeOpenAIChatResponse(this.provider, await parseResponseJson(this.provider, response))
   }
 
   async *stream(request: ModelRequest): AsyncIterable<ModelEvent> {
-    const response = await this.postWithImageFallback({ ...request, stream: true }, request.signal)
+    const response = await this.postWithImageFallback(request, true, request.signal)
 
     if (!response.body) {
       throw new ModelProviderError('Model provider returned an empty stream body.', {
@@ -271,26 +271,26 @@ export class OpenAICompatibleModelClient implements ModelClient {
     }
   }
 
-  private async postWithImageFallback(request: ModelRequest, signal?: AbortSignal): Promise<Response> {
+  private async postWithImageFallback(request: ModelRequest, stream: boolean, signal?: AbortSignal): Promise<Response> {
     const model = request.model ?? this.config.defaultModel
     const target = chatTargetKey(this.config, model)
     const initialConfig = textOnlyChatTargets.has(target)
       ? withoutVision(this.config)
       : this.config
-    const payload = toOpenAIChatPayload(initialConfig, request)
+    const payload = toOpenAIChatPayload(initialConfig, { ...request, stream })
     try {
-      return await this.post(payload, signal)
+      return await this.post(payload, request, signal)
     } catch (error) {
       if (!payloadContainsImage(payload) || !isUnsupportedImageError(error)) throw error
       rememberTextOnlyChatTarget(target)
-      return this.post(toOpenAIChatPayload(withoutVision(this.config), request), signal)
+      return this.post(toOpenAIChatPayload(withoutVision(this.config), { ...request, stream }), request, signal)
     }
   }
 
-  private async post(payload: OpenAIChatPayload, signal?: AbortSignal): Promise<Response> {
+  private async post(payload: OpenAIChatPayload, request: ModelRequest, signal?: AbortSignal): Promise<Response> {
     const response = await this.fetchImpl(chatCompletionsUrl(this.config), {
       method: 'POST',
-      headers: requestHeaders(this.config),
+      headers: modelRequestHeaders(this.config, request),
       body: JSON.stringify(payload),
       signal: abortSignal(this.config.timeoutMs, signal),
     })

--- a/packages/ekko-agent/src/model/providers/openai-responses.ts
+++ b/packages/ekko-agent/src/model/providers/openai-responses.ts
@@ -12,7 +12,7 @@ import type {
   ModelResponse,
   ModelUsage,
 } from '../types'
-import { isPlainRecord, parseJson, postJson, postStream, providerUrl, readServerSentEvents } from '../http'
+import { modelRequestHeaders, isPlainRecord, parseJson, postJson, postStream, providerUrl, readServerSentEvents } from '../http'
 import { collectModelEvents, normalizeAgentReasoning } from '../messages'
 
 interface OpenAIResponsesPayload {
@@ -136,7 +136,7 @@ export class OpenAIResponsesModelClient implements ModelClient {
       this.fetchImpl,
       responsesUrl(this.config),
       toOpenAIResponsesPayload(this.config, { ...request, stream: false }),
-      undefined,
+      modelRequestHeaders(this.config, request),
       request.signal,
     )
     return normalizeOpenAIResponsesResponse(response)
@@ -148,7 +148,7 @@ export class OpenAIResponsesModelClient implements ModelClient {
       this.fetchImpl,
       responsesUrl(this.config),
       toOpenAIResponsesPayload(this.config, { ...request, stream: true }),
-      undefined,
+      modelRequestHeaders(this.config, request),
       request.signal,
     )
 

--- a/packages/ekko-agent/src/runtime/runtime.ts
+++ b/packages/ekko-agent/src/runtime/runtime.ts
@@ -528,6 +528,7 @@ export class AgentRuntime {
         const modelClient = this.modelClientFor(input)
         emit({ type: 'model.started', runId, step })
         const request = this.modelRequest(input, messages, modelClient, contextKey, modelSignal)
+        request.metadata = { ...request.metadata, session_id: contextKey || runId }
         const recoveryDirective = this.currentRecoveryDirective()
         if (recoveryDirective?.active && request.tools?.length) {
           const allowed = new Set(recoveryDirective.allowedToolNames)
@@ -1040,6 +1041,7 @@ export class AgentRuntime {
       requestLogger: this.runtimeLogger,
       requestLogContext: input.logContext,
       requestRunId: runId,
+      sessionId: contextKey || runId,
       onUsage: input.onSkillReviewUsage,
       onStarted: reviewId => emit?.({ type: 'skill.review.started', runId, reviewId }),
       onCompleted: (reviewId, mutations) => emit?.({

--- a/packages/ekko-agent/src/skills/review.ts
+++ b/packages/ekko-agent/src/skills/review.ts
@@ -25,6 +25,7 @@ export interface SkillReviewScheduleInput {
   requestLogger?: EkkoRuntimeLogger
   requestLogContext?: EkkoRuntimeLogContext
   requestRunId?: string
+  sessionId?: string
   onUsage?: (event: SkillReviewUsageEvent) => void
   onStarted?: (reviewId: string) => void
   onCompleted?: (reviewId: string, mutations: number) => void
@@ -89,7 +90,7 @@ export class SkillReviewService {
         tools: tools.definitions(),
         toolChoice: 'auto',
         stream: false,
-        metadata: { purpose: 'ekko-skill-review', review_id: reviewId },
+        metadata: { purpose: 'ekko-skill-review', review_id: reviewId, session_id: input.sessionId || reviewId },
       }, input.modelClient, input, reviewId, step + 1)
       callIndex += 1
       if (response.usage) {

--- a/packages/server/src/modules/coding-agents/protocol/gateway.ts
+++ b/packages/server/src/modules/coding-agents/protocol/gateway.ts
@@ -1,7 +1,11 @@
+import { openCodeSessionHeaders } from '../../studio/public/opencode-session'
+
 /** A provider request issued by a Coding Agent proxy. */
 export interface AgentGatewayRequest {
   url: string
   apiKey: string
+  sessionId?: string
+  provider?: string
   body: unknown
   headers?: Record<string, string>
   signal?: AbortSignal
@@ -46,6 +50,7 @@ export class AgentRunGateway {
     return fetch(request.url, {
       method: 'POST',
       headers: {
+        ...openCodeSessionHeaders(request.url, request.sessionId, request.provider),
         ...(request.apiKey ? { Authorization: `Bearer ${request.apiKey}` } : {}),
         'Content-Type': 'application/json',
         ...request.headers,

--- a/packages/server/src/modules/coding-agents/services/claude-code/proxy.ts
+++ b/packages/server/src/modules/coding-agents/services/claude-code/proxy.ts
@@ -298,6 +298,8 @@ async function callAnthropicMessages(target: ClaudeCodeProxyTarget, body: any): 
   const result = await withCustomEncryptedContentRetry(target, body, nextBody => agentRunGateway.completeJson({
     url: anthropicMessagesUrl(target),
     apiKey: target.apiKey,
+    sessionId: target.chatSessionId || target.agentSessionId || target.routeKey,
+    provider: target.provider,
     headers: {
       ...(target.apiKey ? { 'x-api-key': target.apiKey } : {}),
       'anthropic-version': '2023-06-01',
@@ -316,6 +318,8 @@ async function callOpenAiChat(target: ClaudeCodeProxyTarget, body: any): Promise
   return agentRunGateway.completeJson({
     url: resolveChatCompletionsUrl(target.baseUrl),
     apiKey: target.apiKey,
+    sessionId: target.chatSessionId || target.agentSessionId || target.routeKey,
+    provider: target.provider,
     body: anthropicToOpenAiChat(body, target),
   })
 }
@@ -329,6 +333,8 @@ async function callOpenAiResponses(target: ClaudeCodeProxyTarget, body: any): Pr
   return agentRunGateway.completeJson({
     url: resolveResponsesUrl(target.baseUrl),
     apiKey: target.apiKey,
+    sessionId: target.chatSessionId || target.agentSessionId || target.routeKey,
+    provider: target.provider,
     body: anthropicToOpenAiResponses(body, target),
   })
 }
@@ -369,6 +375,8 @@ async function openAiChatToAnthropicSseStream(target: ClaudeCodeProxyTarget, bod
   const stream = await agentRunGateway.streamBytes({
     url: resolveChatCompletionsUrl(target.baseUrl),
     apiKey: target.apiKey,
+    sessionId: target.chatSessionId || target.agentSessionId || target.routeKey,
+    provider: target.provider,
     body: anthropicToOpenAiChat(body, target, true),
   })
   const [clientStream, observerStream] = teeAsyncIterable(stream)
@@ -386,6 +394,8 @@ async function anthropicMessagesSseStream(target: ClaudeCodeProxyTarget, body: a
   const request = (nextBody: any) => agentRunGateway.streamBytes({
     url: anthropicMessagesUrl(target),
     apiKey: target.apiKey,
+    sessionId: target.chatSessionId || target.agentSessionId || target.routeKey,
+    provider: target.provider,
     headers: {
       ...(target.apiKey ? { 'x-api-key': target.apiKey } : {}),
       'anthropic-version': '2023-06-01',
@@ -436,6 +446,8 @@ async function openAiResponsesToAnthropicSseStream(target: ClaudeCodeProxyTarget
   const stream = await agentRunGateway.streamBytes({
     url: resolveResponsesUrl(target.baseUrl),
     apiKey: target.apiKey,
+    sessionId: target.chatSessionId || target.agentSessionId || target.routeKey,
+    provider: target.provider,
     body: anthropicToOpenAiResponses(body, target, true),
   })
   const [clientStream, observerStream] = teeAsyncIterable(stream)

--- a/packages/server/src/modules/coding-agents/services/codex/proxy.ts
+++ b/packages/server/src/modules/coding-agents/services/codex/proxy.ts
@@ -156,6 +156,8 @@ async function callOpenAiChat(target: CodexProxyTarget, body: any): Promise<any>
   return agentRunGateway.completeJson({
     url: chatCompletionsUrl(target),
     apiKey: target.apiKey,
+    sessionId: target.chatSessionId || target.agentSessionId || target.routeKey,
+    provider: target.provider,
     body: chatBody,
   })
 }
@@ -170,6 +172,8 @@ async function callAnthropicMessages(target: CodexProxyTarget, body: any): Promi
   return agentRunGateway.completeJson({
     url: anthropicMessagesUrl(target),
     apiKey: target.apiKey,
+    sessionId: target.chatSessionId || target.agentSessionId || target.routeKey,
+    provider: target.provider,
     headers: {
       ...(target.apiKey ? { 'x-api-key': target.apiKey } : {}),
       'anthropic-version': '2023-06-01',
@@ -188,6 +192,8 @@ async function callOpenAiResponses(target: CodexProxyTarget, body: any): Promise
   return agentRunGateway.completeJson({
     url: resolveResponsesUrl(target.baseUrl),
     apiKey: target.apiKey,
+    sessionId: target.chatSessionId || target.agentSessionId || target.routeKey,
+    provider: target.provider,
     body: responsesBody,
   })
 }
@@ -266,6 +272,8 @@ async function openAiChatToResponsesSseStream(target: CodexProxyTarget, body: an
   const stream = await agentRunGateway.streamBytes({
     url: chatCompletionsUrl(target),
     apiKey: target.apiKey,
+    sessionId: target.chatSessionId || target.agentSessionId || target.routeKey,
+    provider: target.provider,
     body: chatBody,
   })
   return responsesEventStream(observableResponsesEvents(target, openAiChatSseToResponsesEvents(stream, {
@@ -285,6 +293,8 @@ async function anthropicMessagesToResponsesSseStream(target: CodexProxyTarget, b
   const stream = await agentRunGateway.streamBytes({
     url: anthropicMessagesUrl(target),
     apiKey: target.apiKey,
+    sessionId: target.chatSessionId || target.agentSessionId || target.routeKey,
+    provider: target.provider,
     headers: {
       ...(target.apiKey ? { 'x-api-key': target.apiKey } : {}),
       'anthropic-version': '2023-06-01',
@@ -308,6 +318,8 @@ async function openAiResponsesSseStream(target: CodexProxyTarget, body: any): Pr
   const stream = await agentRunGateway.streamBytes({
     url: resolveResponsesUrl(target.baseUrl),
     apiKey: target.apiKey,
+    sessionId: target.chatSessionId || target.agentSessionId || target.routeKey,
+    provider: target.provider,
     body: responsesBody,
   })
   return responsesEventStream(observableResponsesEvents(target, openAiResponsesSseToResponsesEvents(stream)))

--- a/packages/server/src/modules/hermes/controllers/models.ts
+++ b/packages/server/src/modules/hermes/controllers/models.ts
@@ -1,3 +1,4 @@
+import { openCodeSessionHeaders } from '../../studio/public/opencode-session'
 import { readFile } from 'fs/promises'
 import { existsSync, readFileSync } from 'fs'
 import { join } from 'path'
@@ -967,7 +968,7 @@ export async function fetchProviderModelList(ctx: any) {
 
     const base = baseUrl.replace(/\/+$/, '')
     const modelsUrl = /\/v\d+\/?$/.test(base) ? `${base}/models` : `${base}/v1/models`
-    const headers: Record<string, string> = {}
+    const headers: Record<string, string> = openCodeSessionHeaders(modelsUrl)
     if (apiKey && provider !== OPENCODE_FREE_PROVIDER) headers.Authorization = `Bearer ${apiKey}`
 
     const res = await fetch(modelsUrl, {

--- a/packages/server/src/modules/hermes/services/profiles/config.ts
+++ b/packages/server/src/modules/hermes/services/profiles/config.ts
@@ -1,3 +1,4 @@
+import { openCodeSessionHeaders } from '../../../studio/public/opencode-session'
 import { readFile, chmod } from 'fs/promises'
 import { readdir, stat } from 'fs/promises'
 import { existsSync, readFileSync } from 'fs'
@@ -227,7 +228,7 @@ export async function fetchProviderModels(baseUrl: string, apiKey: string, freeO
   const modelsUrl = /\/v\d+\/?$/.test(base) ? `${base}/models` : `${base}/v1/models`
   try {
     const res = await fetch(modelsUrl, {
-      headers: { Authorization: `Bearer ${apiKey}` },
+      headers: { ...openCodeSessionHeaders(modelsUrl), Authorization: `Bearer ${apiKey}` },
       signal: AbortSignal.timeout(8000),
     })
     if (!res.ok) {

--- a/packages/server/src/modules/hermes/services/providers/model-catalog-cache.ts
+++ b/packages/server/src/modules/hermes/services/providers/model-catalog-cache.ts
@@ -1,3 +1,4 @@
+import { openCodeSessionHeaders } from '../../../studio/public/opencode-session'
 import { readFile } from 'fs/promises'
 import { join } from 'path'
 import { getCompatibleCustomProviders } from '../../../studio/contracts/provider-compat'
@@ -384,6 +385,7 @@ async function fetchClaudeOAuthModels(baseUrl: string, accessToken: string): Pro
   try {
     const res = await fetch(modelsUrl, {
       headers: {
+        ...openCodeSessionHeaders(modelsUrl),
         Authorization: `Bearer ${accessToken}`,
         'anthropic-version': '2023-06-01',
         'anthropic-beta': 'oauth-2025-04-20',

--- a/packages/server/src/modules/hermes/services/providers/provider-editor.ts
+++ b/packages/server/src/modules/hermes/services/providers/provider-editor.ts
@@ -1,3 +1,4 @@
+import { openCodeSessionHeaders } from '../../../studio/public/opencode-session'
 import { createHash, randomBytes } from 'crypto'
 import { chmod } from 'fs/promises'
 import { join, resolve } from 'path'
@@ -433,7 +434,7 @@ async function readLimitedResponse(response: Response): Promise<string> {
 export async function fetchProviderCatalogForTest(baseUrl: string, apiKey: string, apiMode?: ProviderApiMode): Promise<string[]> {
   const endpoint = providerModelsEndpoint(baseUrl, apiMode)
   let current = endpoint.url
-  const headers: Record<string, string> = { Accept: 'application/json' }
+  const headers: Record<string, string> = { ...openCodeSessionHeaders(current.toString()), Accept: 'application/json' }
   if (apiKey) {
     if (endpoint.protocol === 'anthropic') {
       headers['x-api-key'] = apiKey

--- a/packages/server/src/modules/studio/public/opencode-session.ts
+++ b/packages/server/src/modules/studio/public/opencode-session.ts
@@ -1,0 +1,1 @@
+export { openCodeSessionHeaders } from '../../../../../ekko-agent/src/model/opencode-session'

--- a/packages/server/src/modules/studio/public/provider-catalog.ts
+++ b/packages/server/src/modules/studio/public/provider-catalog.ts
@@ -1,3 +1,4 @@
+import { openCodeSessionHeaders } from './opencode-session'
 import { logger } from './logging'
 import { OPENCODE_FREE_BASE_URL, isOpenCodeFreeModel } from '../contracts/opencode-free'
 
@@ -10,7 +11,7 @@ export async function fetchProviderModels(baseUrl: string, apiKey: string, freeO
   const modelsUrl = /\/v\d+\/?$/.test(base) ? `${base}/models` : `${base}/v1/models`
   try {
     const response = await fetch(modelsUrl, {
-      headers: apiKey ? { Authorization: `Bearer ${apiKey}` } : {},
+      headers: { ...openCodeSessionHeaders(modelsUrl), ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}) },
       signal: AbortSignal.timeout(8000),
     })
     if (!response.ok) {

--- a/tests/ekko-agent/opencode-session.test.ts
+++ b/tests/ekko-agent/opencode-session.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from 'vitest'
+import { AgentRuntime, createModelClient } from '../../packages/ekko-agent/src'
+import type { ModelProviderConfig, ModelRequest } from '../../packages/ekko-agent/src'
+import { openCodeSessionHeaders } from '../../packages/ekko-agent/src/model/opencode-session'
+
+const baseUrl = 'https://opencode.ai/zen/go/v1'
+const config: ModelProviderConfig = {
+  id: 'opencode-go', type: 'openai-compatible', baseUrl, defaultModel: 'test-model', apiKey: 'test-key',
+}
+const request: ModelRequest = { messages: [{ role: 'user', content: 'Hello' }], metadata: { session_id: 'conversation-a' } }
+const affinity = (init?: RequestInit) => new Headers(init?.headers).get('x-opencode-session')
+
+describe('OpenCode session affinity', () => {
+  it('recognizes OpenCode hosts and named proxies without matching unrelated URLs', () => {
+    for (const url of [baseUrl, 'https://opencode.ai/zen/v1', 'https://api.opencode.ai/v1']) {
+      expect(openCodeSessionHeaders(url, 'conversation-a')['x-opencode-session']).toMatch(/^[a-f0-9]{64}$/)
+    }
+    expect(openCodeSessionHeaders('https://proxy.example/v1', 'conversation-a', 'custom:opencode-go'))
+      .toEqual(openCodeSessionHeaders(baseUrl, 'conversation-a'))
+    for (const url of ['https://opencode.ai.evil.example/v1', 'https://example.com/opencode.ai', 'https://notopencode.ai', 'invalid']) {
+      expect(openCodeSessionHeaders(url, 'conversation-a')).toEqual({})
+    }
+    expect(openCodeSessionHeaders(baseUrl)).not.toEqual(openCodeSessionHeaders(baseUrl))
+  })
+
+  it.each(['openai-chat', 'openai-responses', 'anthropic-messages'] as const)(
+    'keeps concurrent conversations isolated across create and stream with %s', async requestStyle => {
+      const fetchMock = vi.fn(async (_url: string | URL, init?: RequestInit) => {
+        if (JSON.parse(String(init?.body)).stream) return new Response('data: [DONE]\n\n')
+        return Response.json({ choices: [{ message: { content: 'OK' } }], content: [{ type: 'text', text: 'OK' }], output: [] })
+      })
+      const client = createModelClient({ ...config, requestStyle }, { fetch: fetchMock })
+      await Promise.all([
+        client.create(request),
+        client.create({ ...request, metadata: { session_id: 'conversation-b' } }),
+      ])
+      for await (const _event of client.stream({ ...request })) { /* drain */ }
+      await client.create({ ...request })
+      const ids = fetchMock.mock.calls.map(([, init]) => affinity(init))
+      expect(ids[0]).toMatch(/^[a-f0-9]{64}$/)
+      expect(ids[1]).not.toBe(ids[0])
+      expect(ids[2]).toBe(ids[0])
+      expect(ids[3]).toBe(ids[0])
+      expect(new Headers(fetchMock.mock.calls[0][1]?.headers).get('authorization') ||
+        new Headers(fetchMock.mock.calls[0][1]?.headers).get('x-api-key')).toContain('test-key')
+      expect(JSON.parse(String(fetchMock.mock.calls[0][1]?.body))).not.toHaveProperty('metadata.session_id')
+    },
+  )
+
+  it('keeps runtime turns and retries on the same backend using the context key', async () => {
+    let calls = 0
+    const fetchMock = vi.fn(async (_url: string | URL, _init?: RequestInit) => {
+      if (++calls === 1) return Response.json({ error: { message: 'retry' } }, { status: 503 })
+      return Response.json({ choices: [{ message: { content: 'OK' }, finish_reason: 'stop' }] })
+    })
+    const client = createModelClient({ ...config, capabilities: { streaming: false } }, { fetch: fetchMock })
+    const runtime = new AgentRuntime({ modelClient: client, maxModelRetries: 1 })
+    for (const contextKey of ['session-a', 'session-a', 'session-b']) {
+      await runtime.run({ messages: ['Hello'], contextKey })
+    }
+    const ids = fetchMock.mock.calls.map(([, init]) => affinity(init))
+    expect(ids).toHaveLength(4)
+    expect(ids[0]).toBe(ids[1])
+    expect(ids[1]).toBe(ids[2])
+    expect(ids[3]).not.toBe(ids[0])
+  })
+
+  it('adds affinity to custom OpenCode URLs and leaves other providers alone', async () => {
+    const fetchMock = vi.fn(async (_url: string | URL, _init?: RequestInit) => Response.json({ choices: [] }))
+    for (const url of [baseUrl, 'https://api.example.com/v1']) {
+      await createModelClient({ ...config, id: 'my-provider', baseUrl: url }, { fetch: fetchMock }).create(request)
+    }
+    expect(affinity(fetchMock.mock.calls[0][1])).toBeTruthy()
+    expect(affinity(fetchMock.mock.calls[1][1])).toBeNull()
+  })
+
+  it('reuses an anonymous request scope when the same request is retried', async () => {
+    const fetchMock = vi.fn(async (_url: string | URL, _init?: RequestInit) => Response.json({ choices: [] }))
+    const client = createModelClient(config, { fetch: fetchMock })
+    const anonymous = { messages: request.messages }
+    await client.create(anonymous)
+    await client.create(anonymous)
+    await client.create({ messages: request.messages })
+    const ids = fetchMock.mock.calls.map(([, init]) => affinity(init))
+    expect(ids[0]).toBe(ids[1])
+    expect(ids[2]).not.toBe(ids[0])
+  })
+})

--- a/tests/server/agent-runner-gateway.test.ts
+++ b/tests/server/agent-runner-gateway.test.ts
@@ -6,6 +6,33 @@ afterEach(() => {
 })
 
 describe('agent run gateway', () => {
+  it('shares OpenCode affinity across protocols and retries for one conversation', async () => {
+    const fetchMock = vi.fn(async (_url: string | URL, init?: RequestInit) => {
+      const stream = JSON.parse(String(init?.body)).stream
+      return new Response(stream ? 'data: [DONE]\n\n' : '{}', {
+        headers: { 'Content-Type': stream ? 'text/event-stream' : 'application/json' },
+      })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const gateway = new AgentRunGateway()
+    for (const [sessionId, endpoint, stream] of [
+      ['session-a', 'chat/completions', false],
+      ['session-a', 'responses', true],
+      ['session-b', 'messages', false],
+      ['session-a', 'chat/completions', false],
+    ] as const) {
+      const request = { url: `https://opencode.ai/zen/go/v1/${endpoint}`, apiKey: 'test-key', sessionId, body: { stream } }
+      if (stream) {
+        for await (const _chunk of await gateway.streamBytes(request)) { /* drain */ }
+      } else await gateway.completeJson(request)
+    }
+    const ids = fetchMock.mock.calls.map(([, init]) => new Headers(init?.headers).get('x-opencode-session'))
+    expect(ids[0]).toMatch(/^[a-f0-9]{64}$/)
+    expect(ids[1]).toBe(ids[0])
+    expect(ids[2]).not.toBe(ids[0])
+    expect(ids[3]).toBe(ids[0])
+  })
+
   it('posts JSON requests with bearer auth and custom headers', async () => {
     const fetchMock = vi.fn(async () => new Response(JSON.stringify({ ok: true }), {
       status: 200,

--- a/tests/server/coding-agent-opencode-session.test.ts
+++ b/tests/server/coding-agent-opencode-session.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { claudeProxyMessages, registerClaudeCodeProxyTarget } from '../../packages/server/src/modules/coding-agents/services/claude-code/proxy'
+import { codexProxyResponses, registerCodexProxyTarget } from '../../packages/server/src/modules/coding-agents/services/codex/proxy'
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe.each(['claude-code', 'codex', 'pi', 'grok', 'opencode'])('%s OpenCode provider requests', agentId => {
+  it.each(['chat_completions', 'codex_responses', 'anthropic_messages'] as const)(
+    'preserves chat affinity across native sessions and streaming with %s', async apiMode => {
+      const fetchMock = vi.fn(async (_url: string | URL, init?: RequestInit) => {
+        if (JSON.parse(String(init?.body)).stream) {
+          return new Response('data: [DONE]\n\n', { headers: { 'Content-Type': 'text/event-stream' } })
+        }
+        return Response.json({
+          id: 'response-1', model: 'test-model', role: 'assistant', type: 'message',
+          choices: [{ message: { role: 'assistant', content: 'OK' }, finish_reason: 'stop' }],
+          content: [{ type: 'text', text: 'OK' }], output: [], stop_reason: 'end_turn',
+          usage: { input_tokens: 1, output_tokens: 1 },
+        })
+      })
+      vi.stubGlobal('fetch', fetchMock)
+      for (const [index, chatSessionId] of ['chat-a', 'chat-a', 'chat-b'].entries()) {
+        const input = {
+          profile: 'default', provider: 'opencode-go', model: 'test-model',
+          baseUrl: 'https://opencode.ai/zen/go/v1', apiKey: 'test-key', apiMode,
+          agentId, agentSessionId: `native-${index}`, chatSessionId,
+        }
+        const target = agentId === 'claude-code' ? registerClaudeCodeProxyTarget(input) : registerCodexProxyTarget(input)
+        const ctx: any = {
+          params: { key: target.routeKey },
+          request: { body: {
+            model: 'test-model', stream: index === 1,
+            input: 'Hello', messages: [{ role: 'user', content: 'Hello' }],
+          } },
+          get: (name: string) => name.toLowerCase() === 'authorization' ? `Bearer ${target.token}` : '',
+          set: vi.fn(),
+        }
+        if (agentId === 'claude-code') await claudeProxyMessages(ctx)
+        else await codexProxyResponses(ctx)
+        expect(ctx.status || 200).toBeLessThan(400)
+        if (index === 1) for await (const _chunk of ctx.body) { /* drain stream */ }
+      }
+      expect(fetchMock).toHaveBeenCalledTimes(3)
+      const ids = fetchMock.mock.calls.map(([, init]) => new Headers(init?.headers).get('x-opencode-session'))
+      expect(ids[0]).toMatch(/^[a-f0-9]{64}$/)
+      expect(ids[1]).toBe(ids[0])
+      expect(ids[2]).not.toBe(ids[0])
+    },
+  )
+})

--- a/tests/server/opencode-free-catalog.test.ts
+++ b/tests/server/opencode-free-catalog.test.ts
@@ -10,5 +10,5 @@ it('fetches anonymously and excludes paid models and the Go-only free-named twin
   ] })))
   vi.stubGlobal('fetch', fetchMock)
   expect(await fetchOpenCodeFreeModels()).toEqual(['deepseek-v4-flash-free', 'mimo-v2.5-free'])
-  expect(fetchMock).toHaveBeenCalledWith('https://opencode.ai/zen/v1/models', expect.objectContaining({ headers: {}, signal: expect.any(AbortSignal) }))
+  expect(fetchMock).toHaveBeenCalledWith('https://opencode.ai/zen/v1/models', expect.objectContaining({ headers: { 'x-opencode-session': expect.any(String) }, signal: expect.any(AbortSignal) }))
 })

--- a/tests/server/provider-editor.test.ts
+++ b/tests/server/provider-editor.test.ts
@@ -61,6 +61,19 @@ afterEach(() => {
 })
 
 describe('provider editor service', () => {
+  it('keeps the OpenCode probe affinity header across same-origin redirects', async () => {
+    const { fetchProviderCatalogForTest } = await loadEditor()
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(null, { status: 307, headers: { location: '/zen/go/v1/models/' } }))
+      .mockResolvedValueOnce(Response.json({ data: [{ id: 'glm-5' }] }))
+    vi.stubGlobal('fetch', fetchMock)
+    expect(await fetchProviderCatalogForTest('https://opencode.ai/zen/go/v1', 'test-key')).toEqual(['glm-5'])
+    const headers = fetchMock.mock.calls.map(([, init]) => new Headers(init.headers))
+    expect(headers[0].get('x-opencode-session')).toMatch(/^[a-f0-9]{64}$/)
+    expect(headers[1].get('x-opencode-session')).toBe(headers[0].get('x-opencode-session'))
+    expect(headers[1].get('authorization')).toBe('Bearer test-key')
+  })
+
   it('returns capability metadata without exposing the stored credential', async () => {
     const storedCredential = ['stored', 'credential'].join('-')
     writeProfile('research', [


### PR DESCRIPTION
## Summary
OpenCode Go can reject requests without `x-opencode-session`. Studio now adds an opaque conversation key to its Node provider requests, including Ekko Chat Completions/Responses/Anthropic calls and the shared Coding Agent gateways used by Claude Code, Codex, Pi, Grok, and OpenCode.

Chat turns, retries, streaming, and Ekko background skill reviews reuse the conversation key. Model catalogs and connection probes get an independent operation key, retained across redirects. Custom OpenCode hosts are detected, and unrelated providers keep their existing headers.

Hermes Python requests still require an upstream runtime containing NousResearch/hermes-agent#101864. This change does not upgrade installed runtimes or alter the bundled Hermes source.

## Validation
- Focused provider/runtime suites: 207 tests passed, including all 15 Coding Agent/protocol combinations.
- `npx tsc --noEmit -p packages/server/tsconfig.json` passed.
- `npm run harness:check` passed.
- `npm run build` passed.
- `PORT=8648 npm run test:coverage`: 5,274 passed, 45 failed, 6 skipped. Failures are in untouched UI tests and a TTS route-order test. Eight representative UI failures reproduced on the unmodified base commit.
- `PLAYWRIGHT_PORT=19673 npm run test:e2e -- --workers=4`: 180 passed, 1 failed (XLSX preview worker in an untouched feature). OpenCode provider/chat creation tests for all five Coding Agents passed. The earlier run on port 4173 lost its test server; the isolated rerun completed.
