### PR TITLE
fix: persist coding agent installations across Docker recreation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,9 @@ ENV NODE_ENV=production
 ENV HOME=/home/agent
 ENV HERMES_HOME=/home/agent/.hermes
 ENV HERMES_WEB_UI_MANAGED_GATEWAY=1
-ENV PATH=/opt/hermes/.venv/bin:$PATH
+# Keep runtime-installed coding agent CLIs in the existing Studio data volume.
+ENV NPM_CONFIG_PREFIX=/home/agent/.hermes-web-ui/coding-agent/npm
+ENV PATH=/home/agent/.hermes-web-ui/coding-agent/npm/bin:/opt/hermes/.venv/bin:$PATH
 
 EXPOSE 6060
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,8 @@ services:
       - HERMES_LAN_ADVERTISE_URL=${HERMES_LAN_ADVERTISE_URL:-}
       - HERMES_APP_ENTITLEMENT_REQUIRED=${HERMES_APP_ENTITLEMENT_REQUIRED:-true}
       - HERMES_APP_ENTITLEMENT_PUBLIC_KEY=${HERMES_APP_ENTITLEMENT_PUBLIC_KEY:-}
-      - PATH=/opt/hermes/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - NPM_CONFIG_PREFIX=/home/agent/.hermes-web-ui/coding-agent/npm
+      - PATH=/home/agent/.hermes-web-ui/coding-agent/npm/bin:/opt/hermes/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
       - HERMES_ALLOW_ROOT_GATEWAY=1
     restart: unless-stopped
     stdin_open: true

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -70,6 +70,29 @@ PORT=6060
 - The auth token is auto-generated on first run and printed to container logs.
 - Deleting the token file and restarting will generate a new one.
 
+### Coding agent installations
+
+Coding agents installed from Studio (Claude Code, Codex, Pi, OpenCode, and Grok)
+use npm's global prefix at `/home/agent/.hermes-web-ui/coding-agent/npm`.
+The image and Compose put its `bin` directory on `PATH`. With the default
+mounts, packages and executable links are saved under
+`${HERMES_DATA_DIR}/hermes-web-ui/coding-agent/npm` and remain available after
+container recreation or image updates. Studio's Pi MCP adapter and scoped
+agent configurations also use the existing Studio data volume.
+
+Older images installed these CLIs outside the data volume. After upgrading,
+reinstall affected agents once from Studio to place them in the persistent
+directory. Packages already lost when an old container was removed cannot be
+recovered from the new image. A restart of the same container normally retains
+its writable filesystem; recreation replaces it.
+
+For custom deployments, persist `/home/agent/.hermes-web-ui`, or set
+`NPM_CONFIG_PREFIX` to a directory inside your own persistent mount and include
+`$NPM_CONFIG_PREFIX/bin` on `PATH`. Do not mount over `/usr/local`, which also
+contains the image's Node.js runtime. Native CLI login/configuration directories
+under `/home/agent` are separate from the npm installation; mount those as well
+if you use native global logins and need to retain them across recreation.
+
 ## Port Mapping
 
 | Port | Description |

--- a/tests/docker-agent-persistence.test.ts
+++ b/tests/docker-agent-persistence.test.ts
@@ -1,0 +1,83 @@
+import { execFile } from 'node:child_process'
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, posix } from 'node:path'
+import { promisify } from 'node:util'
+import { parse } from 'yaml'
+import { describe, expect, it } from 'vitest'
+
+const execFileAsync = promisify(execFile)
+
+async function dockerConfiguration() {
+  const dockerfile = await readFile('Dockerfile', 'utf8')
+  const compose = parse(await readFile('docker-compose.yml', 'utf8'))
+  const service = compose.services['hermes-webui']
+  const env = Object.fromEntries(service.environment.map((entry: string) => {
+    const separator = entry.indexOf('=')
+    return [entry.slice(0, separator), entry.slice(separator + 1)]
+  }))
+  return { dockerfile, service, env }
+}
+
+describe('Docker coding agent persistence', () => {
+  it('keeps global npm packages and executable discovery inside the Studio data mount', async () => {
+    const { dockerfile, service, env } = await dockerConfiguration()
+    const imagePrefix = dockerfile.match(/^ENV NPM_CONFIG_PREFIX=(.+)$/m)?.[1]
+    const imagePath = dockerfile.match(/^ENV PATH=(.+)$/m)?.[1]
+    expect(imagePrefix).toBe(env.NPM_CONFIG_PREFIX)
+    const mount = service.volumes.find((volume: string) => volume.endsWith(':/home/agent/.hermes-web-ui'))
+    expect(mount).toBeTruthy()
+    const relativePrefix = posix.relative('/home/agent/.hermes-web-ui', env.NPM_CONFIG_PREFIX)
+    expect(relativePrefix).not.toMatch(/^\.\.(\/|$)/)
+    expect(posix.isAbsolute(relativePrefix)).toBe(false)
+    const bin = `${env.NPM_CONFIG_PREFIX}/bin`
+    expect(imagePath?.split(':')[0]).toBe(bin)
+    expect(env.PATH.split(':')[0]).toBe(bin)
+    expect(env.PATH.split(':')).toContain('/usr/local/bin')
+  })
+
+  it.skipIf(process.platform === 'win32')('can run and uninstall a global CLI from a fresh process after its original container files are removed', async () => {
+    const { env: dockerEnv } = await dockerConfiguration()
+    const root = await mkdtemp(join(tmpdir(), 'studio-docker-npm-'))
+    try {
+      const volume = join(root, 'volume')
+      const oldContainer = join(root, 'old-container')
+      const newContainer = join(root, 'new-container')
+      const prefix = join(volume, posix.relative('/home/agent/.hermes-web-ui', dockerEnv.NPM_CONFIG_PREFIX))
+      await mkdir(oldContainer)
+      await mkdir(newContainer)
+      await writeFile(join(oldContainer, 'package.json'), JSON.stringify({
+        name: 'studio-persistence-fixture', version: '1.0.0', bin: { 'studio-persistence-fixture': 'cli.js' },
+      }))
+      await writeFile(join(oldContainer, 'cli.js'), '#!/usr/bin/env node\nconsole.log("persistent-cli-1.0.0")\n', { mode: 0o755 })
+      await writeFile(join(root, 'npmrc'), '')
+      await writeFile(join(root, 'global-npmrc'), '')
+      const env: NodeJS.ProcessEnv = Object.fromEntries(
+        Object.entries(process.env).filter(([key]) => !key.toLowerCase().startsWith('npm_config_')),
+      )
+      Object.assign(env, {
+        NPM_CONFIG_PREFIX: prefix,
+        NPM_CONFIG_CACHE: join(root, 'npm-cache'),
+        NPM_CONFIG_USERCONFIG: join(root, 'npmrc'),
+        NPM_CONFIG_GLOBALCONFIG: join(root, 'global-npmrc'),
+        NPM_CONFIG_OFFLINE: 'true',
+        NPM_CONFIG_AUDIT: 'false',
+        NPM_CONFIG_FUND: 'false',
+        PATH: `${prefix}/bin:${process.env.PATH}`,
+      })
+      const options = { env, cwd: oldContainer, timeout: 20_000 }
+      await execFileAsync('npm', ['pack', '--ignore-scripts'], options)
+      await execFileAsync('npm', ['install', '-g', join(oldContainer, 'studio-persistence-fixture-1.0.0.tgz'), '--ignore-scripts'], options)
+      await rm(oldContainer, { recursive: true })
+      const freshProcess = { env, cwd: newContainer, timeout: 20_000 }
+      const result = await execFileAsync('studio-persistence-fixture', [], freshProcess)
+      expect(result.stdout.trim()).toBe('persistent-cli-1.0.0')
+      const npmPrefix = await execFileAsync('npm', ['prefix', '-g'], freshProcess)
+      expect(npmPrefix.stdout.trim()).toBe(prefix)
+      await execFileAsync('npm', ['uninstall', '-g', 'studio-persistence-fixture'], freshProcess)
+      await expect(execFileAsync('studio-persistence-fixture', [], freshProcess)).rejects.toMatchObject({ code: 'ENOENT' })
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  }, 60_000)
+})


### PR DESCRIPTION
## Summary

Coding agents installed through Studio use `npm install -g`. The Docker image previously left npm’s global prefix outside the mounted data directories, so recreating or updating a container discarded those installations.

- Set the Docker image and Compose npm prefix to `/home/agent/.hermes-web-ui/coding-agent/npm`, inside the existing Studio data mount, and prepend its executable directory to both PATH definitions.
- Document persistent storage, custom mounts, and the one-time reinstall needed for installations from older images.
- Add an offline npm regression test that installs a packaged CLI, deletes the original container fixture files, then verifies discovery, execution, and uninstall from a fresh process using the retained volume.

This fixes installation loss on container recreation. A plain restart of the same container should retain its writable filesystem; the exact operation in the user report has not yet been confirmed. Native global login/configuration directories are separate and still need their own persistent mounts. Previously discarded installations cannot be recovered automatically.

## Validation

- `npm test -- tests/docker-agent-persistence.test.ts tests/docker-startup-wrapper.test.ts`: 4 passed.
- `npm run harness:check`: passed.
- `npm run build`: passed.
- `docker compose config --format json`: passed.
- Actual Docker recreation was not run locally because the Docker daemon is unavailable. The npm installation smoke test uses real npm offline with temporary files. GitHub Actions runs the full unit/coverage and Playwright suites.
