### PR TITLE
feat: add DSH installation, settings, skills and MCP management

### DIFF
--- a/docs/dsh-management.md
+++ b/docs/dsh-management.md
@@ -1,0 +1,22 @@
+# DeepSeek Harness management
+
+Open **Agent Manager → DeepSeek Harness** to install `@deepseek-ai/dsh`, detect an existing `dsh` CLI, check for updates, or uninstall the CLI. Installation uses the official npm registry and the same global package management path as other Coding Agents. Update checks include prerelease ordering, such as `rc.1` to `rc.2`.
+
+The Settings button opens the shared Coding Agent configuration pages:
+
+| Page | Native files |
+| --- | --- |
+| Settings → Preference | `~/.dsh/AGENTS.md` |
+| Settings → Configuration | `~/.dsh/settings.yaml` |
+| MCP | `~/.dsh/cordis.patch.yml` |
+| Skills | `~/.dsh/skills`, followed by shared `~/.agents/skills` |
+
+These are global CLI files, independent of the active Hermes profile. As with the other Coding Agents, `HERMES_CODING_AGENT_GLOBAL_HOME` can override the home used by Studio. A separately configured DSH instance using a custom `DSH_HOME` is outside this management scope.
+
+Settings require a YAML mapping. MCP changes use Cordis plugin patches with `@deepseek-ai/dsh-mcp-client`, preserving unrelated plugins, comments, tags and anchors. Studio accepts stdio and Streamable HTTP connections. It preserves DSH `!!js` expressions as data and refuses to connection-test an MCP whose configuration depends on those expressions. Studio-managed MCP overrides remain in Studio state; they are not inserted into the user's native patch file.
+
+Skills support direct `<name>/SKILL.md` bundles and flat `<name>.md` files. Files must have YAML frontmatter containing a kebab-case `name` and a `description`. Imports accept a skill folder or ZIP and go directly into `.dsh/skills`, without Hermes category directories. The editor can read, edit and delete native skills, including flat files. Nested category directories are not scanned. Invocation flags can be edited in frontmatter; the Hermes enable switch is hidden for DSH.
+
+This phase adds management only. DSH is not yet a Studio chat agent: ACP session creation, model injection, runtime home isolation and shutdown ownership are follow-up work. The management pages do not start a long-running DSH service or stop an independently running DSH instance.
+
+Native format reference: [DeepSeek Harness source, dsh-v0.1.5-rc.1](https://github.com/deepseek-ai/deepseek-harness/tree/dsh-v0.1.5-rc.1).

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,13 +31,14 @@
         "sherpa-onnx-node": "1.13.3",
         "smol-toml": "^1.8.0",
         "socket.io": "^4.8.3",
-        "socket.io-client": "^4.8.3"
+        "socket.io-client": "^4.8.3",
+        "yaml": "^2.9.0"
       },
       "bin": {
+        "ekko-studio-mcp": "bin/ekko-studio-mcp.mjs",
         "hermes-studio-mcp": "bin/hermes-studio-mcp.mjs",
         "hermes-web-ui": "bin/hermes-web-ui.mjs",
-        "hermes-web-ui-mcp": "bin/hermes-web-ui-mcp.mjs",
-        "ekko-studio-mcp": "bin/ekko-studio-mcp.mjs"
+        "hermes-web-ui-mcp": "bin/hermes-web-ui-mcp.mjs"
       },
       "devDependencies": {
         "@aiden0z/pptx-renderer": "^1.2.4",
@@ -12880,7 +12881,6 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -101,7 +101,8 @@
     "sherpa-onnx-node": "1.13.3",
     "smol-toml": "^1.8.0",
     "socket.io": "^4.8.3",
-    "socket.io-client": "^4.8.3"
+    "socket.io-client": "^4.8.3",
+    "yaml": "^2.9.0"
   },
   "optionalDependencies": {
     "sherpa-onnx-darwin-arm64": "1.13.3",

--- a/packages/client/public/coding-agents/dsh.svg
+++ b/packages/client/public/coding-agents/dsh.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><rect width="64" height="64" rx="16" fill="#4d6bfe"/><text x="32" y="39" text-anchor="middle" font-family="Arial,sans-serif" font-size="23" font-weight="700" fill="white">dsh</text></svg>

--- a/packages/client/src/api/agent-status.ts
+++ b/packages/client/src/api/agent-status.ts
@@ -1,6 +1,6 @@
 import { request } from './client'
 
-export type AgentStatusId = 'hermes' | 'ekko-agent' | 'claude-code' | 'codex' | 'pi' | 'grok' | 'opencode'
+export type AgentStatusId = 'hermes' | 'ekko-agent' | 'claude-code' | 'codex' | 'pi' | 'grok' | 'opencode' | 'dsh'
 export type AgentStatusSource = 'managed-runtime' | 'user-cli' | 'built-in' | 'not-installed'
 
 export interface AgentStatusRecord {
@@ -42,6 +42,7 @@ const AGENT_STATUS_ALIASES: Record<string, AgentStatusId> = {
   pi: 'pi',
   grok: 'grok',
   opencode: 'opencode',
+  dsh: 'dsh',
 }
 
 export function resolveAgentStatusId(agent: string): AgentStatusId | null {

--- a/packages/client/src/api/coding-agents.ts
+++ b/packages/client/src/api/coding-agents.ts
@@ -1,8 +1,8 @@
 import { request } from './client'
 import type { ProviderApiMode } from './studio/provider-api-mode'
 
-export type CodingAgentId = 'claude-code' | 'codex' | 'pi' | 'grok' | 'opencode'
-export type ChatCodingAgentId = CodingAgentId | 'ekko-agent'
+export type CodingAgentId = 'claude-code' | 'codex' | 'pi' | 'grok' | 'opencode' | 'dsh'
+export type ChatCodingAgentId = Exclude<CodingAgentId, 'dsh'> | 'ekko-agent'
 export const CODING_AGENT_API_MODES = [
   'chat_completions',
   'codex_responses',

--- a/packages/client/src/api/hermes/skills.ts
+++ b/packages/client/src/api/hermes/skills.ts
@@ -1,7 +1,7 @@
 import { request, getBaseUrlValue, getApiKey, getActiveProfileName } from '../client'
 
 export type SkillSource = 'builtin' | 'hub' | 'local' | 'external'
-export type SkillTarget = 'hermes' | 'claude' | 'codex' | 'pi' | 'grok' | 'opencode'
+export type SkillTarget = 'hermes' | 'claude' | 'codex' | 'pi' | 'grok' | 'opencode' | 'dsh'
 
 export interface SkillInfo {
   name: string
@@ -188,10 +188,10 @@ export async function saveExternalDirs(dirs: string[]): Promise<void> {
   })
 }
 
-export async function deleteSkillApi(category: string, name: string): Promise<void> {
+export async function deleteSkillApi(category: string, name: string, target: SkillTarget = 'hermes'): Promise<void> {
   const c = encodeURIComponent(category)
   const n = encodeURIComponent(name)
-  await request(`/api/hermes/skills/${c}/${n}`, { method: 'DELETE' })
+  await request(`/api/hermes/skills/${c}/${n}${targetQuery(target)}`, { method: 'DELETE' })
 }
 
 /**
@@ -200,7 +200,7 @@ export async function deleteSkillApi(category: string, name: string): Promise<vo
  * starts with the skill folder name; we forward those paths verbatim as the
  * `filename` parameter so the server can reconstruct the directory tree.
  */
-export async function importSkill(files: File[], category?: string): Promise<{ name: string }> {
+export async function importSkill(files: File[], category?: string, target: SkillTarget = 'hermes'): Promise<{ name: string }> {
   const baseUrl = getBaseUrlValue()
   const token = getApiKey()
   const headers: Record<string, string> = {}
@@ -215,7 +215,7 @@ export async function importSkill(files: File[], category?: string): Promise<{ n
   }
   if (category) formData.append('category', category)
 
-  const res = await fetch(`${baseUrl}/api/hermes/skills/import`, {
+  const res = await fetch(`${baseUrl}/api/hermes/skills/import${targetQuery(target)}`, {
     method: 'POST',
     headers,
     body: formData,

--- a/packages/client/src/components/hermes/skills/SkillImportModal.vue
+++ b/packages/client/src/components/hermes/skills/SkillImportModal.vue
@@ -6,6 +6,7 @@ import { importSkill } from '@/api/hermes/skills'
 import { useI18n } from 'vue-i18n'
 
 const props = defineProps<{
+  allowCategory?: boolean
   importHandler?: (files: File[], category?: string) => Promise<{ name?: string }>
 }>()
 
@@ -117,7 +118,7 @@ function handleClose() {
       <p class="hint">{{ mode === 'zip' ? t('skills.importHintZip') : t('skills.importHintFolder') }}</p>
     </div>
 
-    <div class="form-row">
+    <div v-if="allowCategory !== false" class="form-row">
       <label class="field-label">{{ t('skills.importTargetCategory') }}</label>
       <NInput
         v-model:value="category"

--- a/packages/client/src/views/hermes/AgentManagerView.vue
+++ b/packages/client/src/views/hermes/AgentManagerView.vue
@@ -85,6 +85,7 @@ const codingAgents: CodingAgentCard[] = [
     command: 'opencode',
     packageName: 'opencode-ai',
   },
+  { id: 'dsh', name: 'DeepSeek Harness', provider: 'DeepSeek', logo: '/coding-agents/dsh.svg', command: 'dsh', packageName: '@deepseek-ai/dsh' },
 ]
 
 const updatePolicies = ref<Record<string, AgentUpdatePolicyState>>({})
@@ -121,15 +122,16 @@ const hermesRuntimeStatus = ref<RuntimeVersionStatus | null>(null)
 const aiHelpDrawerVisible = ref(false)
 const aiHelpPrompt = ref('')
 const legacyDataMigrationChecked = ref(false)
-const installing = ref<Record<CodingAgentId, boolean>>({ 'claude-code': false, codex: false, pi: false, grok: false, opencode: false })
-const deleting = ref<Record<CodingAgentId, boolean>>({ 'claude-code': false, codex: false, pi: false, grok: false, opencode: false })
-const checkingUpdate = ref<Record<CodingAgentId, boolean>>({ 'claude-code': false, codex: false, pi: false, grok: false, opencode: false })
+const installing = ref<Record<CodingAgentId, boolean>>({ 'claude-code': false, codex: false, pi: false, grok: false, opencode: false, dsh: false })
+const deleting = ref<Record<CodingAgentId, boolean>>({ 'claude-code': false, codex: false, pi: false, grok: false, opencode: false, dsh: false })
+const checkingUpdate = ref<Record<CodingAgentId, boolean>>({ 'claude-code': false, codex: false, pi: false, grok: false, opencode: false, dsh: false })
 const updateInfo = ref<Record<CodingAgentId, CodingAgentUpdateResult | null>>({
   'claude-code': null,
   codex: null,
   pi: null,
   grok: null,
   opencode: null,
+  dsh: null,
 })
 
 const hermesStatus = computed(() => agentStatusSnapshot.value?.agents.find(agent => agent.id === 'hermes'))

--- a/packages/client/src/views/hermes/CodingAgentConfigView.vue
+++ b/packages/client/src/views/hermes/CodingAgentConfigView.vue
@@ -35,6 +35,7 @@ const settingsKeys: Record<CodingAgentId, Record<SettingsEditor, string>> = {
   pi: { preference: 'agents', configuration: 'settings' },
   grok: { preference: 'agents', configuration: 'settings' },
   opencode: { preference: 'memory', configuration: 'settings' },
+  dsh: { preference: 'memory', configuration: 'settings' },
 }
 
 const skillTargets: Record<CodingAgentId, SkillTarget> = {
@@ -43,6 +44,7 @@ const skillTargets: Record<CodingAgentId, SkillTarget> = {
   pi: 'pi',
   grok: 'grok',
   opencode: 'opencode',
+  dsh: 'dsh',
 }
 
 const editorKinds: SettingsEditor[] = ['preference', 'configuration']

--- a/packages/client/src/views/hermes/SkillsView.vue
+++ b/packages/client/src/views/hermes/SkillsView.vue
@@ -8,7 +8,7 @@ import SkillImportModal from '@/components/hermes/skills/SkillImportModal.vue'
 import SkillExternalDirsModal from '@/components/hermes/skills/SkillExternalDirsModal.vue'
 import SkillSourceLegend from '@/components/hermes/skills/SkillSourceLegend.vue'
 import PendingWriteApprovals from '@/components/hermes/skills/PendingWriteApprovals.vue'
-import { fetchSkills, type SkillCategory, type SkillSource, type SkillInfo, type SkillTarget } from '@/api/hermes/skills'
+import { deleteSkillApi, importSkill, fetchSkills, type SkillCategory, type SkillSource, type SkillInfo, type SkillTarget } from '@/api/hermes/skills'
 import { fetchPendingWrites } from '@/api/hermes/write-gate'
 import { useProfilesStore } from '@/stores/hermes/profiles'
 
@@ -96,6 +96,7 @@ async function loadSkills() {
 }
 
 async function loadPendingWriteCount() {
+  if (!isHermesTarget.value) return
   try {
     const data = await fetchPendingWrites()
     writeApprovalSupported.value = data.supported !== false
@@ -193,7 +194,7 @@ function handleSkillSaved() {
           </span>
         </NButton>
         <NButton
-          v-if="isHermesTarget"
+          v-if="isHermesTarget || skillTarget === 'dsh'"
           class="header-action-btn"
           size="small"
           :title="t('skills.import')"
@@ -234,7 +235,13 @@ function handleSkillSaved() {
       </div>
     </header>
 
-    <SkillImportModal v-if="showImportModal" @close="showImportModal = false" @saved="handleImported" />
+    <SkillImportModal
+      v-if="showImportModal"
+      :allow-category="skillTarget !== 'dsh'"
+      :import-handler="skillTarget === 'dsh' ? (files) => importSkill(files, undefined, 'dsh') : undefined"
+      @close="showImportModal = false"
+      @saved="handleImported"
+    />
     <SkillExternalDirsModal v-if="showExternalDirsModal"
       @close="showExternalDirsModal = false" @saved="handleExternalDirsSaved" />
     <NDrawer
@@ -262,7 +269,9 @@ function handleSkillSaved() {
               :selected-skill="selectedCategory && selectedSkill ? `${selectedCategory}/${selectedSkill}` : null"
               :search-query="searchQuery"
               :source-filter="sourceFilter"
-              :readonly="!isHermesTarget"
+              :readonly="!isHermesTarget && skillTarget !== 'dsh'"
+              :toggleable="isHermesTarget"
+              :delete-handler="skillTarget === 'dsh' ? (category, name) => deleteSkillApi(category, name, 'dsh') : undefined"
               @select="handleSelect"
               @deleted="handleSkillDeleted"
             />

--- a/packages/server/src/modules/coding-agents/services/dsh/config.ts
+++ b/packages/server/src/modules/coding-agents/services/dsh/config.ts
@@ -1,0 +1,125 @@
+import { isAlias, isMap, isNode, isScalar, isSeq, parseDocument, visit, type YAMLMap, type YAMLSeq } from 'yaml'
+
+const MCP_PLUGIN = '@deepseek-ai/dsh-mcp-client'
+
+function invalid(message: string): never {
+  throw Object.assign(new Error(message), { status: 400 })
+}
+
+function document(content: string) {
+  // Parse YAML as data only. Preserve DSH's !!js nodes without evaluating them.
+  const doc = parseDocument(content, { logLevel: 'silent' })
+  if (doc.errors.length) invalid(`Invalid DSH YAML: ${doc.errors[0].message}`)
+  return doc
+}
+
+export function validateDshSettings(content: string): void {
+  const doc = document(content)
+  if (doc.contents !== null && !isMap(doc.contents)) invalid('DSH settings must be a YAML mapping')
+}
+
+function patchDocument(content: string) {
+  const doc = document(content.trim() ? content : '[]\n')
+  if (!isSeq(doc.contents)) invalid('DSH cordis.patch.yml must be a YAML sequence')
+  return doc
+}
+
+interface McpRow { row: YAMLMap; parent: YAMLSeq; name: string }
+
+function mcpRows(root: YAMLSeq): McpRow[] {
+  const rows: McpRow[] = []
+  const scan = (parent: YAMLSeq) => {
+    for (const node of parent.items) {
+      if (!isMap(node)) continue
+      if (node.get('name') === MCP_PLUGIN) {
+        const name = node.getIn(['config', 'serverName'])
+        if (typeof name !== 'string' || !name) invalid('DSH MCP entry requires a literal serverName')
+        if (rows.some(row => row.name === name)) invalid(`Duplicate DSH MCP server: ${name}`)
+        rows.push({ row: node, parent, name })
+      }
+      // New plugins in a patch are mounted through insert, not bare rows.
+      const inserted = node.get('insert', true)
+      if (isSeq(inserted)) scan(inserted)
+    }
+  }
+  scan(root)
+  return rows
+}
+
+export function readDshMcpServers(content: string): Map<string, Record<string, any>> {
+  const doc = patchDocument(content)
+  return new Map(mcpRows(doc.contents as YAMLSeq).map(({ row, name }) => {
+    const value = row.get('config', true)
+    if (!isMap(value)) invalid(`Invalid DSH MCP config: ${name}`)
+    const config = value.toJS(doc) as Record<string, any>
+    delete config.serverName
+    return [name, { ...config, enabled: row.get('disabled') !== true }]
+  }))
+}
+
+export function validateDshMcpServer(name: string, config: Record<string, any>): void {
+  if (!/^[A-Za-z0-9_-]{1,32}$/.test(name)) invalid('DSH MCP names must contain 1–32 letters, digits, underscores or hyphens')
+  if (!config || typeof config !== 'object' || Array.isArray(config)) invalid('DSH MCP config must be an object')
+  const transport = config.transport || config.type || (config.url ? 'http' : 'stdio')
+  if (!['stdio', 'http', 'streamable-http', 'streamable_http', 'streamableHttp'].includes(transport)) {
+    invalid('DSH supports stdio and Streamable HTTP MCP only')
+  }
+  if (transport === 'stdio' && !config.command) invalid('DSH stdio MCP requires a command')
+  if (transport !== 'stdio' && !config.url) invalid('DSH HTTP MCP requires a url')
+  if (config.command && config.url) invalid('DSH MCP requires either command or url, not both')
+  if (typeof config.enabled !== 'undefined' && typeof config.enabled !== 'boolean') invalid('MCP enabled must be a boolean')
+}
+
+export function updateDshMcpServer(content: string, name: string, config: Record<string, any> | null): string {
+  const doc = patchDocument(content)
+  const root = doc.contents as YAMLSeq
+  const existing = mcpRows(root).find(row => row.name === name)
+  if (config === null) {
+    if (!existing) return content
+    existing.parent.items.splice(existing.parent.items.indexOf(existing.row), 1)
+    return doc.toString()
+  }
+  validateDshMcpServer(name, config)
+  const native: Record<string, any> = { ...config, serverName: name, transport: config.url ? 'streamable-http' : 'stdio' }
+  delete native.enabled
+  delete native.type
+  if (existing) {
+    const current = existing.row.get('config', true)
+    if (!isMap(current)) invalid(`Invalid DSH MCP config: ${name}`)
+    // Leave unchanged nodes intact, including comments, anchors and !!js expressions.
+    for (const pair of [...current.items]) {
+      const key = String(isScalar(pair.key) ? pair.key.value : pair.key)
+      if (!(key in native)) current.delete(key)
+    }
+    for (const [key, value] of Object.entries(native)) {
+      const prior: unknown = current.get(key, true)
+      const plain = isNode(prior) ? prior.toJS(doc) : prior
+      if (JSON.stringify(plain) !== JSON.stringify(value)) current.set(key, doc.createNode(value))
+    }
+    existing.row.set('disabled', config.enabled === false)
+  } else {
+    root.add(doc.createNode({ insert: [{
+      id: `mcp-${name}`, name: MCP_PLUGIN, disabled: config.enabled === false, config: native,
+    }] }))
+  }
+  return doc.toString()
+}
+
+export function assertDshMcpProbeIsLiteral(content: string, name: string): void {
+  const doc = patchDocument(content)
+  const row = mcpRows(doc.contents as YAMLSeq).find(row => row.name === name)
+  if (!row) return
+  const seen = new Set<unknown>()
+  const check = (root: YAMLMap | YAMLSeq | ReturnType<typeof doc.createNode>) => visit(root, (_key, node) => {
+    if (seen.has(node)) return visit.SKIP
+    seen.add(node)
+    if (isAlias(node)) {
+      const target = node.resolve(doc)
+      if (target) check(target)
+    }
+    if ((isScalar(node) || isMap(node) || isSeq(node)) && node.tag?.includes(':js')) {
+      invalid('This DSH MCP configuration contains JavaScript expressions; test it in DSH after resolving its environment')
+    }
+  })
+  check(row.row)
+}

--- a/packages/server/src/modules/coding-agents/services/index.ts
+++ b/packages/server/src/modules/coding-agents/services/index.ts
@@ -1,3 +1,4 @@
+import { readDshMcpServers, validateDshSettings } from './dsh/config'
 import { OPENCODE_FREE_PROVIDER, openCodeFreeRuntime } from '../../studio/contracts/opencode-free'
 import { beginAgentPreparation } from './update-lock'
 import { execFile } from 'child_process'
@@ -241,7 +242,7 @@ interface CommandExecution {
   windowsVerbatimArguments?: WindowsCommandExecution['windowsVerbatimArguments']
 }
 
-export type CodingAgentId = CodingAgentRuntime
+export type CodingAgentId = CodingAgentRuntime | 'dsh'
 
 export interface CodingAgentDefinition {
   id: CodingAgentId
@@ -374,6 +375,13 @@ const TOOL_DEFINITIONS: CodingAgentDefinition[] = [
     command: 'opencode',
     packageName: 'opencode-ai',
   },
+  {
+    id: 'dsh',
+    name: 'DeepSeek Harness',
+    provider: 'DeepSeek',
+    command: 'dsh',
+    packageName: '@deepseek-ai/dsh',
+  },
 ]
 
 const CONFIG_FILE_DEFINITIONS: Record<CodingAgentId, Array<Omit<CodingAgentConfigFileDefinition, 'absolutePath'> & { scopedPath: string }>> = {
@@ -400,6 +408,11 @@ const CONFIG_FILE_DEFINITIONS: Record<CodingAgentId, Array<Omit<CodingAgentConfi
     { key: 'mcp', path: '~/.grok/config.toml', scopedPath: 'config.toml', language: 'ini' },
     { key: 'settings', path: '~/.grok/config.toml', scopedPath: 'config.toml', language: 'ini' },
     { key: 'agents', path: '~/.grok/AGENTS.md', scopedPath: 'AGENTS.md', language: 'markdown' },
+  ],
+  dsh: [
+    { key: 'settings', path: '~/.dsh/settings.yaml', scopedPath: 'settings.yaml', language: 'yaml' },
+    { key: 'memory', path: '~/.dsh/AGENTS.md', scopedPath: 'AGENTS.md', language: 'markdown' },
+    { key: 'mcp', path: '~/.dsh/cordis.patch.yml', scopedPath: 'cordis.patch.yml', language: 'yaml' },
   ],
   opencode: [
     { key: 'settings', path: '~/.config/opencode/opencode.json', scopedPath: OPENCODE_CONFIG_FILE, language: 'json' },
@@ -1816,7 +1829,7 @@ export function getCodingAgentManagedMcpServerConfigs(
   id: CodingAgentId,
   profile = 'default',
 ): Record<string, Record<string, unknown>> {
-  if (!['claude-code', 'codex', 'pi', 'grok', 'opencode'].includes(id)) return {}
+  if (!['claude-code', 'codex', 'pi', 'grok', 'opencode', 'dsh'].includes(id)) return {}
   const disabledManaged = getDisabledManagedMcpServers(id, profile)
   return Object.fromEntries(HERMES_MCP_SERVERS.map((item) => {
     const server = managedHermesMcpServerConfig(id, profile || 'default', item.name, item.toolset)
@@ -2703,7 +2716,7 @@ export function getCodingAgentDefinition(id: string): CodingAgentDefinition | nu
 }
 
 export function withCodingAgentRegistry(id: CodingAgentId, args: string[]): string[] {
-  return id === 'codex' || id === 'grok' || id === 'opencode'
+  return id === 'codex' || id === 'grok' || id === 'opencode' || id === 'dsh'
     ? [...args, `--registry=${OFFICIAL_NPM_REGISTRY}`]
     : [...args]
 }
@@ -2807,7 +2820,7 @@ export interface CodingAgentUpdateResult {
   message?: string
 }
 
-function versionGte(a: string, b: string): boolean {
+export function versionGte(a: string, b: string, includePrerelease = false): boolean {
   const x = String(a).match(/\d+(?:\.\d+){0,2}/)
   const y = String(b).match(/\d+(?:\.\d+){0,2}/)
   if (!x || !y) return String(a) === String(b)
@@ -2817,6 +2830,20 @@ function versionGte(a: string, b: string): boolean {
     const u = p[i] || 0
     const v = q[i] || 0
     if (u !== v) return u > v
+  }
+  if (includePrerelease) {
+    const prerelease = (version: string) => version.match(/\d+(?:\.\d+){0,2}-([0-9A-Za-z.-]+)/)?.[1].split('.')
+    const left = prerelease(a)
+    const right = prerelease(b)
+    if (!left || !right) return !left
+    for (let i = 0; i < Math.max(left.length, right.length); i += 1) {
+      if (left[i] === right[i]) continue
+      if (left[i] === undefined || right[i] === undefined) return right[i] === undefined
+      const ln = /^\d+$/.test(left[i])
+      const rn = /^\d+$/.test(right[i])
+      if (ln !== rn) return !ln
+      return ln ? Number(left[i]) > Number(right[i]) : left[i] > right[i]
+    }
   }
   return true
 }
@@ -2860,7 +2887,7 @@ export async function checkUpdateAgent(id: string): Promise<CodingAgentUpdateRes
     )
     const latestVersion = stdout.trim()
     const status = await getCodingAgentStatus(tool)
-    const updateAvailable = !!latestVersion && status.installed && !versionGte(status.version, latestVersion)
+    const updateAvailable = !!latestVersion && status.installed && !versionGte(status.version, latestVersion, id === 'dsh')
     return { success: true, tool: status, latestVersion, updateAvailable }
   } catch (err: any) {
     const status = await getCodingAgentStatus(tool)
@@ -3030,6 +3057,8 @@ export async function readCodingAgentConfigFile(id: string, key: string, scope: 
         ? piLiveConfigDefault(key, normalizedScope.profile) || ''
         : id === 'opencode' && key === 'settings'
           ? '{}\n'
+          : id === 'dsh' && key === 'settings' ? '{}\n'
+            : id === 'dsh' && key === 'mcp' ? '[]\n'
         : ''
     return {
       ...definition,
@@ -3053,6 +3082,8 @@ export async function writeCodingAgentConfigFile(id: string, key: string, conten
     ;(err as any).status = 404
     throw err
   }
+  if (id === 'dsh' && key === 'settings') validateDshSettings(content)
+  if (id === 'dsh' && key === 'mcp') readDshMcpServers(content)
   let persistedContent = content || ''
   if (id === 'grok' && (key === 'mcp' || key === 'settings')) {
     const existingContent = await safeReadFile(definition.absolutePath) || ''
@@ -3113,6 +3144,7 @@ export function invalidateCodingAgentConfigRuntime(
 }
 
 export async function prepareCodingAgentLaunch(id: string, input: CodingAgentLaunchInput): Promise<CodingAgentLaunchResult> {
+  if (id === 'dsh') throw Object.assign(new Error('DSH ACP chat integration is not available yet'), { status: 400 })
   const tool = getCodingAgentDefinition(id)
   if (!tool) {
     const err = new Error('Unknown coding agent')

--- a/packages/server/src/modules/coding-agents/services/mcp-manager.ts
+++ b/packages/server/src/modules/coding-agents/services/mcp-manager.ts
@@ -1,3 +1,4 @@
+import { readDshMcpServers, updateDshMcpServer, validateDshMcpServer, assertDshMcpProbeIsLiteral } from './dsh/config'
 import { readdir, readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { parse as parseToml } from 'smol-toml'
@@ -13,7 +14,7 @@ import { setManagedMcpServerEnabled, setManagedMcpServerOverride } from './mcp-o
 import { getWebUiHome } from '../../studio/public/config'
 import { probeCodingAgentMcpConfig } from './mcp-runtime-isolation'
 
-const CODING_AGENT_IDS = new Set(['claude-code', 'codex', 'pi', 'grok', 'opencode'])
+const CODING_AGENT_IDS = new Set(['claude-code', 'codex', 'pi', 'grok', 'opencode', 'dsh'])
 const STUDIO_MANAGED_NAMES = new Set([
   'hermes-studio-api',
   'hermes-studio-browser',
@@ -285,6 +286,8 @@ async function readServers(id: string, scope: CodingAgentConfigScope): Promise<{
   let servers: Map<string, Record<string, any>>
   if (id === 'claude-code' || id === 'pi') {
     servers = parseJsonDocument(file.content).servers
+  } else if (id === 'dsh') {
+    servers = readDshMcpServers(file.content)
   } else if (id === 'opencode') {
     servers = parseOpenCodeDocument(file.content).servers
   } else {
@@ -308,6 +311,10 @@ async function writeServer(
   config: Record<string, any> | null,
   scope: CodingAgentConfigScope,
 ): Promise<void> {
+  if (id === 'dsh') {
+    await writeCodingAgentConfigFile(id, configKey(id), updateDshMcpServer(originalContent, name, config), scope)
+    return
+  }
   if (id === 'claude-code' || id === 'pi') {
     const { root } = parseJsonDocument(originalContent)
     const persistedServers = isRecord(root.mcpServers) ? { ...root.mcpServers } : {}
@@ -338,6 +345,7 @@ async function writeServer(
 }
 
 function removeServerFromContent(id: string, content: string, name: string): string | null {
+  if (id === 'dsh') return readDshMcpServers(content).has(name) ? updateDshMcpServer(content, name, null) : null
   if (id === 'claude-code' || id === 'pi') {
     const { root } = parseJsonDocument(content)
     const persistedServers = isRecord(root.mcpServers) ? { ...root.mcpServers } : {}
@@ -363,7 +371,7 @@ function removeServerFromContent(id: string, content: string, name: string): str
 
 async function pruneScopedServerCopies(id: string, name: string): Promise<number> {
   const modelRoot = join(getWebUiHome(), 'coding-agent', 'model')
-  const fileName = id === 'claude-code' || id === 'pi'
+  const fileName = id === 'dsh' ? 'cordis.patch.yml' : id === 'claude-code' || id === 'pi'
     ? 'mcp.json'
     : id === 'opencode'
       ? 'opencode.json'
@@ -451,6 +459,7 @@ export async function upsertCodingAgentMcpServer(
   config: Record<string, any>,
   scope: CodingAgentConfigScope = {},
 ): Promise<{ ok: true; name: string }> {
+  assertAgentId(id)
   const normalizedName = name.trim().replace(/^hermes-studio-(api|browser|devices|use)$/, 'ekko-studio-$1')
   if (!normalizedName || normalizedName.length > 128 || /[/\\\x00-\x1f]/.test(normalizedName)) {
     const error = new Error('Valid server name is required')
@@ -481,6 +490,7 @@ export async function upsertCodingAgentMcpServer(
       ;(error as any).status = 400
       throw error
     }
+    if (id === 'dsh') validateDshMcpServer(normalizedName, config)
     setManagedMcpServerOverride(
       id,
       profile,
@@ -501,6 +511,7 @@ export async function upsertCodingAgentMcpServer(
     ;(error as any).status = 400
     throw error
   }
+  if (id === 'dsh') validateDshMcpServer(normalizedName, config)
   const current = await readServers(id, scope)
   await writeServer(id, current.content, normalizedName, normalizeConfig(config), scope)
   return { ok: true, name: normalizedName }
@@ -538,5 +549,10 @@ export async function testCodingAgentMcpServer(
   if (!config) return { ok: false, error: `MCP server not found: ${name}` }
   if (config.enabled === false) return { ok: false, error: 'Enable the MCP server before testing it' }
 
+  if (id === 'dsh') {
+    try { assertDshMcpProbeIsLiteral(current.content, name) } catch (error) {
+      return { ok: false, error: error instanceof Error ? error.message : String(error) }
+    }
+  }
   return probeCodingAgentMcpConfig(config)
 }

--- a/packages/server/src/modules/hermes/controllers/skills.ts
+++ b/packages/server/src/modules/hermes/controllers/skills.ts
@@ -1,3 +1,4 @@
+import { findDshSkillFile, listDshSkills, validateDshSkill } from '../services/skills/dsh-files'
 import { mkdir, readdir, readFile, realpath, rm, stat, writeFile, cp } from 'fs/promises'
 import { homedir, tmpdir } from 'os'
 import { dirname, join, resolve } from 'path'
@@ -31,16 +32,16 @@ function requestSkillsDir(ctx: any): string {
   return join(requestProfileDir(ctx), 'skills')
 }
 
-type SkillTarget = 'hermes' | 'claude' | 'codex' | 'pi' | 'grok' | 'opencode'
+type SkillTarget = 'hermes' | 'claude' | 'codex' | 'pi' | 'grok' | 'opencode' | 'dsh'
 
 function requestSkillTarget(ctx: any): SkillTarget {
   const target = String(ctx.query?.target || 'hermes').trim().toLowerCase()
-  return target === 'claude' || target === 'codex' || target === 'pi' || target === 'grok' || target === 'opencode' ? target : 'hermes'
+  return target === 'claude' || target === 'codex' || target === 'pi' || target === 'grok' || target === 'opencode' || target === 'dsh' ? target : 'hermes'
 }
 
 function globalSkillsDir(target: Exclude<SkillTarget, 'hermes'>): string {
   const globalHome = getCodingAgentGlobalHome()
-  return target === 'claude'
+  return target === 'dsh' ? join(globalHome, '.dsh', 'skills') : target === 'claude'
     ? join(globalHome, '.claude', 'skills')
     : target === 'grok'
       ? join(globalHome, '.grok', 'skills')
@@ -70,6 +71,11 @@ async function resolveSkillDirForTarget(ctx: any, category: string, skillName: s
     return resolveSkillDirFromConfig(config, skillsDir, category, skillName)
   }
 
+  if (target === 'dsh') {
+    if (category !== 'misc') return null
+    const file = await findDshSkillFile([skillsDir, sharedAgentSkillsDir()], skillName)
+    return file && !file.flat ? file.directory : null
+  }
   const localSkillDir = await findSkillDirInRoot(skillsDir, category, skillName)
   if (localSkillDir) return localSkillDir
 
@@ -527,6 +533,11 @@ export async function list(ctx: any) {
   const target = requestSkillTarget(ctx)
   const skillsDir = requestTargetSkillsDir(ctx)
   try {
+    if (target === 'dsh') {
+      const roots = [skillsDir, sharedAgentSkillsDir()]
+      ctx.body = { categories: await listDshSkills(roots), archived: [], paths: { local: skillsDir, external: roots.slice(1) } }
+      return
+    }
     if (target !== 'hermes') {
       let categories = await scanSkillsDirIfExists(skillsDir, new Map(), new Set(), [], new Map())
       const extraDirs: string[] = []
@@ -735,6 +746,10 @@ export async function toggle(ctx: any) {
 export async function listFiles(ctx: any) {
   const { category, skill } = ctx.params
   try {
+    if (requestSkillTarget(ctx) === 'dsh' && category === 'misc') {
+      const file = await findDshSkillFile([requestTargetSkillsDir(ctx), sharedAgentSkillsDir()], skill)
+      if (file?.flat) { ctx.body = { files: [] }; return }
+    }
     const skillDir = await resolveSkillDirForTarget(ctx, category, skill)
     if (!skillDir) {
       ctx.status = 404
@@ -753,6 +768,17 @@ export async function listFiles(ctx: any) {
 export async function readFile_(ctx: any) {
   const filePath = (ctx.params as any).path
   const profileSkillsDir = requestTargetSkillsDir(ctx)
+  if (requestSkillTarget(ctx) === 'dsh') {
+    const parts = String(filePath).split('/')
+    if (parts[0] !== 'misc' || parts.length < 3) { ctx.status = 404; ctx.body = { error: 'File not found' }; return }
+    const file = await findDshSkillFile([profileSkillsDir, sharedAgentSkillsDir()], parts[1])
+    const suffix = parts.slice(2).join('/')
+    const path = file ? (suffix === 'SKILL.md' ? file.path : !file.flat ? resolve(file.directory, suffix) : '') : ''
+    if (!file || !path || !isPathWithin(path, file.directory)) { ctx.status = 404; ctx.body = { error: 'File not found' }; return }
+    const content = await safeReadFile(path)
+    if (content === null) { ctx.status = 404; ctx.body = { error: 'File not found' }; return }
+    ctx.body = { content }; return
+  }
   // Handle 'misc' category: real skill dir is skills/<skill>, not skills/misc/<skill>
   let realPath = filePath
   if (filePath.startsWith('misc/')) {
@@ -872,6 +898,13 @@ export async function updateSkill(ctx: any) {
       }
     }
 
+    if (target === 'dsh') {
+      validateDshSkill(content)
+      const file = category === 'misc' ? await findDshSkillFile([skillsDir, sharedAgentSkillsDir()], name) : null
+      if (!file) { ctx.status = 404; ctx.body = { error: 'Skill not found' }; return }
+      await writeFile(file.path, content, 'utf-8')
+      ctx.body = { success: true }; return
+    }
     const usesSharedAgentSkills = target === 'grok' || target === 'opencode'
     const localSkillDir = usesSharedAgentSkills
       ? await resolveSkillDirForTarget(ctx, category, name)
@@ -894,7 +927,7 @@ export async function updateSkill(ctx: any) {
     hashCache.delete(localSkillDir)
     ctx.body = { success: true }
   } catch (err: any) {
-    ctx.status = 500
+    ctx.status = err.status || 500
     ctx.body = { error: err.message }
   }
 }
@@ -951,6 +984,12 @@ export async function deleteSkill(ctx: any) {
     return
   }
 
+  if (requestSkillTarget(ctx) === 'dsh') {
+    const file = category === 'misc' ? await findDshSkillFile([requestTargetSkillsDir(ctx), sharedAgentSkillsDir()], name) : null
+    if (!file) { ctx.status = 404; ctx.body = { error: 'Skill not found' }; return }
+    await rm(file.flat ? file.path : file.directory, { recursive: !file.flat, force: true })
+    ctx.body = { success: true }; return
+  }
   const skillsDir = requestSkillsDir(ctx)
   try {
     // Determine source — only allow deleting `local` skills
@@ -1064,7 +1103,10 @@ export async function importSkill(ctx: any) {
     return
   }
 
-  const skillsDir = requestSkillsDir(ctx)
+  const target = requestSkillTarget(ctx)
+  if (target !== 'hermes' && target !== 'dsh') { ctx.status = 400; ctx.body = { error: 'Skill import is not supported for this target' }; return }
+  if (target === 'dsh' && category) { ctx.status = 400; ctx.body = { error: 'DSH skills must be imported without a category' }; return }
+  const skillsDir = requestTargetSkillsDir(ctx)
   await mkdir(skillsDir, { recursive: true })
   const targetRoot = category ? join(skillsDir, category) : skillsDir
 
@@ -1166,13 +1208,14 @@ export async function importSkill(ctx: any) {
         return
       }
 
+      if (target === 'dsh') validateDshSkill((await safeReadFile(join(skillSrcDir, 'SKILL.md'))) || '')
       const targetDir = join(targetRoot, skillName)
       if (!isPathWithin(targetDir, skillsDir)) {
         ctx.status = 400
         ctx.body = { error: 'Resolved target path escapes skills directory' }
         return
       }
-      if (await pathExists(targetDir)) {
+      if (await pathExists(targetDir) || (target === 'dsh' && await findDshSkillFile([skillsDir], skillName))) {
         ctx.status = 409
         ctx.body = { error: `Skill "${skillName}" already exists` }
         return
@@ -1204,6 +1247,10 @@ export async function importSkill(ctx: any) {
         ctx.body = { error: `Invalid skill name "${skillName}"` }
         return
       }
+      if (target === 'dsh') {
+        const definition = filePartsAll.find(p => (p.filename || '').replace(/\\/g, '/') === `${skillName}/SKILL.md`)
+        validateDshSkill(definition?.data.toString('utf-8') || '')
+      }
       // Must include SKILL.md
       const hasSkillMd = filePartsAll.some(p => {
         const rel = (p.filename || '').replace(/\\/g, '/')
@@ -1226,7 +1273,7 @@ export async function importSkill(ctx: any) {
         ctx.body = { error: 'Resolved target path escapes skills directory' }
         return
       }
-      if (await pathExists(targetDir)) {
+      if (await pathExists(targetDir) || (target === 'dsh' && await findDshSkillFile([skillsDir], skillName))) {
         ctx.status = 409
         ctx.body = { error: `Skill "${skillName}" already exists` }
         return
@@ -1258,7 +1305,7 @@ export async function importSkill(ctx: any) {
 
     ctx.body = { success: true, name: skillName }
   } catch (err: any) {
-    ctx.status = 500
+    ctx.status = err.status || 500
     ctx.body = { error: err.message }
   } finally {
     if (stagingDir) {

--- a/packages/server/src/modules/hermes/services/skills/dsh-files.ts
+++ b/packages/server/src/modules/hermes/services/skills/dsh-files.ts
@@ -1,0 +1,62 @@
+import { readFile, readdir, stat } from 'node:fs/promises'
+import { join } from 'node:path'
+import { load } from 'js-yaml'
+
+function safeName(name: string): boolean {
+  return Boolean(name) && !name.startsWith('.') && !/[\\/\x00-\x1f]/.test(name)
+}
+
+export function validateDshSkill(content: string): { name: string; description: string } {
+  const frontmatter = /^---\s*\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/.exec(content)
+  let data: any
+  try { data = frontmatter ? load(frontmatter[1]) : null } catch { /* reported below */ }
+  if (!data || typeof data.name !== 'string' || !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(data.name)
+    || typeof data.description !== 'string' || !data.description.trim()) {
+    throw Object.assign(new Error('DSH skills require YAML frontmatter with a kebab-case name and a description'), { status: 400 })
+  }
+  return { name: data.name, description: data.description }
+}
+
+export interface DshSkillFile { name: string; directory: string; path: string; flat: boolean }
+
+export async function findDshSkillFile(roots: string[], name: string): Promise<DshSkillFile | null> {
+  if (!safeName(name)) return null
+  for (const root of roots) {
+    for (const flat of [false, true]) {
+      const directory = flat ? root : join(root, name)
+      const path = flat ? join(root, `${name}.md`) : join(directory, 'SKILL.md')
+      try {
+        if ((await stat(path)).isFile()) return { name, directory, path, flat }
+      } catch (error: any) { if (error.code !== 'ENOENT' && error.code !== 'ENOTDIR') throw error }
+    }
+  }
+  return null
+}
+
+/** Match DSH's direct bundles and flat Markdown files; nested categories aren't discovered. */
+export async function listDshSkills(roots: string[]) {
+  const skills = new Map<string, { name: string; description: string; enabled: boolean; source: string }>()
+  const loadedNames = new Set<string>()
+  for (const root of roots) {
+    let entries
+    try { entries = await readdir(root) } catch (error: any) {
+      if (error.code === 'ENOENT') continue
+      throw error
+    }
+    for (const entry of entries.sort()) {
+      if (!safeName(entry)) continue
+      const name = entry.endsWith('.md') ? entry.slice(0, -3) : entry
+      if (skills.has(name)) continue
+      const file = await findDshSkillFile([root], name)
+      if (!file) continue
+      const content = await readFile(file.path, 'utf8')
+      try {
+        const metadata = validateDshSkill(content)
+        if (loadedNames.has(metadata.name)) continue
+        loadedNames.add(metadata.name)
+        skills.set(name, { name, description: metadata.description, enabled: true, source: 'local' })
+      } catch { /* DSH also omits malformed skill definitions. */ }
+    }
+  }
+  return skills.size ? [{ name: 'misc', description: '', skills: [...skills.values()].sort((a, b) => a.name.localeCompare(b.name)) }] : []
+}

--- a/packages/server/src/modules/studio/public/agent-status-registry.ts
+++ b/packages/server/src/modules/studio/public/agent-status-registry.ts
@@ -1,4 +1,4 @@
-export type AgentStatusId = 'hermes' | 'ekko-agent' | 'claude-code' | 'codex' | 'pi' | 'grok' | 'opencode'
+export type AgentStatusId = 'hermes' | 'ekko-agent' | 'claude-code' | 'codex' | 'pi' | 'grok' | 'opencode' | 'dsh'
 
 export type AgentStatusSource =
   | 'managed-runtime'
@@ -46,7 +46,7 @@ export interface AgentAvailabilitySnapshot {
   agents: AgentAvailabilityRecord[]
 }
 
-const AGENT_ORDER: AgentStatusId[] = ['hermes', 'ekko-agent', 'claude-code', 'codex', 'pi', 'grok', 'opencode']
+const AGENT_ORDER: AgentStatusId[] = ['hermes', 'ekko-agent', 'claude-code', 'codex', 'pi', 'grok', 'opencode', 'dsh']
 
 const DEFAULTS: Record<AgentStatusId, Omit<AgentStatusRecord, 'updatedAt'>> = {
   hermes: {
@@ -108,6 +108,10 @@ const DEFAULTS: Record<AgentStatusId, Omit<AgentStatusRecord, 'updatedAt'>> = {
     path: '',
     error: '',
     installations: [],
+  },
+  dsh: {
+    id: 'dsh', name: 'DeepSeek Harness', provider: 'DeepSeek', kind: 'coding-agent',
+    installed: false, version: '', source: 'not-installed', path: '', error: '', installations: [],
   },
   opencode: {
     id: 'opencode',

--- a/packages/server/src/modules/studio/services/agent-availability.ts
+++ b/packages/server/src/modules/studio/services/agent-availability.ts
@@ -13,6 +13,7 @@ const AGENT_ALIASES: Record<string, AgentStatusId> = {
   pi: 'pi',
   grok: 'grok',
   opencode: 'opencode',
+  dsh: 'dsh',
 }
 
 const AGENT_NAMES: Record<AgentStatusId, string> = {
@@ -23,6 +24,7 @@ const AGENT_NAMES: Record<AgentStatusId, string> = {
   pi: 'Pi',
   grok: 'Grok',
   opencode: 'OpenCode',
+  dsh: 'DeepSeek Harness',
 }
 
 export const AGENT_NOT_INSTALLED = 'AGENT_NOT_INSTALLED'

--- a/tests/client/agent-manager-page.test.ts
+++ b/tests/client/agent-manager-page.test.ts
@@ -288,7 +288,7 @@ describe('Agent Manager page', () => {
     expect(wrapper.get('[data-testid="agent-card-codex"]').text()).toContain('agentManager.codingAgentDescription')
     expect(wrapper.get('[data-testid="agent-card-codex"]').text()).toContain('codingAgents.installNow')
     expect(wrapper.get('.coding-agent-grid').findAll('.agent-card').map(card => card.attributes('data-testid')))
-      .toEqual(['agent-card-ekko', 'agent-card-hermes', 'agent-card-claude-code', 'agent-card-codex', 'agent-card-pi', 'agent-card-grok', 'agent-card-opencode'])
+      .toEqual(['agent-card-ekko', 'agent-card-hermes', 'agent-card-claude-code', 'agent-card-codex', 'agent-card-pi', 'agent-card-grok', 'agent-card-opencode', 'agent-card-dsh'])
   })
 
   it('detects the CLI before offering Runtime management in the desktop shell', async () => {

--- a/tests/e2e/dsh-management.spec.ts
+++ b/tests/e2e/dsh-management.spec.ts
@@ -1,0 +1,87 @@
+import AdmZip from 'adm-zip'
+import { expect, test } from '@playwright/test'
+import { authenticate, mockHermesApi, TEST_ACCESS_KEY } from './fixtures'
+
+test('installs DSH from Agent Manager and saves its native settings', async ({ page }) => {
+  await authenticate(page, TEST_ACCESS_KEY, 'research')
+  const api = await mockHermesApi(page)
+  let installed = false
+  const tool = () => ({ id: 'dsh', name: 'DeepSeek Harness', provider: 'DeepSeek', command: 'dsh', packageName: '@deepseek-ai/dsh', installed, version: installed ? '0.1.5-rc.1' : '', path: installed ? '/usr/local/bin/dsh' : '', error: '' })
+  await page.route('**/api/coding-agents', route => route.fulfill({ json: { tools: [tool()] } }))
+  await page.route('**/api/coding-agents/dsh/install', async route => {
+    expect(route.request().method()).toBe('POST')
+    installed = true
+    await route.fulfill({ json: { success: true, tools: [tool()], tool: tool() } })
+  })
+  const contents: Record<string, string> = { settings: '{}\n', memory: '' }
+  await page.route('**/api/coding-agents/dsh/config-files/*', async route => {
+    const key = new URL(route.request().url()).pathname.split('/').at(-1)!
+    if (route.request().method() === 'PUT') contents[key] = route.request().postDataJSON().content
+    await route.fulfill({ json: { key, content: contents[key], path: `~/.dsh/${key === 'settings' ? 'settings.yaml' : 'AGENTS.md'}`, exists: true, language: key === 'settings' ? 'yaml' : 'markdown' } })
+  })
+  await page.goto('/#/studio/agents')
+  const card = page.getByTestId('agent-card-dsh')
+  await expect(card).toBeVisible()
+  await card.getByRole('button', { name: 'Install', exact: true }).click()
+  await expect(card).toContainText('0.1.5-rc.1')
+  expect(installed).toBe(true)
+  await card.getByTestId('agent-settings-dsh').click()
+  await expect(page).toHaveURL(/\/studio\/agents\/dsh\/settings/)
+  const settings = page.locator('.settings-editor-panel').nth(1)
+  await settings.locator('textarea').fill('theme: dark\n')
+  await settings.getByRole('button', { name: 'Save', exact: true }).click()
+  await expect.poll(() => contents.settings).toBe('theme: dark\n')
+  expect(contents.memory).toBe('')
+  expect(api.unexpectedRequests).toEqual([])
+})
+
+test('opens DSH skills and adds an MCP through the shared management UI', async ({ page }) => {
+  await authenticate(page, TEST_ACCESS_KEY, 'research')
+  const api = await mockHermesApi(page)
+  let imported = false
+  await page.route('**/api/hermes/skills**', async route => {
+    const url = new URL(route.request().url())
+    if (!url.searchParams.has('target')) return route.fallback()
+    expect(url.searchParams.get('target')).toBe('dsh')
+    if (url.pathname === '/api/hermes/skills/import') {
+      expect(route.request().method()).toBe('POST')
+      expect(route.request().postDataBuffer()?.toString()).toContain('demo.zip')
+      imported = true
+      return route.fulfill({ json: { name: 'imported' } })
+    }
+    if (url.pathname === '/api/hermes/skills') {
+      await route.fulfill({ json: { categories: [{ name: 'misc', skills: [{ name: 'demo', description: 'DSH native skill', enabled: true, source: 'local' }] }], archived: [] } })
+    } else {
+      await route.fulfill({ json: url.pathname.endsWith('/files') ? { files: [] } : { content: '---\nname: demo\ndescription: DSH native skill\n---\nInstructions' } })
+    }
+  })
+  await page.goto('/#/studio/agents/dsh/skills')
+  await expect(page.locator('.skill-item').filter({ hasText: 'demo' })).toBeVisible()
+  await expect(page.locator('.skill-item').getByRole('switch')).toHaveCount(0)
+  await page.getByRole('button', { name: 'Import', exact: true }).click()
+  await expect(page.locator('.field-label')).toHaveCount(0)
+  await page.locator('.n-modal').getByText('Zip', { exact: true }).click()
+  const zip = new AdmZip()
+  zip.addFile('imported/SKILL.md', Buffer.from('---\nname: imported\ndescription: Example\n---\nInstructions'))
+  await page.locator('.n-modal input[type=file]').setInputFiles({ name: 'demo.zip', mimeType: 'application/zip', buffer: zip.toBuffer() })
+  await page.getByRole('button', { name: 'Confirm', exact: true }).click()
+  await expect.poll(() => imported).toBe(true)
+
+  const servers: any[] = []
+  await page.route('**/api/coding-agents/dsh/mcp/servers**', async route => {
+    const url = new URL(route.request().url())
+    if (url.pathname.endsWith('/test')) return route.fulfill({ json: { ok: true, tools: [] } })
+    if (route.request().method() === 'POST') {
+      const { name, config } = route.request().postDataJSON()
+      servers.push({ name, raw_config: config, managed: false, transport: 'stdio', connected: false, tools_registered: 0, tool_names: [], tool_names_registered: [], tool_details: [] })
+      await route.fulfill({ json: { ok: true, name } })
+    } else await route.fulfill({ json: { ok: true, servers, total_tools: 0 } })
+  })
+  await page.goto('/#/studio/agents/dsh/mcp')
+  await page.getByRole('button', { name: '+ Add Server', exact: true }).click()
+  await page.locator('.n-modal textarea').fill(JSON.stringify({ docs: { command: 'node', args: ['docs.mjs'] } }))
+  await page.locator('.n-modal').getByRole('button', { name: 'Save', exact: true }).click()
+  await expect.poll(() => servers.length).toBe(1)
+  expect(servers[0]).toMatchObject({ name: 'docs', raw_config: { command: 'node', args: ['docs.mjs'] } })
+  expect(api.unexpectedRequests).toEqual([])
+})

--- a/tests/server/agent-status-registry.test.ts
+++ b/tests/server/agent-status-registry.test.ts
@@ -22,6 +22,7 @@ describe('Agent status registry', () => {
       'pi',
       'grok',
       'opencode',
+      'dsh',
     ])
     expect(snapshot.agents.find(agent => agent.id === 'ekko-agent')).toMatchObject({
       installed: true,

--- a/tests/server/coding-agent-mcp-manager.test.ts
+++ b/tests/server/coding-agent-mcp-manager.test.ts
@@ -76,6 +76,22 @@ afterEach(() => {
 })
 
 describe('coding Agent MCP manager', () => {
+  it('manages DSH native patches without persisting Studio-managed entries', async () => {
+    const home = makeHome()
+    await upsertCodingAgentMcpServer('dsh', 'docs', { command: 'node', args: ['docs.mjs'] })
+    const listed = await listCodingAgentMcpServers('dsh')
+    expect(listed.servers.find(server => server.name === 'docs')).toMatchObject({ raw_config: { enabled: true }, managed: false })
+    const managed = listed.servers.filter(server => server.managed)
+    expect(managed).toHaveLength(4)
+    for (const server of managed) expect(server.raw_config.env.ELECTRON_RUN_AS_NODE).toBe('1')
+    const path = join(home, '.dsh', 'cordis.patch.yml')
+    expect(readFileSync(path, 'utf8')).not.toContain('ekko-studio-api')
+    await upsertCodingAgentMcpServer('dsh', 'ekko-studio-api', { enabled: false })
+    expect((await listCodingAgentMcpServers('dsh')).servers.find(server => server.name === 'ekko-studio-api')?.raw_config.enabled).toBe(false)
+    await removeCodingAgentMcpServer('dsh', 'docs')
+    expect((await listCodingAgentMcpServers('dsh')).servers.some(server => server.name === 'docs')).toBe(false)
+  })
+
   it('manages Claude JSON while preserving unrelated root configuration', async () => {
     const home = makeHome()
     const path = join(home, '.claude', 'mcp.json')

--- a/tests/server/coding-agent-npm-registry.test.ts
+++ b/tests/server/coding-agent-npm-registry.test.ts
@@ -21,6 +21,7 @@ describe('coding Agent npm registry policy', () => {
   it.each([
     ['codex', '@openai/codex'],
     ['grok', '@xai-official/grok'],
+    ['dsh', '@deepseek-ai/dsh'],
   ] as const)('uses the official npm Registry for %s package operations', (agentId, packageName) => {
     expect(withCodingAgentRegistry(agentId, ['install', '-g', packageName])).toEqual([
       'install',

--- a/tests/server/dsh-config.test.ts
+++ b/tests/server/dsh-config.test.ts
@@ -1,0 +1,84 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { parseDocument } from 'yaml'
+import { readCodingAgentConfigFile, writeCodingAgentConfigFile, versionGte } from '../../packages/server/src/bootstrap/coding-agents'
+import { assertDshMcpProbeIsLiteral, readDshMcpServers, updateDshMcpServer } from '../../packages/server/src/modules/coding-agents/services/dsh/config'
+
+let home: string | undefined
+const previousHome = process.env.HERMES_CODING_AGENT_GLOBAL_HOME
+afterEach(() => {
+  if (home) rmSync(home, { recursive: true, force: true })
+  home = undefined
+  if (previousHome === undefined) delete process.env.HERMES_CODING_AGENT_GLOBAL_HOME
+  else process.env.HERMES_CODING_AGENT_GLOBAL_HOME = previousHome
+})
+
+describe('DSH native configuration', () => {
+  it('reads defaults and saves native settings and instructions independently', async () => {
+    home = mkdtempSync(join(tmpdir(), 'studio-dsh-config-'))
+    process.env.HERMES_CODING_AGENT_GLOBAL_HOME = home
+    expect((await readCodingAgentConfigFile('dsh', 'settings')).content).toBe('{}\n')
+    expect((await readCodingAgentConfigFile('dsh', 'mcp')).content).toBe('[]\n')
+    await writeCodingAgentConfigFile('dsh', 'settings', 'model: deepseek-chat\n')
+    await writeCodingAgentConfigFile('dsh', 'memory', 'Project instructions\n')
+    await expect(writeCodingAgentConfigFile('dsh', 'settings', '- bad\n')).rejects.toThrow('mapping')
+    await expect(writeCodingAgentConfigFile('dsh', 'mcp', 'mcpServers: {}')).rejects.toThrow('sequence')
+    expect(readFileSync(join(home, '.dsh/settings.yaml'), 'utf8')).toBe('model: deepseek-chat\n')
+    expect(readFileSync(join(home, '.dsh/AGENTS.md'), 'utf8')).toBe('Project instructions\n')
+  })
+
+  it('inserts, edits, disables and removes MCP plugins while preserving Cordis expressions', () => {
+    const initial = `# keep plugin configuration\n- id: other\n  config:\n    secret: !!js process.env.TEST_SECRET\n`
+    const inserted = updateDshMcpServer(initial, 'docs', { command: 'node', args: ['docs.mjs'], env: { MODE: 'test' } })
+    const rows = parseDocument(inserted, { logLevel: 'silent' }).toJS()
+    expect(rows[1].insert[0]).toMatchObject({ name: '@deepseek-ai/dsh-mcp-client', config: { serverName: 'docs', transport: 'stdio' } })
+    const edited = updateDshMcpServer(inserted, 'docs', { url: 'https://example.com/mcp', enabled: false })
+    expect(readDshMcpServers(edited).get('docs')).toEqual({ transport: 'streamable-http', url: 'https://example.com/mcp', enabled: false })
+    expect(edited).toContain('# keep plugin configuration')
+    expect(edited).toContain('!!js process.env.TEST_SECRET')
+    const removed = updateDshMcpServer(edited, 'docs', null)
+    expect(readDshMcpServers(removed).size).toBe(0)
+    expect(removed).toContain('!!js process.env.TEST_SECRET')
+  })
+
+  it('preserves an unchanged MCP expression and refuses to probe it as a literal', () => {
+    const source = `- insert:\n    - name: '@deepseek-ai/dsh-mcp-client'\n      config:\n        serverName: docs\n        transport: stdio\n        command: node\n        env: !!js process.env\n`
+    const config = readDshMcpServers(source).get('docs')!
+    const edited = updateDshMcpServer(source, 'docs', { ...config, enabled: false })
+    expect(edited).toContain('!!js process.env')
+    expect(() => assertDshMcpProbeIsLiteral(edited, 'docs')).toThrow('JavaScript expressions')
+  })
+
+  it('resolves YAML aliases for display and preserves their anchors during edits', () => {
+    const source = `- id: defaults\n  env: &env\n    MODE: test\n- insert:\n    - name: '@deepseek-ai/dsh-mcp-client'\n      config:\n        serverName: docs\n        command: node\n        env: *env\n`
+    const config = readDshMcpServers(source).get('docs')!
+    expect(config.env).toEqual({ MODE: 'test' })
+    const edited = updateDshMcpServer(source, 'docs', { ...config, enabled: false })
+    expect(edited).toContain('env: *env')
+    expect(() => assertDshMcpProbeIsLiteral(edited, 'docs')).not.toThrow()
+    const dynamic = source.replace('env: &env\n    MODE: test', 'env: &env !!js process.env')
+    expect(() => assertDshMcpProbeIsLiteral(dynamic, 'docs')).toThrow('JavaScript expressions')
+  })
+
+  it.each([
+    ['bad.name', { command: 'node' }],
+    ['docs', { type: 'sse', url: 'https://example.com/sse' }],
+    ['docs', { transport: 'stdio', url: 'https://example.com/mcp' }],
+    ['docs', { command: 'node', url: 'https://example.com/mcp' }],
+  ])('rejects unsupported MCP configuration: %s %j', (name, config) => {
+    expect(() => updateDshMcpServer('[]', name as string, config as any)).toThrow()
+  })
+
+  it.each([
+    ['0.1.5-rc.1', '0.1.5-rc.2', false],
+    ['dsh 0.1.5-rc.10', '0.1.5-rc.2', true],
+    ['0.1.5-rc.2', '0.1.5', false],
+    ['0.1.5', '0.1.5-rc.2', true],
+    ['0.1.5-rc.2', '0.1.5-rc.2', true],
+    ['0.1.6-rc.1', '0.1.5', true],
+  ])('compares DSH prereleases %s >= %s', (installed, latest, result) => {
+    expect(versionGte(installed, latest, true)).toBe(result)
+  })
+})

--- a/tests/server/skills-controller.test.ts
+++ b/tests/server/skills-controller.test.ts
@@ -108,6 +108,83 @@ describe('skills controller', () => {
     mockListSkillUsageEventsAfterMessageId.mockResolvedValue({ events: [], cursor: 12, reset: false })
   })
 
+  it('lists, reads, edits and deletes DSH native flat and bundled skills', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'studio-dsh-skills-'))
+    const previous = process.env.HERMES_CODING_AGENT_GLOBAL_HOME
+    process.env.HERMES_CODING_AGENT_GLOBAL_HOME = root
+    const skill = (name: string, description = 'Example') => `---\nname: ${name}\ndescription: ${description}\n---\nInstructions\n`
+    try {
+      await mkdir(join(root, '.dsh/skills/bundle'), { recursive: true })
+      await mkdir(join(root, '.agents/skills/shared'), { recursive: true })
+      await mkdir(join(root, '.agents/skills/duplicate'), { recursive: true })
+      await mkdir(join(root, '.dsh/skills/category/nested'), { recursive: true })
+      await writeFile(join(root, '.dsh/skills/flat.md'), skill('flat'))
+      await writeFile(join(root, '.dsh/skills/bundle/SKILL.md'), skill('bundle'))
+      await writeFile(join(root, '.agents/skills/shared/SKILL.md'), skill('shared'))
+      await writeFile(join(root, '.agents/skills/duplicate/SKILL.md'), skill('bundle'))
+      await writeFile(join(root, '.dsh/skills/category/nested/SKILL.md'), skill('nested'))
+      const controller = await loadController()
+      const ctx: any = { query: { target: 'dsh' }, params: {}, state: {}, body: null }
+      await controller.list(ctx)
+      expect(ctx.body.categories[0].skills.map((s: any) => s.name)).toEqual(['bundle', 'flat', 'shared'])
+      ctx.params = { path: 'misc/flat/SKILL.md' }
+      await controller.readFile_(ctx)
+      expect(ctx.body.content).toBe(skill('flat'))
+      ctx.params = { category: 'misc', skill: 'flat' }
+      ctx.request = { body: { content: skill('flat', 'Updated') } }
+      await controller.updateSkill(ctx)
+      expect(ctx.body).toEqual({ success: true })
+      expect(await readFile(join(root, '.dsh/skills/flat.md'), 'utf8')).toContain('Updated')
+      ctx.request.body.content = '# Missing frontmatter'
+      await controller.updateSkill(ctx)
+      expect(ctx.status).toBe(400)
+      expect(await readFile(join(root, '.dsh/skills/flat.md'), 'utf8')).toContain('Updated')
+      await controller.deleteSkill(ctx)
+      await expect(readFile(join(root, '.dsh/skills/flat.md'))).rejects.toThrow()
+      expect(await readFile(join(root, '.dsh/skills/bundle/SKILL.md'), 'utf8')).toBe(skill('bundle'))
+    } finally {
+      if (previous === undefined) delete process.env.HERMES_CODING_AGENT_GLOBAL_HOME
+      else process.env.HERMES_CODING_AGENT_GLOBAL_HOME = previous
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('imports DSH skills into the global DSH home and rejects categories and invalid definitions', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'studio-dsh-import-'))
+    const previous = process.env.HERMES_CODING_AGENT_GLOBAL_HOME
+    process.env.HERMES_CODING_AGENT_GLOBAL_HOME = root
+    const boundary = '----dsh-skill-test'
+    const definition = '---\nname: demo\ndescription: Example\n---\nDo work\n'
+    const context = (content: string, category?: string): any => ({
+      query: { target: 'dsh' }, state: {},
+      get: () => `multipart/form-data; boundary=${boundary}`,
+      req: Readable.from([multipartBody(boundary, [
+        { name: 'file', filename: 'demo/SKILL.md', value: content },
+        ...(category ? [{ name: 'category', value: category }] : []),
+      ])]),
+    })
+    try {
+      const { importSkill } = await loadController()
+      const bad = context('# No frontmatter')
+      await importSkill(bad)
+      expect(bad.status).toBe(400)
+      const categorized = context(definition, 'tools')
+      await importSkill(categorized)
+      expect(categorized.status).toBe(400)
+      const valid = context(definition)
+      await importSkill(valid)
+      expect(valid.body).toEqual({ success: true, name: 'demo' })
+      expect(await readFile(join(root, '.dsh/skills/demo/SKILL.md'), 'utf8')).toBe(definition)
+      const duplicate = context(definition)
+      await importSkill(duplicate)
+      expect(duplicate.status).toBe(409)
+    } finally {
+      if (previous === undefined) delete process.env.HERMES_CODING_AGENT_GLOBAL_HOME
+      else process.env.HERMES_CODING_AGENT_GLOBAL_HOME = previous
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
   it('loads skill usage from the request-scoped profile state database', async () => {
     const { usageStats } = await loadController()
     const ctx: any = { query: { days: '30' }, state: { profile: { name: 'research' } }, body: null }


### PR DESCRIPTION
Superseded by #3020, the consolidated DSH PR targeting `main`. All commits from this PR are included there.

## Summary
- Add DeepSeek Harness to Agent Manager with CLI detection, installation, removal and prerelease-aware update checks for `@deepseek-ai/dsh`.
- Reuse the Coding Agent settings, Skill and MCP pages with DSH native files: `settings.yaml`, `AGENTS.md`, `cordis.patch.yml`, direct skill bundles and flat Markdown skills. Skill imports target the global DSH home; native MCP edits preserve other plugins, YAML expressions and anchors.
- Keep this phase limited to management. ACP chat, model injection and owned runtime shutdown remain follow-up work. No persistent DSH service is launched by these pages.

## Validation
- `npm ci --include=dev --ignore-scripts --no-audit --no-fund` passed.
- `npm run harness:check` and `npm run build` passed.
- Focused Vitest coverage: 108 tests passed across DSH configuration, MCP management, skills, registry, client API and Agent Manager/navigation tests.
- `PLAYWRIGHT_PORT=4198 PLAYWRIGHT_CHANNEL=chrome npx playwright test tests/e2e/dsh-management.spec.ts --workers=1`: 2 passed, covering installation, settings save, ZIP skill import and MCP addition with mocked APIs.
- `NODE_ENV=test npm run test:coverage -- --maxWorkers=4 --minWorkers=1`: 5388 passed, 7 failed, 6 skipped. All seven failures also reproduce on `main`: five existing launch-environment assertions, one devices LAN-address assertion and one group-chat member identity assertion.
- Full Playwright run: 180 passed and 2 session-category tests failed; stopped the remaining hung run after the other tests completed. DSH browser tests pass separately.

## Follow-up
- Complete ACP runtime/session integration and isolated `DSH_HOME` ownership before exposing DSH as a Studio chat agent.
- Global configuration management intentionally follows Studio's global Coding Agent home. Independently configured custom `DSH_HOME` instances are outside this scope.
