### PR TITLE
fix(coding-agent): follow latest Pi package versions

### DIFF
--- a/packages/ekko-agent/skills/hermes-studio-installation/references/coding-agents.md
+++ b/packages/ekko-agent/skills/hermes-studio-installation/references/coding-agents.md
@@ -24,10 +24,10 @@ Studio installs these global npm packages:
 | --- | --- | --- |
 | Claude Code | `claude` | `@anthropic-ai/claude-code` |
 | Codex | `codex` | `@openai/codex` |
-| Pi | `pi` | Studio-pinned `@earendil-works/pi-coding-agent` |
+| Pi | `pi` | `@earendil-works/pi-coding-agent` |
 | Grok | `grok` | `@xai-official/grok` |
 
-At this Studio revision, Pi is pinned to `0.84.1`. Its installation is incomplete without Studio's separately pinned `pi-mcp-adapter` `2.24.0`, installed below:
+Pi follows the package's current npm version, like the other coding agents. Its installation is incomplete without `pi-mcp-adapter`, which also follows its current npm version and is installed below:
 
 ```text
 <HERMES_WEB_UI_HOME>/coding-agent/pi-mcp-adapter
@@ -38,13 +38,13 @@ The Agents page install action effectively performs the following. The Pi adapte
 ```bash
 npm install -g @anthropic-ai/claude-code
 npm install -g @openai/codex --registry=https://registry.npmjs.org
-npm install -g @earendil-works/pi-coding-agent@0.84.1
+npm install -g @earendil-works/pi-coding-agent
 npm install -g @xai-official/grok --registry=https://registry.npmjs.org
 studio_home="${HERMES_WEB_UI_HOME:-$HOME/.hermes-web-ui}"
-npm install --prefix "$studio_home/coding-agent/pi-mcp-adapter" --save-exact pi-mcp-adapter@2.24.0
+npm install --prefix "$studio_home/coding-agent/pi-mcp-adapter" pi-mcp-adapter
 ```
 
-Run only the line for the requested Agent. For Pi, run both Pi lines, or use the Agents page so Studio chooses the revision's current pins automatically.
+Run only the line for the requested Agent. For Pi, run both Pi lines, or use the Agents page so Studio installs the packages' current npm versions automatically.
 
 ## Success criteria
 
@@ -75,7 +75,7 @@ The Agents page **Check update** action behaves as follows:
 
 - Claude Code: compares the detected version with `npm view @anthropic-ai/claude-code version`.
 - Codex: compares the detected version with `npm view @openai/codex version --registry=https://registry.npmjs.org`.
-- Pi: compares the detected version with Studio's pinned Pi version; it does not chase npm latest independently.
+- Pi: compares the detected version with `npm view @earendil-works/pi-coding-agent version`.
 - Grok: compares the detected version with `npm view @xai-official/grok version --registry=https://registry.npmjs.org`.
 
 Studio uses the official npm Registry only for Codex and Grok installation and

--- a/packages/server/src/modules/coding-agents/services/index.ts
+++ b/packages/server/src/modules/coding-agents/services/index.ts
@@ -56,10 +56,7 @@ const CLAUDE_CODE_ROOT_PERMISSION_ARGS = ['--permission-mode', 'auto']
 // model context window, so it can compact too late for the 20MB proxy body
 // limit. Mirror Hermes' 50% compression budget and pass Studio's window.
 const CLAUDE_CODE_AUTO_COMPACT_PERCENT = 50
-const PI_MCP_ADAPTER_VERSION = '2.24.0'
-const PI_MCP_ADAPTER_PACKAGE = `pi-mcp-adapter@${PI_MCP_ADAPTER_VERSION}`
-const PI_CODING_AGENT_VERSION = '0.84.1'
-const PI_CODING_AGENT_PACKAGE = `@earendil-works/pi-coding-agent@${PI_CODING_AGENT_VERSION}`
+const PI_MCP_ADAPTER_PACKAGE = 'pi-mcp-adapter'
 const OFFICIAL_NPM_REGISTRY = 'https://registry.npmjs.org'
 const PI_PROVIDER_ID = 'hermes-studio'
 const PI_PROXY_TARGET_FILE = 'proxy-target.json'
@@ -2686,6 +2683,10 @@ export function withCodingAgentRegistry(id: CodingAgentId, args: string[]): stri
     : [...args]
 }
 
+export function piMcpAdapterInstallArgs(adapterRoot: string): string[] {
+  return ['install', '--prefix', adapterRoot, PI_MCP_ADAPTER_PACKAGE]
+}
+
 export function getCodingAgentConfigFileDefinitions(id: string): CodingAgentConfigFileDefinition[] {
   const tool = getCodingAgentDefinition(id)
   if (!tool) return []
@@ -2719,7 +2720,7 @@ export async function getCodingAgentStatus(definition: CodingAgentDefinition): P
         rawVersion,
         source: 'user-cli',
         path: resolvedCommand,
-        error: `Pi MCP Adapter ${PI_MCP_ADAPTER_VERSION} is not installed`,
+        error: 'Pi MCP Adapter is not installed',
       }
       recordCodingAgentStatus(status)
       return status
@@ -2824,12 +2825,6 @@ export async function checkUpdateAgent(id: string): Promise<CodingAgentUpdateRes
     throw err
   }
   try {
-    if (tool.id === 'pi') {
-      const status = await getCodingAgentStatus(tool)
-      const latestVersion = PI_CODING_AGENT_VERSION
-      const updateAvailable = status.installed && !versionGte(status.version, latestVersion)
-      return { success: true, tool: status, latestVersion, updateAvailable }
-    }
     const env = await commandEnv()
     const { stdout } = await runNpm(
       withCodingAgentRegistry(tool.id, ['view', tool.packageName, 'version']),
@@ -2863,7 +2858,7 @@ export async function installCodingAgent(id: string): Promise<CodingAgentMutatio
     const env = await commandEnv()
     await runNpm(withCodingAgentRegistry(
       tool.id,
-      ['install', '-g', tool.id === 'pi' ? PI_CODING_AGENT_PACKAGE : tool.packageName],
+      ['install', '-g', tool.packageName],
     ), {
       timeout: 10 * 60 * 1000,
       env,
@@ -2871,7 +2866,7 @@ export async function installCodingAgent(id: string): Promise<CodingAgentMutatio
     if (tool.id === 'pi') {
       const adapterRoot = getPiMcpAdapterRoot()
       await mkdir(adapterRoot, { recursive: true })
-      await runNpm(['install', '--prefix', adapterRoot, '--save-exact', PI_MCP_ADAPTER_PACKAGE], {
+      await runNpm(piMcpAdapterInstallArgs(adapterRoot), {
         timeout: 10 * 60 * 1000,
         env,
       })
@@ -3449,7 +3444,7 @@ export async function prepareCodingAgentLaunch(id: string, input: CodingAgentLau
     ]
   } else if (tool.id === 'pi') {
     if (!existsSync(getPiMcpAdapterEntry())) {
-      const err = new Error(`Pi MCP Adapter ${PI_MCP_ADAPTER_VERSION} is not installed. Reinstall Pi from Coding Agents.`)
+      const err = new Error('Pi MCP Adapter is not installed. Reinstall Pi from Coding Agents.')
       ;(err as any).status = 400
       throw err
     }

--- a/tests/server/coding-agent-npm-registry.test.ts
+++ b/tests/server/coding-agent-npm-registry.test.ts
@@ -1,7 +1,23 @@
 import { describe, expect, it } from 'vitest'
-import { withCodingAgentRegistry } from '../../packages/server/src/modules/coding-agents/services'
+import {
+  getCodingAgentDefinitions,
+  piMcpAdapterInstallArgs,
+  withCodingAgentRegistry,
+} from '../../packages/server/src/modules/coding-agents/services'
 
 describe('coding Agent npm registry policy', () => {
+  it('does not pin coding Agent or Pi MCP Adapter package versions', () => {
+    for (const agent of getCodingAgentDefinitions()) {
+      expect(agent.packageName).not.toMatch(/@\d+\.\d+\.\d+(?:$|[-+])/)
+    }
+    expect(piMcpAdapterInstallArgs('/tmp/pi-adapter')).toEqual([
+      'install',
+      '--prefix',
+      '/tmp/pi-adapter',
+      'pi-mcp-adapter',
+    ])
+  })
+
   it.each([
     ['codex', '@openai/codex'],
     ['grok', '@xai-official/grok'],
@@ -27,6 +43,11 @@ describe('coding Agent npm registry policy', () => {
         'install',
         '-g',
         'package',
+      ])
+      expect(withCodingAgentRegistry(agentId, ['view', 'package', 'version'])).toEqual([
+        'view',
+        'package',
+        'version',
       ])
     },
   )


### PR DESCRIPTION
## Summary
- stop pinning `@earendil-works/pi-coding-agent` to `0.84.1`
- stop pinning `pi-mcp-adapter` to `2.24.0` and remove `--save-exact`
- make Pi update checks query npm like the other coding agents
- update installation guidance and add regression coverage ensuring managed coding-agent packages are not version-pinned

## Agent version audit
- Claude Code: unpinned
- Codex: unpinned
- Pi: unpinned by this PR
- Grok: unpinned
- OpenCode: unpinned
- Ekko Agent: bundled with Studio, not independently installed by Agent Manager

The Codex `0.128.0` and `0.142.0` constants are capability gates, not install pins.

## Validation
- `vitest run tests/server/coding-agent-npm-registry.test.ts tests/server/coding-agents-launch.test.ts tests/server/pi-config-editor.test.ts` — 98 passed
- `tsc --noEmit -p packages/server/tsconfig.json`
- `git diff --check`
