### PR TITLE
fix: remove unsupported OpenCode /compact command

### DIFF
--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -270,7 +270,8 @@ const filteredBridgeCommands = computed(() => {
   const commands = isBridgeSession.value
     ? bridgeCommands.value
     : isCodingAgentSession.value
-      ? bridgeCommands.value.filter(command => CODING_AGENT_SLASH_COMMANDS.includes(command.name))
+      ? bridgeCommands.value.filter(command => CODING_AGENT_SLASH_COMMANDS.includes(command.name)
+        && !(command.name === 'compact' && (chatStore.activeSession?.codingAgentId === 'opencode' || chatStore.activeSession?.agent === 'opencode')))
       : isForkCommandSession.value
         ? bridgeCommands.value.filter(command => command.name === 'fork')
         : []

--- a/packages/server/src/modules/coding-agents/services/session-command.ts
+++ b/packages/server/src/modules/coding-agents/services/session-command.ts
@@ -227,6 +227,16 @@ export async function handleCodingAgentSessionCommand(
     const compactRow = getSession(sessionId)
     const compactInfo = codingAgentRunManager.getRunInfo(sessionId)
     const compactAgentId = compactRow?.agent || compactInfo?.agentId || ''
+    if (compactAgentId === 'opencode') {
+      emitCommand({
+        ok: false,
+        action: 'compact',
+        terminal: !compactInfo?.running && !state.isWorking,
+        message: 'OpenCode /compact is not available in Studio. Compaction is managed by OpenCode internally.',
+        compacted: false,
+      })
+      return
+    }
     const compactAgentName = compactAgentId === 'codex'
       ? 'Codex'
       : compactAgentId === 'pi'

--- a/tests/client/chat-input-draft.test.ts
+++ b/tests/client/chat-input-draft.test.ts
@@ -392,6 +392,18 @@ describe('ChatInput draft persistence', () => {
     expect(wrapper.get('.n-slider-stub').classes()).not.toContain('reasoning-effort-slider--max')
   })
 
+  it.each(['opencode', 'codex', 'claude', 'pi', 'grok'] as const)('shows the supported commands for %s', async agent => {
+    const wrapper = mountForSession(`session-commands-${agent}`, { source: 'coding_agent', agent })
+    await wrapper.get('textarea').setValue('/')
+    await nextTick()
+    const commands = wrapper.findAll('.slash-command-item').map(item => item.text())
+    for (const name of ['context', 'usage', 'status']) {
+      expect(commands.some(text => text.includes(`/${name}`))).toBe(true)
+    }
+    expect(commands.some(text => text.includes('/compact'))).toBe(agent !== 'opencode')
+    wrapper.unmount()
+  })
+
   it('opens the skill picker from /skill and inserts the selected skill command', async () => {
     fetchSkillsMock.mockResolvedValue({
       categories: [

--- a/tests/server/coding-agent-session-command.test.ts
+++ b/tests/server/coding-agent-session-command.test.ts
@@ -163,6 +163,23 @@ describe('coding agent session commands', () => {
     expect(command.message).toContain('After: 200 tokens')
   })
 
+  it.each([false, true])('does not launch manual OpenCode compaction when running=%s', async running => {
+    getSessionMock.mockReturnValue({ id: 'session-1', agent: 'opencode' })
+    getRunInfoMock.mockReturnValue(running ? { agentId: 'opencode', running: true } : null)
+    const { handleCodingAgentSessionCommand } = await import('../../packages/server/src/modules/coding-agents/services/session-command')
+    const { socket, nsp, emitted } = makeSocket()
+    await handleCodingAgentSessionCommand(nsp, socket as any, { session_id: 'session-1' },
+      { name: 'compact', rawName: 'compact', args: '' }, 'default', new Map())
+    expect(compactMock).not.toHaveBeenCalled()
+    expect(startCodingAgentRunMock).not.toHaveBeenCalled()
+    expect(compactStoredCodingAgentSessionMock).not.toHaveBeenCalled()
+    const commands = emitted.filter(item => item.event === 'session.command')
+    expect(commands).toHaveLength(1)
+    expect(commands[0].payload).toMatchObject({ ok: false, terminal: !running, compacted: false,
+      message: expect.stringContaining('managed by OpenCode internally') })
+    expect(commands[0].payload.started).toBeUndefined()
+  })
+
   it('reports native compact failure without compressing Studio transcript', async () => {
     compactMock.mockRejectedValue(new Error('native compact unsupported'))
     getSessionMock.mockReturnValue({ id: 'session-1', agent: 'codex' })


### PR DESCRIPTION
## Summary
OpenCode sessions offered `/compact` even though Studio does not support its native manual compaction, resulting in an unsupported-session error. Hide this command for OpenCode and return a clear explanation if it is entered manually, without starting or restoring a runner or interrupting an active turn. Keep `/context`, `/usage`, and `/status` available.

The App menu change is already on main: https://github.com/EKKOLearnAI/hermes-studio-app/commit/036ea5179337a76ec62bbf80268310ecc84360a6.

## Validation
- `npm run build` — passed.
- `npm run harness:check` — passed.
- `npm run test -- tests/server/coding-agent-session-command.test.ts tests/server/opencode-run.test.ts tests/client/chat-store-session-command.test.ts` — 33 tests passed.
- `npm run test -- tests/client/chat-input-draft.test.ts -t 'shows the supported commands'` — 5 cases passed, covering OpenCode and the other coding agents.
- The full chat-input test file has an existing failure in `hides bridge autocomplete for non-Hermes slash prefixes`; reproduced against the unmodified component and test from the original checkout's HEAD.
