### PR TITLE
chore: bump Studio and desktop to 0.7.19

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Ekko Studio API",
     "description": "Ekko Studio API — chat sessions, scheduled jobs, platform channels, model management, skills, memory, logs, file browser, group chat, and terminal.",
-    "version": "0.7.18"
+    "version": "0.7.19"
   },
   "servers": [
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hermes-web-ui",
-  "version": "0.7.18",
+  "version": "0.7.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hermes-web-ui",
-      "version": "0.7.18",
+      "version": "0.7.19",
       "license": "BSL-1.1",
       "dependencies": {
         "@audio/decode-mp3": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-web-ui",
-  "version": "0.7.18",
+  "version": "0.7.19",
   "description": "Ekko Studio is a local-first AI workspace for multi-agent chat, coding, and visual workflows, available on desktop and the web.",
   "repository": {
     "type": "git",

--- a/packages/desktop/package-lock.json
+++ b/packages/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hermes-studio",
-  "version": "0.7.18",
+  "version": "0.7.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hermes-studio",
-      "version": "0.7.18",
+      "version": "0.7.19",
       "license": "BSL-1.1",
       "dependencies": {
         "electron-updater": "^6.3.9",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-studio",
-  "version": "0.7.18",
+  "version": "0.7.19",
   "description": "Ekko Studio desktop app for multi-agent chat, coding, and visual workflows, with bundled local runtimes.",
   "homepage": "https://ekkostudio.xyz",
   "author": {


### PR DESCRIPTION
## Summary
Bump Studio and the desktop app from 0.7.18 to 0.7.19 to match the merged frontend changelog. Synchronize both package manifests and both lockfiles, including their root package entries, and the generated OpenAPI version.

## Validation
- `npm run harness:check` passed.
- `npm ci --ignore-scripts --include=dev --no-audit --no-fund` passed in the repository root and `packages/desktop`.
- `npm run build` passed.
- `git diff --check` passed; the change contains only seven version values across five files.
