### PR TITLE
fix: preserve usage and refresh Grok session settings

### DIFF
--- a/packages/server/src/bootstrap/session-agent-runtime-adapter.ts
+++ b/packages/server/src/bootstrap/session-agent-runtime-adapter.ts
@@ -41,4 +41,7 @@ configureSessionAgentRuntime({
     )
   },
   stopCodingAgentSessionRun: (sessionId, options) => codingAgentRunManager.stop(sessionId, options),
+  invalidateCodingAgentSessionRuntime: (sessionId, agentId = 'grok') => codingAgentRunManager.invalidateMatching(
+    launch => launch.sessionId === sessionId && launch.agentId === agentId,
+  ),
 })

--- a/packages/server/src/modules/coding-agents/services/grok/streaming-json.ts
+++ b/packages/server/src/modules/coding-agents/services/grok/streaming-json.ts
@@ -50,20 +50,19 @@ export function parseGrokStreamingJsonLine(line: string): GrokStreamEvent | null
   }
   if (type === 'plan') return { type, entries: event.entries }
   if (type === 'usage') {
-    return { type, usage: event.usage, stopReason: String(event.stopReason || '') }
+    return { type, usage: event.usage ?? event.data?.usage, stopReason: String(event.stopReason || event.data?.stopReason || '') }
   }
   if (type === 'end') {
     return {
       type,
       sessionId: String(event.sessionId || ''),
       stopReason: String(event.stopReason || ''),
-      usage: event.usage,
+      usage: event.usage ?? event.data?.usage,
     }
   }
   if (type === 'error') {
-    return { type, message: String(event.message || 'Grok run failed'), usage: event.usage }
+    return { type, message: String(event.message || event.data?.message || 'Grok run failed'), usage: event.usage ?? event.data?.usage }
   }
   const message = statusMessage(event)
   return message ? { type: 'status', message } : null
 }
-

--- a/packages/server/src/modules/coding-agents/services/index.ts
+++ b/packages/server/src/modules/coding-agents/services/index.ts
@@ -3544,7 +3544,12 @@ export async function prepareCodingAgentLaunch(id: string, input: CodingAgentLau
           chatSessionId: isolatedInput.sessionId,
         })
       : null
-    const capabilities = getModelRuntimeCapabilities({ profile: scope.profile, provider, model })
+    const capabilities = getModelRuntimeCapabilities({
+      profile: scope.profile,
+      provider,
+      model,
+      ...(provider === 'custom' || provider.startsWith('custom:') ? { fallbackContextLength: 128_000 } : {}),
+    })
     const baseConfigRoot = getScopedConfigRoot(tool.id, scope)
     const globalGrokHome = process.env.GROK_HOME?.trim() || join(getGlobalConfigHome(), '.grok')
     const globalInstructions = await safeReadFile(join(globalGrokHome, 'AGENTS.md')) || ''

--- a/packages/server/src/modules/coding-agents/services/runtime/run-manager.ts
+++ b/packages/server/src/modules/coding-agents/services/runtime/run-manager.ts
@@ -2432,7 +2432,7 @@ export class CodingAgentRunManager {
           },
           error: (message, usage) => {
             run.codexPendingUsage = usage || run.codexPendingUsage
-            this.failCodexExecTurn(run, message)
+            this.failCodexExecTurn(run, message, usage)
           },
           status: message => this.emitTerminalStatus(run, message),
         })
@@ -2457,7 +2457,7 @@ export class CodingAgentRunManager {
         }
         if (run.printCompleted) return
         if (code === 0) this.completeClaudePrintTurn(run, run.codexPendingUsage)
-        else this.failCodexExecTurn(run, run.codexPendingError || exitErrorMessage('Grok', code, run.currentChildStderr))
+        else this.failCodexExecTurn(run, run.codexPendingError || exitErrorMessage('Grok', code, run.currentChildStderr), run.codexPendingUsage)
       },
     })
     run.currentChild = child
@@ -2928,7 +2928,7 @@ export class CodingAgentRunManager {
     this.failCodexExecTurn(run, message)
   }
 
-  private failCodexExecTurn(run: ManagedCodingAgentRun, message: string) {
+  private failCodexExecTurn(run: ManagedCodingAgentRun, message: string, usage?: unknown) {
     this.handleClaudePrintResponseEvent(run, {
       type: 'response.failed',
       data: {
@@ -2940,6 +2940,7 @@ export class CodingAgentRunManager {
           model: run.launch.model,
           error: { message },
           output: [],
+          usage,
         },
       },
     })

--- a/packages/server/src/modules/hermes/controllers/models.ts
+++ b/packages/server/src/modules/hermes/controllers/models.ts
@@ -11,6 +11,7 @@ import { getCopilotModelsDetailed, resolveCopilotOAuthToken, type CopilotModelMe
 import { readAppConfig, writeAppConfig, providerDisplayLabel, type ModelVisibilityRule } from '../../studio/public/app-config'
 import { listUserProfiles } from '../../studio/public/users'
 import { readModelContextRecord, upsertModelContextRecord } from '../../studio/public/provider-context'
+import { getModelContextLength } from '../services/models/context'
 import { readProviderModelCatalogCache,
   refreshConfiguredProviderModelCatalogs,
   resolveProviderCatalogModels,
@@ -1210,8 +1211,17 @@ export async function getModelContext(ctx: any) {
       return
     }
     if (!result.row) {
-      ctx.status = 404
-      ctx.body = { error: 'Model context not found' }
+      const isCustomProvider = provider === 'custom' || provider.startsWith('custom:')
+      if (!isCustomProvider) {
+        ctx.status = 404
+        ctx.body = { error: 'Model context not found' }
+        return
+      }
+      const fallbackContextLength = 128_000
+      const contextLimit = getModelContextLength({ profile, provider, model, fallbackContextLength })
+      ctx.body = {
+        data: { id: null, provider, model, context_limit: contextLimit, limit: contextLimit },
+      }
       return
     }
 

--- a/packages/server/src/modules/hermes/services/models/context.ts
+++ b/packages/server/src/modules/hermes/services/models/context.ts
@@ -10,10 +10,17 @@ const HERMES_BASE = detectHermesHome()
 const MODELS_DEV_CACHE = resolve(HERMES_BASE, 'models_dev_cache.json')
 const DEFAULT_CONTEXT_LENGTH = 256_000
 
+function fallbackContextLength(options: ModelContextLengthOptions): number {
+  return options.fallbackContextLength && options.fallbackContextLength > 0
+    ? Math.floor(options.fallbackContextLength)
+    : DEFAULT_CONTEXT_LENGTH
+}
+
 export interface ModelContextLengthOptions {
   profile?: string
   model?: string | null
   provider?: string | null
+  fallbackContextLength?: number
 }
 
 interface ModelLimit {
@@ -431,10 +438,10 @@ export function getModelContextLength(input?: string | ModelContextLengthOptions
   const profile = options.profile
   const profileDir = getProfileDir(profile)
   const config = loadConfig(profileDir)
-  if (!config) return DEFAULT_CONTEXT_LENGTH
+  if (!config) return fallbackContextLength(options)
 
   let model = String(options.model || '').trim() || getDefaultModel(config)
-  if (!model) return DEFAULT_CONTEXT_LENGTH
+  if (!model) return fallbackContextLength(options)
 
   let provider = String(options.provider || '').trim() || getDefaultProvider(config)
 
@@ -446,7 +453,7 @@ export function getModelContextLength(input?: string | ModelContextLengthOptions
 
   if (provider?.toLowerCase() === 'moa') {
     const aggregator = resolveMoaAggregator(config, model)
-    if (!aggregator) return DEFAULT_CONTEXT_LENGTH
+    if (!aggregator) return fallbackContextLength(options)
     model = aggregator.model
     provider = aggregator.provider
 
@@ -471,7 +478,7 @@ export function getModelContextLength(input?: string | ModelContextLengthOptions
   if (cached) return cached
 
   // 5. Fallback
-  return DEFAULT_CONTEXT_LENGTH
+  return fallbackContextLength(options)
 }
 
 export function getModelRuntimeCapabilities(input: ModelContextLengthOptions): {

--- a/packages/server/src/modules/studio/controllers/sessions.ts
+++ b/packages/server/src/modules/studio/controllers/sessions.ts
@@ -12,6 +12,7 @@ import {
   listHermesSessionSummaryGroups,
   notifyHermesSessionModelChanged,
   stopCodingAgentSessionRun,
+  invalidateCodingAgentSessionRuntime,
 } from '../public/session-agent-runtime'
 import {
   listSessions as localListSessions,
@@ -1601,6 +1602,7 @@ export async function setReasoningEffort(ctx: any) {
   }
 
   localUpdateSession(id, { reasoning_effort: reasoningEffort })
+  if (existing.agent === 'grok') invalidateCodingAgentSessionRuntime(id)
   getChatRunServer()?.emitSessionSettingsUpdated(id, {
     reasoning_effort: reasoningEffort,
   })

--- a/packages/server/src/modules/studio/public/session-agent-runtime.ts
+++ b/packages/server/src/modules/studio/public/session-agent-runtime.ts
@@ -11,6 +11,7 @@ export interface SessionAgentRuntimeDependencies {
   listHermesSessionSummaryGroups: (...args: any[]) => Promise<any>
   notifyHermesSessionModelChanged: (...args: any[]) => Promise<void>
   stopCodingAgentSessionRun: (...args: any[]) => any
+  invalidateCodingAgentSessionRuntime: (...args: any[]) => any
 }
 
 let dependencies: SessionAgentRuntimeDependencies | null = null
@@ -36,3 +37,4 @@ export const listHermesSessionSummaries = (...args: any[]): Promise<any[]> => co
 export const listHermesSessionSummaryGroups = (...args: any[]): Promise<any> => configured().listHermesSessionSummaryGroups(...args)
 export const notifyHermesSessionModelChanged = (...args: any[]): Promise<void> => configured().notifyHermesSessionModelChanged(...args)
 export const stopCodingAgentSessionRun = (...args: any[]) => configured().stopCodingAgentSessionRun(...args)
+export const invalidateCodingAgentSessionRuntime = (...args: any[]) => configured().invalidateCodingAgentSessionRuntime(...args)

--- a/tests/server/agent-runner/grok/grok-runtime.test.ts
+++ b/tests/server/agent-runner/grok/grok-runtime.test.ts
@@ -227,4 +227,15 @@ describe('Grok streaming JSON adaptation', () => {
     expect(completed).toEqual([{ id: 'call-1', output: { lines: 42 }, failed: false }])
     expect(sessions).toEqual(['session-1'])
   })
+
+  it('accepts usage fields emitted at the top level of native events', () => {
+    const usage = parseGrokStreamingJsonLine('{"type":"end","sessionId":"session-1","data":{"usage":{"prompt_tokens":81441,"completion_tokens":128}}}')
+
+    expect(usage).toEqual({
+      type: 'end',
+      sessionId: 'session-1',
+      stopReason: '',
+      usage: { prompt_tokens: 81441, completion_tokens: 128 },
+    })
+  })
 })

--- a/tests/server/model-context.test.ts
+++ b/tests/server/model-context.test.ts
@@ -74,6 +74,14 @@ describe('getModelContextLength', () => {
     expect(getModelContextLength()).toBe(256_000)
   })
 
+  it('uses a caller-provided fallback only when no model context is configured', async () => {
+    writeConfig(`model:\n  default: grok-4.6\n  provider: custom:grok\n`)
+
+    const { getModelContextLength } = await loadModelContext()
+
+    expect(getModelContextLength({ provider: 'custom:grok', model: 'grok-4.6', fallbackContextLength: 128_000 })).toBe(128_000)
+  })
+
   it('does not scan other providers when the configured provider exists without that model', async () => {
     writeConfig(`model:\n  default: gpt-5.5\n  provider: openai-codex\n`)
     writeModelsCache({

--- a/tests/server/sessions-controller.test.ts
+++ b/tests/server/sessions-controller.test.ts
@@ -51,6 +51,7 @@ const agentStatusMocks = vi.hoisted(() => ({ hermesAvailable: true }))
 const codingAgentRunManagerMock = vi.hoisted(() => ({
   stop: vi.fn(),
 }))
+const invalidateCodingAgentSessionRuntimeMock = vi.hoisted(() => vi.fn())
 
 vi.mock('../../packages/server/src/modules/hermes/services/history/conversations-db', () => ({
   listConversationSummariesFromDb: listConversationSummariesFromDbMock,
@@ -237,6 +238,7 @@ vi.mock('../../packages/server/src/modules/studio/public/session-agent-runtime',
     )
   },
   stopCodingAgentSessionRun: codingAgentRunManagerMock.stop,
+  invalidateCodingAgentSessionRuntime: invalidateCodingAgentSessionRuntimeMock,
 }))
 
 vi.mock('../../packages/server/src/modules/studio/public/agent-status-registry', () => ({
@@ -316,6 +318,7 @@ describe('session conversations controller', () => {
     bridgeGetRuntimeStateMock.mockReset()
     bridgeGetRuntimeStateMock.mockReturnValue({ ready: false, running: false, endpoint: 'ipc:///tmp/hermes-agent-bridge.sock' })
     codingAgentRunManagerMock.stop.mockReset()
+    invalidateCodingAgentSessionRuntimeMock.mockReset()
   })
 
   it('lists conversations from the local session store', async () => {
@@ -2112,6 +2115,19 @@ describe('session conversations controller', () => {
       reasoning_effort: 'high',
     })
     expect(ctx.body).toEqual({ ok: true, reasoning_effort: 'high' })
+  })
+
+  it('restarts a Grok runtime after changing session reasoning effort', async () => {
+    getSessionMock.mockReturnValue({ id: 'grok-session', profile: 'default', agent: 'grok' })
+
+    const mod = await import('../../packages/server/src/modules/studio/controllers/sessions')
+    await mod.setReasoningEffort({
+      params: { id: 'grok-session' },
+      request: { body: { reasoningEffort: 'max' } },
+      body: null,
+    } as any)
+
+    expect(invalidateCodingAgentSessionRuntimeMock).toHaveBeenCalledWith('grok-session')
   })
 
   it('deletes a current-profile Hermes history session even when no local Web UI session exists', async () => {


### PR DESCRIPTION
## Summary
- Preserve usage emitted by Grok native events, including failed turns, so session counters remain accurate.
- Bound context selection for custom providers without model metadata and refresh a running Grok runtime after reasoning-effort changes.

Closes #2971

## Validation
- `git diff --check`
- Focused Vitest suites and `npm run build` were not run because dependencies were unavailable in the isolated worktree and the package registry was unreachable.