### PR TITLE
fix(media): respect versioned provider base paths

### DIFF
--- a/packages/server/src/modules/studio/controllers/media.ts
+++ b/packages/server/src/modules/studio/controllers/media.ts
@@ -105,7 +105,16 @@ function readJsonFile(path: string): any {
 function buildApiUrl(baseUrl: string, pathWithV1: string): string {
   const base = (baseUrl || 'https://api.apikey.fun/v1').replace(/\/+$/, '')
   const apiPath = pathWithV1.startsWith('/') ? pathWithV1 : `/${pathWithV1}`
-  if (base.endsWith('/v1') && apiPath.startsWith('/v1/')) return `${base}${apiPath.slice(3)}`
+  if (!apiPath.startsWith('/v1/')) return `${base}${apiPath}`
+
+  const providerPath = apiPath.slice(3)
+  if (base.endsWith('/v1')) return `${base}${providerPath}`
+  try {
+    const pathname = new URL(base).pathname.replace(/\/+$/, '')
+    if (pathname) return `${base}${providerPath}`
+  } catch {
+    // Keep the legacy /v1 default for non-standard base URL strings.
+  }
   return `${base}${apiPath}`
 }
 

--- a/packages/server/src/modules/studio/controllers/media.ts
+++ b/packages/server/src/modules/studio/controllers/media.ts
@@ -111,7 +111,8 @@ function buildApiUrl(baseUrl: string, pathWithV1: string): string {
   if (base.endsWith('/v1')) return `${base}${providerPath}`
   try {
     const pathname = new URL(base).pathname.replace(/\/+$/, '')
-    if (pathname) return `${base}${providerPath}`
+    // Match provider catalog API roots; plain proxy prefixes still need /v1.
+    if (/\/(?:v\d+(?:beta)?|openai)$/.test(pathname)) return `${base}${providerPath}`
   } catch {
     // Keep the legacy /v1 default for non-standard base URL strings.
   }

--- a/tests/server/media-controller.test.ts
+++ b/tests/server/media-controller.test.ts
@@ -31,7 +31,18 @@ describe('media controller', () => {
     expect(defaultImageOutputPath('bad/request:id', 1)).toBe(join('/tmp/hermes-web-ui-test-home', 'media', 'bad_request_id-2.png'))
   })
 
-  it('generates images through the requested configured custom provider', async () => {
+  it.each([
+    ['', '/v1'],
+    ['/', '/v1'],
+    ['/v1', '/v1'],
+    ['/proxy/v1/', '/proxy/v1'],
+    ['/api/v3/', '/api/v3'],
+    ['/api/paas/v4', '/api/paas/v4'],
+    ['/v1beta/openai', '/v1beta/openai'],
+    ['/proxy', '/proxy/v1'],
+    ['/proxy/', '/proxy/v1'],
+    ['/proxy/v3/images', '/proxy/v3/images/v1'],
+  ])('generates images with provider base path "%s" using API root "%s"', async (basePath, apiRoot) => {
     vi.stubEnv('AGNES_API_KEY', 'agnes-secret')
     vi.doMock('../../packages/server/src/modules/studio/public/profile-config', () => ({
       getActiveProfileName: () => 'default',
@@ -42,7 +53,7 @@ describe('media controller', () => {
       readConfigYamlForProfile: vi.fn(async () => ({
         custom_providers: [{
           name: 'agnes',
-          base_url: 'https://agnes.example',
+          base_url: `https://agnes.example${basePath}`,
           api_key_env: 'AGNES_API_KEY',
           model: 'agnes-image-2.1-flash',
         }],
@@ -79,11 +90,11 @@ describe('media controller', () => {
         ok: true,
         mode: 'text',
         provider: 'agnes',
-        base_url: 'https://agnes.example',
+        base_url: `https://agnes.example${basePath}`,
         profile: 'default',
       })
       expect(fetchMock).toHaveBeenCalledWith(
-        'https://agnes.example/v1/images/generations',
+        `https://agnes.example${apiRoot}/images/generations`,
         expect.objectContaining({
           method: 'POST',
           headers: expect.objectContaining({
@@ -155,7 +166,10 @@ describe('media controller', () => {
     }
   })
 
-  it('routes Studio image-to-image and multipart edits through their configured tasks', async () => {
+  it.each([
+    ['/api/v3', '/api/paas/v4', '/api/v3', '/api/paas/v4'],
+    ['/proxy/', '/proxy/', '/proxy/v1', '/proxy/v1'],
+  ])('routes image-to-image and multipart edits through bases "%s" and "%s"', async (generationBase, editBase, generationRoot, editRoot) => {
     vi.stubEnv('GENERATION_IMG_KEY', 'generation-secret')
     vi.stubEnv('EDIT_IMG_KEY', 'edit-secret')
     vi.doMock('../../packages/server/src/modules/studio/public/profile-config', () => ({
@@ -168,12 +182,12 @@ describe('media controller', () => {
         custom_providers: [
           {
             name: 'Generation Images',
-            base_url: 'https://generation.example/api/v3',
+            base_url: `https://generation.example${generationBase}`,
             api_key_env: 'GENERATION_IMG_KEY',
           },
           {
             name: 'Edit Images',
-            base_url: 'https://edit.example/api/paas/v4',
+            base_url: `https://edit.example${editBase}`,
             api_key_env: 'EDIT_IMG_KEY',
           },
         ],
@@ -221,7 +235,7 @@ describe('media controller', () => {
 
       expect(ctx.status).toBe(200)
       expect(ctx.body).toMatchObject({ ok: true, provider: 'Edit Images', mode: 'image' })
-      expect(String(fetchMock.mock.calls[0][0])).toBe('https://edit.example/api/paas/v4/responses')
+      expect(String(fetchMock.mock.calls[0][0])).toBe(`https://edit.example${editRoot}/responses`)
       expect(fetchMock.mock.calls[0][1]).toMatchObject({
         headers: expect.objectContaining({ Authorization: 'Bearer edit-secret' }),
       })
@@ -252,7 +266,7 @@ describe('media controller', () => {
 
       expect(editCtx.status).toBe(200)
       expect(editCtx.body).toMatchObject({ ok: true, provider: 'Generation Images', mode: 'edit' })
-      expect(String(fetchMock.mock.calls[1][0])).toBe('https://generation.example/api/v3/images/edits')
+      expect(String(fetchMock.mock.calls[1][0])).toBe(`https://generation.example${generationRoot}/images/edits`)
       expect(fetchMock.mock.calls[1][1]).toMatchObject({
         headers: expect.objectContaining({ Authorization: 'Bearer generation-secret' }),
       })

--- a/tests/server/media-controller.test.ts
+++ b/tests/server/media-controller.test.ts
@@ -42,7 +42,7 @@ describe('media controller', () => {
       readConfigYamlForProfile: vi.fn(async () => ({
         custom_providers: [{
           name: 'agnes',
-          base_url: 'https://agnes.example/v1',
+          base_url: 'https://agnes.example',
           api_key_env: 'AGNES_API_KEY',
           model: 'agnes-image-2.1-flash',
         }],
@@ -79,7 +79,7 @@ describe('media controller', () => {
         ok: true,
         mode: 'text',
         provider: 'agnes',
-        base_url: 'https://agnes.example/v1',
+        base_url: 'https://agnes.example',
         profile: 'default',
       })
       expect(fetchMock).toHaveBeenCalledWith(
@@ -113,7 +113,7 @@ describe('media controller', () => {
       readConfigYamlForProfile: vi.fn(async () => ({
         custom_providers: [{
           name: 'Studio Images',
-          base_url: 'https://images.example/v1',
+          base_url: 'https://images.example/api/v3',
           api_key_env: 'STUDIO_IMG_KEY',
         }],
         auxiliary: {
@@ -145,7 +145,7 @@ describe('media controller', () => {
 
       expect(ctx.status).toBe(200)
       expect(ctx.body).toMatchObject({ ok: true, provider: 'Studio Images' })
-      expect(String(fetchMock.mock.calls[0][0])).toBe('https://images.example/v1/images/generations')
+      expect(String(fetchMock.mock.calls[0][0])).toBe('https://images.example/api/v3/images/generations')
       expect(JSON.parse(String((fetchMock.mock.calls[0][1] as RequestInit).body)))
         .toMatchObject({ model: 'seedream-4' })
       expect(timeoutSpy).toHaveBeenCalledWith(42_000)
@@ -168,12 +168,12 @@ describe('media controller', () => {
         custom_providers: [
           {
             name: 'Generation Images',
-            base_url: 'https://generation.example/v1',
+            base_url: 'https://generation.example/api/v3',
             api_key_env: 'GENERATION_IMG_KEY',
           },
           {
             name: 'Edit Images',
-            base_url: 'https://edit.example/v1',
+            base_url: 'https://edit.example/api/paas/v4',
             api_key_env: 'EDIT_IMG_KEY',
           },
         ],
@@ -221,7 +221,7 @@ describe('media controller', () => {
 
       expect(ctx.status).toBe(200)
       expect(ctx.body).toMatchObject({ ok: true, provider: 'Edit Images', mode: 'image' })
-      expect(String(fetchMock.mock.calls[0][0])).toBe('https://edit.example/v1/responses')
+      expect(String(fetchMock.mock.calls[0][0])).toBe('https://edit.example/api/paas/v4/responses')
       expect(fetchMock.mock.calls[0][1]).toMatchObject({
         headers: expect.objectContaining({ Authorization: 'Bearer edit-secret' }),
       })
@@ -252,7 +252,7 @@ describe('media controller', () => {
 
       expect(editCtx.status).toBe(200)
       expect(editCtx.body).toMatchObject({ ok: true, provider: 'Generation Images', mode: 'edit' })
-      expect(String(fetchMock.mock.calls[1][0])).toBe('https://generation.example/v1/images/edits')
+      expect(String(fetchMock.mock.calls[1][0])).toBe('https://generation.example/api/v3/images/edits')
       expect(fetchMock.mock.calls[1][1]).toMatchObject({
         headers: expect.objectContaining({ Authorization: 'Bearer generation-secret' }),
       })


### PR DESCRIPTION
## Summary
- Preserve `/v1` for host-only custom provider base URLs and avoid duplicating it when the base already ends in `/v1`.
- Treat a custom provider base URL ending in a version segment (for example `/api/v3` or `/api/paas/v4`) or `/openai` as the API root, so image generation, Responses image-to-image, and multipart image edits append only their endpoint path.
- Extend media controller coverage across host-only, versioned, `/openai`, and plain proxy-prefixed provider bases, including trailing slashes.

Fixes #2993

## Root cause
`buildApiUrl()` removed the endpoint's `/v1` prefix only when the configured base ended exactly in `/v1`. Any other versioned API root received an extra `/v1`, producing URLs such as `/api/v3/v1/images/generations`.

## Approach and tradeoffs
The URL joiner now inspects the final segment of the configured base pathname, using the same API-root recognition as the provider catalog endpoint. Bases ending in `/v1`, `/v3`, `/v4`, other integer versions (including `beta`), or `/openai` append `/images/generations`, `/responses`, or `/images/edits` directly. Host-only bases and ordinary reverse-proxy prefixes retain the legacy `/v1/...` behavior: `/proxy` still targets `/proxy/v1/images/generations`. Invalid/non-standard base strings retain the legacy fallback.

This PR intentionally does not add a first-class Volcengine provider or provider-specific endpoint overrides; it fixes the generic custom-provider URL behavior described by the bug.

## Validation
- `npm run test -- tests/server/media-controller.test.ts` — passed, 21 tests after the proxy compatibility fix. Four proxy-path regression cases failed against the preceding PR revision and passed after narrowing the path check.
- Regression proof before the fix: the updated media tests failed with `/api/v3/v1/images/generations` and `/api/paas/v4/v1/responses`; the same tests pass after the fix.
- `npm run harness:check` — passed.
- `npm run build` — passed.
- Original submission, before the proxy compatibility follow-up: `npm run test:e2e` — full run reached 150 passed, 4 failed, 27 not run; all four failed tests passed together on the one allowed focused rerun with `--workers=1`, indicating unrelated concurrency flakes.
- Original submission, before the proxy compatibility follow-up: `npm run test:coverage` — 646 files passed, 2 skipped, 1 failed. The failure is the unrelated `tests/client/use-speech-tts.test.ts` cross-realm `Blob instanceof Blob` assertion; it reproduces unchanged on clean `origin/main`.

## Risk / compatibility
- Low scope: one server-side URL join helper used by the three Studio image request modes.
- Existing host-only, `/v1`, and ordinary reverse-proxy prefix behavior remains covered.
- No auth, credential, persistence, migration, or file-access behavior changes.

## AI disclosure
This change and PR description were prepared with AI assistance and reviewed against the repository's existing contribution and validation guidance.

