### PR TITLE
fix: record native global agent usage and model attribution

### DIFF
--- a/packages/server/src/modules/coding-agents/services/grok/streaming-json.ts
+++ b/packages/server/src/modules/coding-agents/services/grok/streaming-json.ts
@@ -4,9 +4,9 @@ export type GrokStreamEvent =
   | { type: 'tool_call'; toolCallId: string; title: string; toolName: string; rawInput: unknown; status: string }
   | { type: 'tool_call_update'; toolCallId: string; status: string; content: unknown; rawOutput: unknown }
   | { type: 'plan'; entries: unknown }
-  | { type: 'usage'; usage: unknown; stopReason: string }
-  | { type: 'end'; sessionId: string; stopReason: string; usage: unknown }
-  | { type: 'error'; message: string; usage?: unknown }
+  | { type: 'usage'; usage: unknown; stopReason: string; messageId?: string }
+  | { type: 'end'; sessionId: string; stopReason: string; usage: unknown; modelUsage?: unknown }
+  | { type: 'error'; message: string; usage?: unknown; modelUsage?: unknown }
   | { type: 'status'; message: string }
 
 function statusMessage(event: any): string {
@@ -50,7 +50,7 @@ export function parseGrokStreamingJsonLine(line: string): GrokStreamEvent | null
   }
   if (type === 'plan') return { type, entries: event.entries }
   if (type === 'usage') {
-    return { type, usage: event.usage ?? event.data?.usage, stopReason: String(event.stopReason || event.data?.stopReason || '') }
+    return { type, usage: event.usage ?? event.data?.usage, stopReason: String(event.stopReason || event.data?.stopReason || ''), ...(event.messageId ? { messageId: String(event.messageId) } : {}) }
   }
   if (type === 'end') {
     return {
@@ -58,10 +58,11 @@ export function parseGrokStreamingJsonLine(line: string): GrokStreamEvent | null
       sessionId: String(event.sessionId || ''),
       stopReason: String(event.stopReason || ''),
       usage: event.usage ?? event.data?.usage,
+      ...(event.modelUsage || event.data?.modelUsage ? { modelUsage: event.modelUsage ?? event.data?.modelUsage } : {}),
     }
   }
   if (type === 'error') {
-    return { type, message: String(event.message || event.data?.message || 'Grok run failed'), usage: event.usage ?? event.data?.usage }
+    return { type, message: String(event.message || event.data?.message || 'Grok run failed'), usage: event.usage ?? event.data?.usage, ...(event.modelUsage || event.data?.modelUsage ? { modelUsage: event.modelUsage ?? event.data?.modelUsage } : {}) }
   }
   const message = statusMessage(event)
   return message ? { type: 'status', message } : null

--- a/packages/server/src/modules/coding-agents/services/runtime/native-model.ts
+++ b/packages/server/src/modules/coding-agents/services/runtime/native-model.ts
@@ -1,0 +1,65 @@
+import { createReadStream, existsSync } from 'fs'
+import { readdir } from 'fs/promises'
+import { join } from 'path'
+import { createInterface } from 'readline'
+import { DatabaseSync } from 'node:sqlite'
+
+async function findRollout(root: string, sessionId: string, depth = 0): Promise<string | undefined> {
+  if (depth > 3) return
+  let entries
+  try { entries = await readdir(root, { withFileTypes: true }) } catch { return }
+  for (const entry of entries) {
+    if (entry.isFile() && entry.name.startsWith('rollout-') && entry.name.endsWith(`-${sessionId}.jsonl`)) return join(root, entry.name)
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory() || !/^\d{2,4}$/.test(entry.name)) continue
+    const found = await findRollout(join(root, entry.name), sessionId, depth + 1)
+    if (found) return found
+  }
+}
+
+/** Read only the identified thread, and never reuse a previous turn's model. */
+export async function readCodexTurnModel(home: string, sessionId: string, startedAt: number): Promise<{ model: string; provider?: string } | undefined> {
+  const endedAt = Date.now()
+  if (!/^[a-zA-Z0-9-]+$/.test(sessionId)) return
+  const file = await findRollout(join(home, 'sessions'), sessionId)
+  if (!file) return
+  const models = new Set<string>()
+  let provider: string | undefined
+  let matchedSession = false
+  const stream = createReadStream(file, { encoding: 'utf8', signal: AbortSignal.timeout(2_000) })
+  const lines = createInterface({ input: stream, crlfDelay: Infinity })
+  try {
+    for await (const line of lines) {
+      let event: any
+      try { event = JSON.parse(line) } catch { continue }
+      const payload = event.payload || {}
+      if (event.type === 'session_meta') {
+        matchedSession = payload.id === sessionId
+        provider = typeof payload.model_provider === 'string' ? payload.model_provider : undefined
+      }
+      const timestamp = Date.parse(event.timestamp)
+      if (event.type === 'turn_context' && timestamp >= startedAt && timestamp <= endedAt && typeof payload.model === 'string' && payload.model.trim()) {
+        models.add(payload.model.trim())
+      }
+    }
+  } catch { return } finally {
+    lines.close()
+    stream.destroy()
+  }
+  if (matchedSession && models.size === 1) return { model: [...models][0], provider }
+}
+
+/** OpenCode step parts reference the assistant message that owns the model. */
+export function readOpenCodeMessageModel(databasePath: string | undefined, sessionId: string, messageId: string): { model: string; provider?: string } | undefined {
+  if (!databasePath || !sessionId || !messageId || !existsSync(databasePath)) return
+  let db: DatabaseSync | undefined
+  try {
+    db = new DatabaseSync(databasePath, { readOnly: true })
+    const row = db.prepare('SELECT data FROM message WHERE id = ? AND session_id = ?').get(messageId, sessionId)
+    if (!row || typeof row.data !== 'string') return
+    const message = JSON.parse(row.data)
+    if (message.role !== 'assistant' || typeof message.modelID !== 'string' || !message.modelID.trim()) return
+    return { model: message.modelID.trim(), provider: typeof message.providerID === 'string' ? message.providerID : undefined }
+  } catch { return } finally { db?.close() }
+}

--- a/packages/server/src/modules/coding-agents/services/runtime/native-usage.ts
+++ b/packages/server/src/modules/coding-agents/services/runtime/native-usage.ts
@@ -1,0 +1,157 @@
+import { createHash } from 'crypto'
+import { normalizeTokenUsage, type NormalizedTokenUsage } from '../../../studio/public/usage'
+
+export interface NativeUsageRow {
+  id: string
+  model: string
+  provider?: string
+  usage: NormalizedTokenUsage
+  apiCalls?: number
+  scope: 'run' | 'model_call'
+}
+
+const tokenKeys = ['inputTokens', 'outputTokens', 'cacheReadTokens', 'cacheWriteTokens', 'reasoningTokens'] as const
+
+function measured(value: unknown): NormalizedTokenUsage | undefined {
+  const usage = normalizeTokenUsage(value)
+  return usage.isEstimated ? undefined : usage
+}
+
+function modelName(value: unknown): string {
+  return typeof value === 'string' && value.trim() !== 'unknown' ? value.trim() : ''
+}
+
+function sameTotals(rows: NativeUsageRow[], usage: NormalizedTokenUsage): boolean {
+  return tokenKeys.every(key => rows.reduce((sum, row) => sum + row.usage[key], 0) === usage[key])
+}
+
+/** Per-turn native accounting. Never mixes a session total with a turn total. */
+export class NativeTurnUsage {
+  model = ''
+  provider?: string
+  private readonly messages = new Map<string, NativeUsageRow>()
+  private claudeMessage?: { id: string; model: string; usage: Record<string, unknown> }
+  private readonly claudeModels = new Set<string>()
+  private modelUsage?: Record<string, any>
+  private pendingUsage?: unknown
+  private readonly grokResponses = new Map<string, unknown>()
+
+  observeClaude(event: any) {
+    if (event.type === 'system' && event.subtype === 'init') this.model = modelName(event.model)
+    const message = event.type === 'assistant' ? event.message : undefined
+    if (message && !event.isApiErrorMessage) {
+      const model = modelName(message.model)
+      if (model) { this.claudeModels.add(model); this.model = model }
+      const usage = measured(message.usage)
+      // Some CLIs emit placeholder zero-usage top-level messages before the
+      // authoritative message_delta. Do not overwrite a completed stream row.
+      if (message.id && usage && !this.messages.has(message.id)) {
+        this.messages.set(message.id, { id: message.id, model, usage, apiCalls: 1, scope: 'model_call' })
+      }
+    }
+    if (event.type === 'stream_event') {
+      const frame = event.event || {}
+      if (frame.type === 'message_start') {
+        const model = modelName(frame.message?.model)
+        if (model) { this.claudeModels.add(model); this.model = model }
+        this.claudeMessage = { id: String(frame.message?.id || ''), model, usage: { ...frame.message?.usage } }
+      } else if (frame.type === 'message_delta' && this.claudeMessage) {
+        Object.assign(this.claudeMessage.usage, frame.usage)
+      } else if (frame.type === 'message_stop' && this.claudeMessage) {
+        const { id, model, usage: raw } = this.claudeMessage
+        const usage = measured(raw)
+        if (id && usage) this.messages.set(id, { id, model, usage, apiCalls: 1, scope: 'model_call' })
+        this.claudeMessage = undefined
+      }
+    }
+    if (event.type === 'result') {
+      this.pendingUsage = event.usage
+      this.modelUsage = event.modelUsage
+    }
+  }
+
+  observePi(event: any): NativeUsageRow | undefined {
+    const message = event.type === 'message_end' ? event.message : undefined
+    if (message?.role !== 'assistant') return
+    const raw = message.usage
+    const usage = measured(raw && {
+      inputTokens: raw.input, outputTokens: raw.output,
+      cacheReadTokens: raw.cacheRead, cacheWriteTokens: raw.cacheWrite,
+      reasoningTokens: raw.reasoning,
+    })
+    if (!usage) return
+    if (['error', 'aborted'].includes(message.stopReason) && tokenKeys.every(key => usage[key] === 0)) return
+    // Pi repeats the same message in turn_end and agent_end. Only message_end
+    // owns accounting; the native timestamp/content identify duplicate delivery.
+    const id = String(message.id || createHash('sha256').update(JSON.stringify(message)).digest('hex'))
+    if (this.messages.has(id)) return
+    const model = modelName(message.model)
+    const row: NativeUsageRow = { id, model, provider: modelName(message.provider), usage, apiCalls: 1, scope: 'model_call' }
+    this.messages.set(id, row)
+    this.model = model
+    return row
+  }
+
+  observeGrok(event: { type: string; usage?: unknown; modelUsage?: unknown; messageId?: string }) {
+    if (event.type === 'usage' && event.usage) {
+      this.grokResponses.set(event.messageId || `response-${this.grokResponses.size}`, event.usage)
+    }
+    if (event.type === 'end' || event.type === 'error') {
+      if (event.usage) this.pendingUsage = event.usage
+      if (event.modelUsage && typeof event.modelUsage === 'object' && !Array.isArray(event.modelUsage)) {
+        this.modelUsage = event.modelUsage as Record<string, any>
+        const models = Object.keys(this.modelUsage)
+        if (models.length === 1) this.model = modelName(models[0])
+      }
+    }
+  }
+
+  rows(agent: string, finalUsage: unknown, fallbackModel = ''): NativeUsageRow[] {
+    if (agent === 'pi') return [...this.messages.values()]
+    if (agent === 'codex') {
+      const raw = finalUsage as any
+      const usage = normalizeTokenUsage(raw && {
+        ...raw,
+        cache_write_tokens: raw.cache_write_input_tokens ?? raw.cache_write_tokens,
+        reasoning_tokens: raw.reasoning_output_tokens ?? raw.reasoning_tokens,
+      }, {}, { inputIncludesCache: true })
+      return usage.isEstimated ? [] : [{ id: 'turn', model: this.model || fallbackModel, provider: this.provider, usage, scope: 'run' }]
+    }
+
+    let usage = measured(this.pendingUsage ?? finalUsage)
+    if (agent === 'grok' && !this.pendingUsage && this.grokResponses.size) {
+      // A crash/error may omit the final aggregate. Per-response boundaries
+      // are additive, whereas end.usage is already the aggregate.
+      const observed = [...this.grokResponses.values()].map(measured).filter((row): row is NormalizedTokenUsage => !!row)
+      if (observed.length) usage = Object.fromEntries(tokenKeys.map(key => [key, observed.reduce((sum, row) => sum + row[key], 0)])) as unknown as NormalizedTokenUsage
+    }
+    if (!usage) return agent === 'claude-code' ? [...this.messages.values()] : []
+    if (agent === 'claude-code' && this.messages.size && sameTotals([...this.messages.values()], usage)) {
+      return [...this.messages.values()]
+    }
+
+    const models = Object.entries(this.modelUsage || {}).map(([model, raw]) => {
+      if (!raw || typeof raw !== 'object') return undefined
+      const normalized = measured({
+        inputTokens: raw.inputTokens, outputTokens: raw.outputTokens,
+        cacheReadTokens: raw.cacheReadInputTokens,
+        cacheWriteTokens: raw.cacheCreationInputTokens,
+        reasoningTokens: raw.reasoningTokens ?? raw.thinkingTokens,
+      })
+      return normalized ? {
+        id: `model:${model}`, model: modelName(model), usage: normalized, scope: 'run' as const,
+        ...(Number.isInteger(raw.modelCalls) && raw.modelCalls >= 0 ? { apiCalls: raw.modelCalls } : {}),
+      } : undefined
+    }).filter((row): row is NonNullable<typeof row> => !!row)
+    // Grok's per-model summaries omit reasoning in some versions. With one
+    // model attribution is unambiguous; with several keep an aggregate fallback.
+    if (models.length === 1 && !models[0].usage.reasoningTokens) models[0].usage.reasoningTokens = usage.reasoningTokens
+    if (models.length && sameTotals(models, usage)) return models
+
+    const names = new Set([...models.map(row => row.model), ...this.claudeModels].filter(Boolean))
+    const model = names.size === 1 ? [...names][0] : names.size > 1 ? '' : this.model || fallbackModel
+    // Claude modelUsage can include auxiliary work absent from result.usage.
+    // Keep the authoritative turn tokens instead of adding those totals again.
+    return [{ id: 'turn', model, usage, scope: 'run' }]
+  }
+}

--- a/packages/server/src/modules/coding-agents/services/runtime/run-manager.ts
+++ b/packages/server/src/modules/coding-agents/services/runtime/run-manager.ts
@@ -28,6 +28,9 @@ import { updateManagedPromptFileSync } from '../prompt-file'
 import { grokSessionExists, startGrokTurnProcess } from '../grok/turn-process'
 import { applyGrokStreamEvent } from '../grok/event-adapter'
 import { isolatedCodingAgentChildEnv } from './child-env'
+import { NativeTurnUsage, type NativeUsageRow } from './native-usage'
+import { readCodexTurnModel, readOpenCodeMessageModel } from './native-model'
+import { getCodingAgentGlobalHome } from '../../../studio/public/coding-agent-global-home'
 
 export { isolatedCodingAgentChildEnv } from './child-env'
 
@@ -184,6 +187,10 @@ interface ManagedCodingAgentRun {
   codexChatText?: string
   codexPendingUsage?: any
   codexPendingError?: string
+  codexTurnFailed?: boolean
+  nativeUsage?: NativeTurnUsage
+  nativeTurnStartedAt?: number
+  nativeCompletionPending?: boolean
   terminalUsageRefresh?: Promise<void>
   stoppedByUser?: boolean
   pendingChatCompletionEvent?: 'run.completed' | 'run.failed'
@@ -787,10 +794,17 @@ export class CodingAgentRunManager {
   send(sessionId: string, input: string, options: CodingAgentRunSendOptions = {}): { runId: string; messageId?: number } {
     const run = this.getBySession(sessionId)
     if (!run) throw new Error('Coding agent session not found')
+    if (run.nativeCompletionPending) throw new Error('Coding agent is still completing the previous input')
     if (agentUpdateLocked(run.launch.agentId)) throw new Error('Agent is updating; retry after completion')
     const text = String(input || '').trim()
     const images = Array.isArray(options.images) ? options.images : []
     if (!text && images.length === 0) throw new Error('Input is required')
+    // Keep native metadata separate from launch configuration: global CLIs can
+    // choose a different model each turn, including during a resumed session.
+    if (!childIsRunning(run.currentChild) || (run.launch.agentId === 'pi' && !run.turnActive)) {
+      run.nativeUsage = new NativeTurnUsage()
+      run.nativeTurnStartedAt = Date.now()
+    }
     const systemPrompt = String(options.systemPrompt || '').trim()
     this.ensureDbSession(run)
     run.assistantMessageId = undefined
@@ -1154,22 +1168,9 @@ export class CodingAgentRunManager {
     if (isTerminalEvent) {
       run.assistantMessageId = this.persistTerminalResponse(run)
       const final = (storageSafeResponseEvent.data as any).response || storageSafeResponseEvent.data
-      if (run.launch.mode !== 'scoped' && final?.usage) {
-        const usage = normalizeTokenUsage(final.usage)
-        if (!usage.isEstimated) {
-          recordSessionUsage({
-            sessionId: run.launch.sessionId,
-            runId: final?.id || run.printResponseId || run.runMarker,
-            source: 'coding_agent',
-            agent: usageCodingAgent(run.launch.agentId),
-            usageScope: 'run',
-            usage: final.usage,
-            profile: run.launch.profile,
-            model: final?.model || run.launch.model,
-            provider: run.launch.provider,
-            isEstimated: false,
-          })
-        }
+      if (run.launch.mode !== 'scoped' && !['opencode', 'pi'].includes(run.launch.agentId)) {
+        const rows = (run.nativeUsage || new NativeTurnUsage()).rows(run.launch.agentId, final?.usage, final?.model || run.launch.model)
+        this.recordNativeUsage(run, rows, final?.id || run.printResponseId || run.runMarker || run.id)
       }
       const deferPiUsageRefresh = run.launch.agentId === 'pi'
       run.terminalUsageRefresh = deferPiUsageRefresh
@@ -1205,6 +1206,24 @@ export class CodingAgentRunManager {
     run.state.responseRun = undefined
     updateSessionStats(run.launch.sessionId)
     return assistantMessageId
+  }
+
+  private recordNativeUsage(run: ManagedCodingAgentRun, rows: NativeUsageRow[], responseId: string) {
+    for (const row of rows) {
+      recordSessionUsage({
+        sessionId: run.launch.sessionId,
+        runId: `${responseId}:${row.id}`,
+        source: 'coding_agent',
+        agent: usageCodingAgent(run.launch.agentId),
+        usageScope: row.scope,
+        apiCalls: row.apiCalls,
+        usage: row.usage,
+        profile: run.launch.profile,
+        model: row.model,
+        provider: row.provider || run.launch.provider,
+        isEstimated: false,
+      })
+    }
   }
 
   private schedulePiTerminalUsageRefresh(run: ManagedCodingAgentRun) {
@@ -1648,6 +1667,10 @@ export class CodingAgentRunManager {
     }
 
     if (run.printCompleted) return
+    if (run.launch.mode === 'global') {
+      const row = run.nativeUsage?.observePi(event)
+      if (row) this.recordNativeUsage(run, [row], run.printResponseId || run.id)
+    }
     if (event.type === 'auto_retry_start') {
       run.piWillRetry = true
       return
@@ -1983,6 +2006,7 @@ export class CodingAgentRunManager {
     }
 
     if (run.printCompleted) return
+    if (run.launch.mode === 'global') run.nativeUsage?.observeClaude(event)
 
     if (event.type === 'stream_event' && event.event) {
       this.handleClaudeAnthropicStreamEvent(run, event.event)
@@ -2349,7 +2373,7 @@ export class CodingAgentRunManager {
           id: run.printResponseId,
           object: 'response',
           status: 'completed',
-          model: run.launch.model,
+          model: run.nativeUsage?.model || run.launch.model,
           output,
           usage,
         },
@@ -2410,6 +2434,7 @@ export class CodingAgentRunManager {
       images,
       onEvent: (event) => {
         this.touch(run)
+        if (run.launch.mode === 'global') run.nativeUsage?.observeGrok(event)
         applyGrokStreamEvent(event, {
           text: value => this.appendCodexText(run, value),
           thought: value => this.appendCodexReasoning(run, value),
@@ -2432,7 +2457,7 @@ export class CodingAgentRunManager {
           },
           error: (message, usage) => {
             run.codexPendingUsage = usage || run.codexPendingUsage
-            this.failCodexExecTurn(run, message, usage)
+            this.failCodexExecTurn(run, message, run.codexPendingUsage)
           },
           status: message => this.emitTerminalStatus(run, message),
         })
@@ -2595,6 +2620,8 @@ export class CodingAgentRunManager {
           reasoningTokens: tokens.reasoning,
         })
         if (!usage.isEstimated) {
+          const nativeModel = readOpenCodeMessageModel(run.launch.env?.OPENCODE_DB, nativeSessionId || run.launch.agentNativeSessionId || '', String(part.messageID || ''))
+          if (nativeModel && run.nativeUsage) Object.assign(run.nativeUsage, nativeModel)
           recordSessionUsage({
             sessionId: run.launch.sessionId,
             runId: String(part.id),
@@ -2604,8 +2631,8 @@ export class CodingAgentRunManager {
             apiCalls: 1,
             usage,
             profile: run.launch.profile,
-            model: run.launch.model,
-            provider: run.launch.provider,
+            model: nativeModel?.model || run.launch.model,
+            provider: nativeModel?.provider || run.launch.provider,
             isEstimated: false,
           })
         }
@@ -2699,6 +2726,7 @@ export class CodingAgentRunManager {
     run.printTextStarted = false
     run.printText = ''
     run.codexPendingError = undefined
+    run.codexTurnFailed = false
     run.printCompleted = false
     run.responseStartEmitted = false
     run.terminalEventHandled = false
@@ -2786,13 +2814,29 @@ export class CodingAgentRunManager {
       })
     })
 
-    child.on('exit', (code) => {
+    // Native stdout owns global usage. Drain it before final accounting and
+    // model lookup; `exit` can precede the last JSONL bytes.
+    child.on(run.launch.mode === 'global' ? 'close' : 'exit', (code: number | null) => {
       if (stdoutBuffer.trim()) this.handleCodexExecLine(run, stdoutBuffer)
       if (run.currentChildKillTimer) clearTimeout(run.currentChildKillTimer)
       run.currentChildKillTimer = undefined
       run.currentChild = undefined
       logger.info({ runId: run.id, sessionId: run.launch.sessionId, code }, '[coding-agent-run] codex exec exited')
-      this.finishCodexExecTurn(run, code)
+      const nativeSessionId = run.launch.agentNativeSessionId
+      if (run.launch.mode === 'global' && nativeSessionId && run.nativeTurnStartedAt) {
+        const home = run.launch.env?.CODEX_HOME || process.env.CODEX_HOME || join(getCodingAgentGlobalHome(), '.codex')
+        run.nativeCompletionPending = true
+        void readCodexTurnModel(home, nativeSessionId, run.nativeTurnStartedAt).then(metadata => {
+          run.nativeCompletionPending = false
+          if (run.exited || run.stoppedByUser) return
+          if (metadata && run.nativeUsage) Object.assign(run.nativeUsage, metadata)
+          this.finishCodexExecTurn(run, code)
+        }).catch(err => {
+          run.nativeCompletionPending = false
+          logger.warn({ err, runId: run.id }, '[coding-agent-run] failed to read native model metadata')
+          if (!run.exited && !run.stoppedByUser) this.finishCodexExecTurn(run, code)
+        })
+      } else this.finishCodexExecTurn(run, code)
     })
   }
 
@@ -2802,7 +2846,7 @@ export class CodingAgentRunManager {
       void this.emitAndMarkPrintChatRunCompletedAfterUsage(run, run.pendingChatCompletionEvent, run.pendingChatCompletionPayload)
       return
     }
-    if (code === 0) {
+    if (code === 0 && !run.codexTurnFailed) {
       this.completeCodexExecTurn(run, run.codexPendingUsage)
       return
     }
@@ -2817,6 +2861,7 @@ export class CodingAgentRunManager {
           model: run.launch.model,
           error: { message: run.codexPendingError || exitErrorMessage('Codex', code, run.currentChildStderr) },
           output: [],
+          usage: run.codexPendingUsage,
         },
       },
     })
@@ -2869,7 +2914,11 @@ export class CodingAgentRunManager {
       return
     }
     if (type === 'turn.failed') {
-      this.failCodexExecTurn(run, event.error?.message || event.message || 'Codex run failed')
+      run.codexTurnFailed = true
+      run.codexPendingUsage = event.usage ?? run.codexPendingUsage
+      const message = event.error?.message || event.message || 'Codex run failed'
+      if (run.launch.mode === 'global') this.deferCodexExecError(run, message)
+      else this.failCodexExecTurn(run, message, run.codexPendingUsage)
       return
     }
     if (type === 'error') {
@@ -2909,7 +2958,11 @@ export class CodingAgentRunManager {
       return
     }
     if (method === 'turn/failed') {
-      this.failCodexExecTurn(run, params.error?.message || params.message || 'Codex run failed')
+      run.codexTurnFailed = true
+      run.codexPendingUsage = params.usage ?? run.codexPendingUsage
+      const message = params.error?.message || params.message || 'Codex run failed'
+      if (run.launch.mode === 'global') this.deferCodexExecError(run, message)
+      else this.failCodexExecTurn(run, message, run.codexPendingUsage)
       return
     }
     if (method === 'error') {
@@ -2921,11 +2974,11 @@ export class CodingAgentRunManager {
     // Codex emits broad `error` events for recoverable stream retries as well as
     // failures. Let the native process exit status arbitrate the turn: exit 0
     // discards this provisional error, while a non-zero exit reports it.
-    if (childIsRunning(run.currentChild)) {
+    if (childIsRunning(run.currentChild) || (run.launch.mode === 'global' && run.currentChild)) {
       run.codexPendingError = message
       return
     }
-    this.failCodexExecTurn(run, message)
+    this.failCodexExecTurn(run, message, run.codexPendingUsage)
   }
 
   private failCodexExecTurn(run: ManagedCodingAgentRun, message: string, usage?: unknown) {

--- a/packages/server/src/modules/studio/services/chat-run/usage.ts
+++ b/packages/server/src/modules/studio/services/chat-run/usage.ts
@@ -110,7 +110,9 @@ export async function calcAndUpdateUsage(
         ...usage,
         ...(latest
           ? {
-              contextInputTokens: Number(latest.input_tokens || 0),
+              // Accounting keeps ordinary and cached input disjoint, but both
+              // occupy the model's context window.
+              contextInputTokens: Number(latest.input_tokens || 0) + Number(latest.cache_read_tokens || 0) + Number(latest.cache_write_tokens || 0),
               contextOutputTokens: Number(latest.output_tokens || 0),
             }
           : {}),

--- a/tests/fixtures/coding-agents/global-native-usage.json
+++ b/tests/fixtures/coding-agents/global-native-usage.json
@@ -1,0 +1,163 @@
+{
+  "codex": [
+    {
+      "type": "turn.completed",
+      "usage": {
+        "input_tokens": 17783,
+        "cached_input_tokens": 12928,
+        "cache_write_input_tokens": 0,
+        "output_tokens": 5,
+        "reasoning_output_tokens": 0
+      }
+    }
+  ],
+  "pi": [
+    {
+      "type": "message_end",
+      "message": {
+        "role": "assistant",
+        "model": "glm-5-turbo",
+        "provider": "glm",
+        "usage": {
+          "input": 450,
+          "output": 33,
+          "cacheRead": 0,
+          "cacheWrite": 0,
+          "reasoning": 29,
+          "totalTokens": 483,
+          "cost": {
+            "input": 0,
+            "output": 0,
+            "cacheRead": 0,
+            "cacheWrite": 0,
+            "total": 0
+          }
+        },
+        "stopReason": "stop",
+        "timestamp": 1789092584578
+      }
+    },
+    {
+      "type": "agent_settled"
+    }
+  ],
+  "grok": [
+    {
+      "type": "usage",
+      "usage": {
+        "input_tokens": 16950,
+        "output_tokens": 42,
+        "cache_read_input_tokens": 640,
+        "cache_creation_input_tokens": 0,
+        "reasoning_tokens": 37
+      }
+    },
+    {
+      "type": "end",
+      "usage": {
+        "input_tokens": 16950,
+        "cache_read_input_tokens": 640,
+        "cache_creation_input_tokens": 0,
+        "output_tokens": 42,
+        "reasoning_tokens": 37,
+        "total_tokens": 17632
+      },
+      "modelUsage": {
+        "grok-4.6-build": {
+          "inputTokens": 16950,
+          "outputTokens": 42,
+          "cacheReadInputTokens": 640,
+          "cacheCreationInputTokens": 0,
+          "modelCalls": 1,
+          "costUSD": 0.00586024
+        }
+      },
+      "stopReason": "end_turn"
+    }
+  ],
+  "claude-code": [
+    {
+      "type": "system",
+      "subtype": "init",
+      "model": "glm-5.1"
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "message_start",
+        "message": {
+          "id": "claude-native-message",
+          "role": "assistant",
+          "model": "glm-5.1",
+          "usage": {
+            "input_tokens": 0,
+            "output_tokens": 0
+          }
+        }
+      }
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "message_delta",
+        "usage": {
+          "input_tokens": 1203,
+          "output_tokens": 3,
+          "cache_read_input_tokens": 4160,
+          "server_tool_use": {
+            "web_search_requests": 0
+          },
+          "service_tier": "standard"
+        }
+      }
+    },
+    {
+      "type": "stream_event",
+      "event": {
+        "type": "message_stop"
+      }
+    },
+    {
+      "type": "result",
+      "subtype": "success",
+      "is_error": false,
+      "usage": {
+        "input_tokens": 1203,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 4160,
+        "output_tokens": 3,
+        "output_tokens_details": {
+          "thinking_tokens": 0
+        },
+        "server_tool_use": {
+          "web_search_requests": 0,
+          "web_fetch_requests": 0
+        },
+        "service_tier": "standard",
+        "cache_creation": {
+          "ephemeral_1h_input_tokens": 0,
+          "ephemeral_5m_input_tokens": 0
+        },
+        "inference_geo": "",
+        "iterations": [],
+        "speed": "standard"
+      },
+      "modelUsage": {
+        "glm-5.1": {
+          "inputTokens": 1304,
+          "outputTokens": 54,
+          "cacheReadInputTokens": 4800,
+          "cacheCreationInputTokens": 0,
+          "webSearchRequests": 0,
+          "costUSD": 0.010270000000000001,
+          "contextWindow": 200000,
+          "maxOutputTokens": 32000,
+          "thinkingTokens": 0,
+          "canonicalModel": "glm-5.1",
+          "provider": "firstParty",
+          "costBasis": "unknown"
+        }
+      }
+    }
+  ]
+}

--- a/tests/server/native-agent-usage.test.ts
+++ b/tests/server/native-agent-usage.test.ts
@@ -1,0 +1,164 @@
+import { EventEmitter } from 'events'
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { PassThrough } from 'stream'
+import { spawn } from 'child_process'
+import { DatabaseSync } from 'node:sqlite'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import '../../packages/server/src/bootstrap/coding-agent-adapters'
+import { CodingAgentRunManager } from '../../packages/server/src/modules/coding-agents/services/runtime/run-manager'
+import { initAllHermesTables } from '../../packages/server/src/modules/studio/infrastructure/database/schemas'
+import { getRecordedUsageTotals, getUsage, getLocalUsageStats } from '../../packages/server/src/modules/studio/repositories/usage-store'
+import fixtures from '../fixtures/coding-agents/global-native-usage.json'
+
+vi.mock('child_process', async importOriginal => ({
+  ...await importOriginal<typeof import('child_process')>(), spawn: vi.fn(),
+}))
+
+describe('global native usage accounting', () => {
+  let manager: CodingAgentRunManager
+  let workspace: string
+  let sessionId: string
+  let child: any
+  let emitted: ReturnType<typeof vi.fn>
+  beforeEach(() => {
+    initAllHermesTables()
+    workspace = mkdtempSync(join(tmpdir(), 'native-usage-'))
+    sessionId = `chat-${workspace}`
+    manager = new CodingAgentRunManager()
+    emitted = vi.fn()
+    ;(manager as any).emitToChat = emitted
+    child = Object.assign(new EventEmitter(), {
+      stdin: new PassThrough(), stdout: new PassThrough(), stderr: new PassThrough(),
+      exitCode: null, signalCode: null, kill: vi.fn(),
+    })
+    vi.mocked(spawn).mockReturnValue(child)
+  })
+  afterEach(async () => {
+    child.exitCode = 0
+    manager.shutdown()
+    await new Promise(resolve => setImmediate(resolve))
+    rmSync(workspace, { recursive: true, force: true })
+    vi.clearAllMocks()
+  })
+  function start(agentId: string, mode: 'global' | 'scoped' = 'global') {
+    manager.start({
+      agentSessionId: sessionId, sessionId, agentId, mode,
+      profile: sessionId, provider: mode === 'global' ? 'global' : 'test', model: '', command: agentId,
+      args: agentId === 'pi' ? ['--mode', 'rpc'] : [], shellCommand: agentId,
+      workspaceDir: workspace, env: { GROK_HOME: workspace, CODEX_HOME: workspace, OPENCODE_DB: join(workspace, 'opencode.db') },
+    })
+    manager.send(sessionId, 'usage audit')
+  }
+  function emit(event: unknown) { child.stdout.write(`${JSON.stringify(event)}\n`) }
+  function close(code = 0) {
+    child.exitCode = code
+    child.emit('exit', code)
+    child.emit('close', code)
+  }
+
+  it.each(['codex', 'pi', 'claude-code', 'grok'] as const)('records captured %s events with model attribution', async agentId => {
+    start(agentId)
+    if (agentId === 'codex') {
+      const dir = join(workspace, 'sessions', '2026', '09', '11')
+      mkdirSync(dir, { recursive: true })
+      writeFileSync(join(dir, 'rollout-test-native-thread.jsonl'), [
+        { type: 'session_meta', payload: { id: 'native-thread', model_provider: 'openai' } },
+        { type: 'turn_context', timestamp: '2020-01-01T00:00:00Z', payload: { model: 'old-model' } },
+        { type: 'turn_context', timestamp: new Date().toISOString(), payload: { model: 'gpt-6-astra' } },
+      ].map(row => JSON.stringify(row)).join('\n'))
+      emit({ type: 'thread.started', thread_id: 'native-thread' })
+    }
+    for (const event of fixtures[agentId]) emit(event)
+    close()
+    await vi.waitFor(() => expect(getUsage(sessionId)?.model).toBe({ codex: 'gpt-6-astra', pi: 'glm-5-turbo', 'claude-code': 'glm-5.1', grok: 'grok-4.6-build' }[agentId]))
+    expect(getRecordedUsageTotals(sessionId, 'coding_agent')).toMatchObject({
+      codex: { inputTokens: 4855, outputTokens: 5, cacheReadTokens: 12928 },
+      pi: { inputTokens: 450, outputTokens: 33, reasoningTokens: 29, apiCalls: 1 },
+      'claude-code': { inputTokens: 1203, outputTokens: 3, cacheReadTokens: 4160, apiCalls: 1 },
+      grok: { inputTokens: 16950, outputTokens: 42, cacheReadTokens: 640, reasoningTokens: 37, apiCalls: 1 },
+    }[agentId])
+    await vi.waitFor(() => expect(emitted).toHaveBeenCalledWith(sessionId, 'usage.updated', expect.objectContaining({
+      contextTokens: { codex: 17788, pi: 483, 'claude-code': 5366, grok: 17632 }[agentId],
+    })))
+  })
+
+  it.each(['pi', 'claude-code', 'grok', 'codex'] as const)('%s scoped usage still comes only from the proxy', async agentId => {
+    start(agentId, 'scoped')
+    manager.handleProxyUsageEvent(sessionId, { type: 'response.completed', data: { response: { id: 'proxy-1', model: 'proxy-model', usage: { input_tokens: 12, output_tokens: 3 } } } })
+    for (const event of fixtures[agentId]) emit(event)
+    close()
+    expect(getRecordedUsageTotals(sessionId, 'coding_agent')).toMatchObject({ inputTokens: 12, outputTokens: 3, apiCalls: 1 })
+    expect(getUsage(sessionId)?.model).toBe('proxy-model')
+  })
+
+  it('does not duplicate Pi messages repeated in delivery or terminal events, and resets for another turn', () => {
+    start('pi')
+    const message = fixtures.pi[0]
+    emit(message)
+    emit(message)
+    // Usage is durable before settlement, including when a user stops here.
+    expect(getRecordedUsageTotals(sessionId, 'coding_agent')).toMatchObject({ inputTokens: 450, apiCalls: 1 })
+    emit({ type: 'turn_end', message: message.message })
+    emit({ type: 'agent_end', messages: [message.message] })
+    emit({ type: 'agent_settled' })
+    emit({ type: 'agent_settled' })
+    expect(getRecordedUsageTotals(sessionId, 'coding_agent')).toMatchObject({ inputTokens: 450, apiCalls: 1 })
+    manager.send(sessionId, 'next')
+    emit({ type: 'message_end', message: { ...message.message, model: 'second-model', timestamp: 999, usage: { input: 5, output: 2 } } })
+    emit({ type: 'agent_settled' })
+    expect(getRecordedUsageTotals(sessionId, 'coding_agent')).toMatchObject({ inputTokens: 455, outputTokens: 35, apiCalls: 2 })
+    expect(getUsage(sessionId)?.model).toBe('second-model')
+  })
+
+  it('retains all completed Grok response usage on error, without counting a final aggregate twice', () => {
+    start('grok')
+    emit({ type: 'usage', messageId: 'one', usage: { input_tokens: 10, output_tokens: 2 } })
+    emit({ type: 'usage', messageId: 'one', usage: { input_tokens: 10, output_tokens: 2 } })
+    emit({ type: 'usage', messageId: 'two', usage: { input_tokens: 20, output_tokens: 3 } })
+    emit({ type: 'error', message: 'upstream failed' })
+    close(1)
+    expect(getRecordedUsageTotals(sessionId, 'coding_agent')).toMatchObject({ inputTokens: 30, outputTokens: 5 })
+  })
+
+  it('waits for native Codex stdout to drain and retains measured usage on a failed exit', () => {
+    start('codex')
+    child.exitCode = 1
+    child.emit('exit', 1)
+    expect(getUsage(sessionId)).toBeUndefined()
+    emit({ type: 'turn.completed', usage: { input_tokens: 10, output_tokens: 2, cached_input_tokens: 4 } })
+    emit({ type: 'turn.failed', error: { message: 'native failure' } })
+    expect(getUsage(sessionId)).toBeUndefined()
+    child.emit('close', 1)
+    expect(getRecordedUsageTotals(sessionId, 'coding_agent')).toMatchObject({ inputTokens: 6, outputTokens: 2, cacheReadTokens: 4 })
+  })
+
+  it('splits a Grok turn across models and preserves explicit model call counts', () => {
+    start('grok')
+    emit({ type: 'end', usage: { input_tokens: 30, output_tokens: 5 }, modelUsage: {
+      first: { inputTokens: 10, outputTokens: 2, modelCalls: 1 },
+      second: { inputTokens: 20, outputTokens: 3, modelCalls: 2 },
+    } })
+    close()
+    expect(getRecordedUsageTotals(sessionId, 'coding_agent')).toMatchObject({ inputTokens: 30, outputTokens: 5, apiCalls: 3 })
+    expect(getLocalUsageStats(sessionId).by_model).toEqual(expect.arrayContaining([
+      expect.objectContaining({ model: 'first', input_tokens: 10 }),
+      expect.objectContaining({ model: 'second', input_tokens: 20 }),
+    ]))
+  })
+
+  it('uses the exact OpenCode assistant message model and leaves other sessions alone', () => {
+    const db = new DatabaseSync(join(workspace, 'opencode.db'))
+    db.exec('CREATE TABLE message (id TEXT, session_id TEXT, data TEXT)')
+    db.prepare('INSERT INTO message VALUES (?, ?, ?)').run('msg', 'native-session', JSON.stringify({ role: 'assistant', modelID: 'actual-model', providerID: 'actual-provider' }))
+    db.close()
+    start('opencode')
+    const event = { type: 'step_finish', sessionID: 'native-session', part: { id: 'step', messageID: 'msg', type: 'step-finish', tokens: { input: 10, output: 2 } } }
+    emit(event)
+    emit(event)
+    close()
+    expect(getUsage(sessionId)?.model).toBe('actual-model')
+    expect(getRecordedUsageTotals(sessionId, 'coding_agent')).toMatchObject({ inputTokens: 10, outputTokens: 2, apiCalls: 1 })
+  })
+})

--- a/tests/server/native-usage-metadata.test.ts
+++ b/tests/server/native-usage-metadata.test.ts
@@ -1,0 +1,79 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { DatabaseSync } from 'node:sqlite'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { readCodexTurnModel, readOpenCodeMessageModel } from '../../packages/server/src/modules/coding-agents/services/runtime/native-model'
+import { NativeTurnUsage } from '../../packages/server/src/modules/coding-agents/services/runtime/native-usage'
+
+describe('native model metadata', () => {
+  let root: string
+  const startedAt = Date.parse('2026-09-11T01:00:00Z')
+  beforeEach(() => { root = mkdtempSync(join(tmpdir(), 'native-model-')) })
+  afterEach(() => rmSync(root, { recursive: true, force: true }))
+  function rollout(id: string, events: unknown[]) {
+    const dir = join(root, 'sessions', '2026', '09', '10')
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(join(dir, `rollout-test-${id}.jsonl`), events.map(row => JSON.stringify(row)).join('\n'))
+  }
+  const context = (model: string, timestamp = '2026-09-11T01:00:01Z') => ({ type: 'turn_context', timestamp, payload: { model } })
+  it('finds a resumed thread in an older directory without borrowing its previous model', async () => {
+    rollout('wanted', [{ type: 'session_meta', payload: { id: 'wanted', model_provider: 'native-provider' } }, context('old', '2026-09-10T01:00:01Z'), context('actual')])
+    rollout('another', [{ type: 'session_meta', payload: { id: 'another' } }, context('wrong')])
+    expect(await readCodexTurnModel(root, 'wanted', startedAt)).toEqual({ model: 'actual', provider: 'native-provider' })
+  })
+  it('does not attribute failed-before-start turns to a previous model', async () => {
+    rollout('wanted', [{ type: 'session_meta', payload: { id: 'wanted' } }, context('old', '2026-09-10T01:00:01Z')])
+    expect(await readCodexTurnModel(root, 'wanted', startedAt)).toBeUndefined()
+    expect(await readCodexTurnModel(root, '../wanted', startedAt)).toBeUndefined()
+    expect(await readCodexTurnModel(root, 'missing', startedAt)).toBeUndefined()
+  })
+  it('rejects a mismatched header and ambiguous multi-model turn', async () => {
+    rollout('wanted', [{ type: 'session_meta', payload: { id: 'another' } }, context('wrong')])
+    expect(await readCodexTurnModel(root, 'wanted', startedAt)).toBeUndefined()
+    rollout('wanted', [{ type: 'session_meta', payload: { id: 'wanted' } }, context('first'), context('second')])
+    expect(await readCodexTurnModel(root, 'wanted', startedAt)).toBeUndefined()
+  })
+  it('does not read an OpenCode user message or a different native session', () => {
+    const file = join(root, 'opencode.db')
+    const db = new DatabaseSync(file)
+    db.exec('CREATE TABLE message (id TEXT, session_id TEXT, data TEXT)')
+    db.prepare('INSERT INTO message VALUES (?, ?, ?)').run('id', 'session', JSON.stringify({ role: 'user', modelID: 'selection-only' }))
+    db.close()
+    expect(readOpenCodeMessageModel(file, 'session', 'id')).toBeUndefined()
+    expect(readOpenCodeMessageModel(file, 'other', 'id')).toBeUndefined()
+    expect(readOpenCodeMessageModel(join(root, 'missing'), 'session', 'id')).toBeUndefined()
+  })
+})
+
+describe('native usage normalization', () => {
+  it('separates all Codex input buckets and preserves native reasoning output', () => {
+    const tracker = new NativeTurnUsage()
+    expect(tracker.rows('codex', { input_tokens: 100, cached_input_tokens: 40, cache_write_input_tokens: 10, output_tokens: 20, reasoning_output_tokens: 15 })[0].usage).toMatchObject({
+      inputTokens: 50, cacheReadTokens: 40, cacheWriteTokens: 10, outputTokens: 20, reasoningTokens: 15,
+    })
+  })
+  it('does not invent usage for an authentication error', () => {
+    expect(new NativeTurnUsage().rows('codex', undefined)).toEqual([])
+    expect(new NativeTurnUsage().rows('grok', undefined)).toEqual([])
+  })
+  it('does not replace Claude authoritative usage with a larger auxiliary-work summary', () => {
+    const tracker = new NativeTurnUsage()
+    tracker.observeClaude({ type: 'result', usage: { input_tokens: 10, output_tokens: 2 }, modelUsage: { actual: { inputTokens: 500, outputTokens: 20 } } })
+    const rows = tracker.rows('claude-code', undefined)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({ model: 'actual', usage: { inputTokens: 10, outputTokens: 2 } })
+  })
+  it('retains completed Claude calls on a later API failure', () => {
+    const tracker = new NativeTurnUsage()
+    tracker.observeClaude({ type: 'assistant', message: { id: 'message', model: 'actual', usage: { input_tokens: 10, output_tokens: 2 } } })
+    tracker.observeClaude({ type: 'assistant', isApiErrorMessage: true, message: { id: 'error', model: '<synthetic>', usage: { input_tokens: 0, output_tokens: 0 } } })
+    expect(tracker.rows('claude-code', undefined)).toMatchObject([{ model: 'actual', usage: { inputTokens: 10, outputTokens: 2 } }])
+  })
+  it('uses Grok final error aggregate instead of adding preceding response counters', () => {
+    const tracker = new NativeTurnUsage()
+    tracker.observeGrok({ type: 'usage', usage: { input_tokens: 10, output_tokens: 2 } })
+    tracker.observeGrok({ type: 'error', usage: { input_tokens: 30, output_tokens: 5 }, modelUsage: { actual: { inputTokens: 30, outputTokens: 5, modelCalls: 2 } } })
+    expect(tracker.rows('grok', { input_tokens: 10, output_tokens: 2 })).toMatchObject([{ model: 'actual', apiCalls: 2, usage: { inputTokens: 30, outputTokens: 5 } }])
+  })
+})


### PR DESCRIPTION
## Summary

Global coding-agent runs recorded empty model names, and Pi did not persist native message usage. This change records native usage with model attribution while preserving scoped proxy accounting.

- Codex reads model metadata from the exact native thread and current turn, separates cached input, preserves reasoning/cache-write tokens, and drains stdout before settling global runs.
- Pi persists each completed assistant message immediately, with duplicate protection across delivery, settlement, and later turns.
- Claude reconciles per-message counters against the authoritative turn total; Grok retains `modelUsage` and explicit call counts. Failed Grok turns retain completed response usage.
- OpenCode resolves each completed step's model through its native assistant message. Context occupancy includes cached input after accounting separates the token buckets.

Missing or inconsistent model metadata remains unknown rather than being guessed from another session or current defaults. Existing historical usage is not rewritten. OpenCode was verified with its installed SDK types and a native database fixture; the other four adapters also use sanitized events captured from successful local CLI runs.

## Validation

- Focused server regression suites: 155 passed.
- `npm run test:e2e -- --workers=4`: 181 passed.
- `npm run build` and `npm run harness:check`: passed.
- `npm run test:coverage -- --maxWorkers=4`: 5,327 passed, 6 skipped, 44 failed. All 44 failures reproduce unchanged on main at `8b703279`; the failure-name sets match exactly, with no additional failures.
