### PR TITLE
feat: integrate Studio image routes with Hermes image providers

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -7983,7 +7983,10 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "enum": [
+                "custom"
+              ]
             }
           }
         ]
@@ -8109,7 +8112,10 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "enum": [
+                "custom"
+              ]
             }
           }
         ]
@@ -14897,6 +14903,32 @@
                 ]
               }
             }
+          }
+        }
+      }
+    },
+    "/api/studio/media/image-providers": {
+      "get": {
+        "tags": [
+          "Media"
+        ],
+        "summary": "Get image-providers",
+        "description": "GET /api/studio/media/image-providers",
+        "operationId": "getImageProviders",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
           }
         }
       }

--- a/packages/client/src/api/hermes/config.ts
+++ b/packages/client/src/api/hermes/config.ts
@@ -143,6 +143,23 @@ export interface FallbackProvidersResponse {
   fallback_providers: FallbackProviderEntry[]
 }
 
+export interface StudioImageProvider {
+  name: string
+  display_name: string
+  available: boolean
+  active: boolean
+  default_model?: string | null
+  models: Array<{ id: string; display?: string; [key: string]: unknown }>
+  capabilities: { modalities?: string[]; max_reference_images?: number; [key: string]: unknown }
+  setup?: { badge?: string; tag?: string; required_env_vars?: string[] }
+}
+
+export interface StudioImageProvidersResponse {
+  ok: boolean
+  profile: string
+  providers: StudioImageProvider[]
+}
+
 export interface MoaModelSlot {
   provider: string
   model: string
@@ -216,6 +233,10 @@ export async function saveDelegationModel(delegation: DelegationModelConfig): Pr
 
 export async function fetchFallbackProviders(): Promise<FallbackProvidersResponse> {
   return request<FallbackProvidersResponse>('/api/hermes/config/fallback-providers')
+}
+
+export async function fetchStudioImageProviders(): Promise<StudioImageProvidersResponse> {
+  return request<StudioImageProvidersResponse>('/api/studio/media/image-providers')
 }
 
 export async function saveFallbackProviders(fallbackProviders: FallbackProviderEntry[]): Promise<{

--- a/packages/client/src/components/hermes/models/AuxiliaryModelsPanel.vue
+++ b/packages/client/src/components/hermes/models/AuxiliaryModelsPanel.vue
@@ -1,16 +1,18 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
-import { NButton, NInput, NInputNumber, NModal, NSelect, NSpin, useMessage } from 'naive-ui'
+import { NButton, NInput, NInputNumber, NModal, NSelect, NSpin, useMessage, type SelectOption } from 'naive-ui'
 import { useI18n } from 'vue-i18n'
 import {
   fetchAuxiliaryModels,
   fetchDelegationModel,
+  fetchStudioImageProviders,
   saveAuxiliaryModels,
   saveDelegationModel,
   type AuxiliaryModelSettings,
   type AuxiliaryModelTask,
   type AuxiliaryModelsConfig,
   type DelegationModelConfig,
+  type StudioImageProvider,
 } from '@/api/hermes/config'
 import { useModelsStore } from '@/stores/hermes/models'
 import { useProfilesStore } from '@/stores/hermes/profiles'
@@ -27,6 +29,7 @@ const savingDelegation = ref(false)
 const tasks = ref<AuxiliaryModelTask[]>([])
 const auxiliary = ref<AuxiliaryModelsConfig>({})
 const delegation = ref<DelegationModelConfig>({})
+const studioImageProviders = ref<StudioImageProvider[]>([])
 const showEditor = ref(false)
 const showDelegationEditor = ref(false)
 const editingTask = ref<AuxiliaryModelTask | null>(null)
@@ -108,7 +111,7 @@ const isEditingStudioImage = computed(() => (
 
 const providerOptions = computed(() => {
   const seen = new Set<string>()
-  const options = [{
+  const options: SelectOption[] = [{
     label: isEditingStudioImage.value
       ? t('models.auxiliaryProviderStudioDefault')
       : t('models.auxiliaryProviderAuto'),
@@ -116,6 +119,19 @@ const providerOptions = computed(() => {
   }]
   if (!isEditingStudioImage.value) {
     options.push({ label: t('models.auxiliaryProviderMain'), value: 'main' })
+  } else {
+    const modality = editingTask.value?.key === 'image_edit' ? 'image' : 'text'
+    for (const provider of studioImageProviders.value) {
+      const modalities = provider.capabilities?.modalities || ['text']
+      if (!modalities.includes(modality)) continue
+      const value = `image:${provider.name}`
+      seen.add(value)
+      options.push({
+        label: provider.display_name || provider.name,
+        value,
+        disabled: !provider.available,
+      })
+    }
   }
   for (const group of modelsStore.providers) {
     if (!group.provider) continue
@@ -135,6 +151,9 @@ function canonicalProviderValue(value: string): string {
 function selectableProviderValue(provider: string, customOnly = false): string {
   if (!provider || provider === 'auto') return provider
   if (provider === 'main') return customOnly ? '' : provider
+  if (customOnly && provider.startsWith('image:')) {
+    return studioImageProviders.value.some(item => `image:${item.name}` === provider) ? provider : ''
+  }
   const direct = modelsStore.providers.find(group => group.provider === provider)
   if (direct && (!customOnly || direct.provider.startsWith('custom:'))) return direct.provider
   const canonical = canonicalProviderValue(provider)
@@ -145,6 +164,13 @@ function selectableProviderValue(provider: string, customOnly = false): string {
 }
 
 function modelsForProvider(provider: string): string[] {
+  if (provider.startsWith('image:')) {
+    const name = provider.slice('image:'.length)
+    return studioImageProviders.value
+      .find(item => item.name === name)
+      ?.models.map(model => model.id)
+      .filter(Boolean) || []
+  }
   const group = modelsStore.providers.find(item => item.provider === provider)
   return group?.models || []
 }
@@ -175,9 +201,13 @@ function configuredLabel(task: AuxiliaryModelTask, settings?: AuxiliaryModelSett
     ? t('models.auxiliaryProviderStudioDefault')
     : t('models.auxiliaryProviderAuto')
   if (!settings || Object.keys(settings).length === 0) return defaultProviderLabel
-  const provider = !settings.provider || settings.provider === 'auto'
+  let provider = !settings.provider || settings.provider === 'auto'
     ? (settings.base_url ? t('models.auxiliaryCustomEndpoint') : defaultProviderLabel)
     : settings.provider
+  if (provider.startsWith('image:')) {
+    const native = studioImageProviders.value.find(item => `image:${item.name}` === provider)
+    provider = native?.display_name || provider.slice('image:'.length)
+  }
   return settings.model ? `${provider} / ${settings.model}` : provider
 }
 
@@ -196,13 +226,15 @@ function timeoutLabel(task: AuxiliaryModelTask, settings?: AuxiliaryModelSetting
 async function loadModelRouting() {
   loading.value = true
   try {
-    const [auxiliaryData, delegationData] = await Promise.all([
+    const [auxiliaryData, delegationData, imageProviderData] = await Promise.all([
       fetchAuxiliaryModels(),
       fetchDelegationModel(),
+      fetchStudioImageProviders().catch(() => ({ ok: false, profile: '', providers: [] })),
     ])
     tasks.value = auxiliaryData.tasks
     auxiliary.value = auxiliaryData.auxiliary
     delegation.value = delegationData.delegation
+    studioImageProviders.value = imageProviderData.providers
   } catch (e: any) {
     message.error(e.message || t('models.modelRoutingLoadFailed'))
   } finally {
@@ -307,7 +339,7 @@ function buildSettings(): AuxiliaryModelSettings {
   const extraBody = readExtraBody()
   const model = form.value.model.trim()
   if (provider) settings.provider = provider
-  if (provider && provider !== 'auto' && provider !== 'main' && !model) {
+  if (provider && provider !== 'auto' && provider !== 'main' && !model && modelsForProvider(provider).length > 0) {
     throw new Error(t('models.modelRequired'))
   }
   if (model) settings.model = model
@@ -379,7 +411,10 @@ watch(() => form.value.provider, (provider) => {
     return
   }
   if (!modelsForProvider(provider).includes(form.value.model)) {
-    form.value.model = ''
+    const native = provider.startsWith('image:')
+      ? studioImageProviders.value.find(item => `image:${item.name}` === provider)
+      : undefined
+    form.value.model = native?.default_model || ''
   }
 }, { flush: 'sync' })
 

--- a/packages/ekko-agent/skills/image-gen/SKILL.md
+++ b/packages/ekko-agent/skills/image-gen/SKILL.md
@@ -57,7 +57,7 @@ Use when parts of the source should be preserved:
 ## Options
 
 - `--profile <name>`: required in Ekko runs; use the current runtime Profile.
-- `--provider <name>`: optional configured custom provider. Omit it to use the Profile's image route and server fallback.
+- `--provider <name>`: optional configured provider. Native Hermes image providers use `image:<name>`; custom OpenAI-compatible providers use their configured name. Omit it to use the Profile's image route and server fallback.
 - `--size <width>x<height>`: defaults to `1024x1024`. Also accepts `auto` when supported.
 - `--quality <value>`: optional provider quality setting.
 - `--n <count>`: number of images; defaults to `1`.
@@ -72,5 +72,6 @@ Do not invent a provider or model override. Use them only when the user requeste
 
 - `missing_fun_codex_provider`: the current Profile has no default `fun-codex` provider or configured image route.
 - `missing_apikey_image_provider`: the requested provider is absent from the current Profile.
+- `native_image_generation_failed`: the selected Hermes image provider returned an error or no image.
 - `profile_not_found`: the Ekko Profile does not map to an existing Studio/Hermes Profile used by the media endpoint.
 - `401`, `403`, connection failure, timeout, or any provider error: report the Studio error and stop. Do not bypass Studio or silently retry against another service.

--- a/packages/server/src/bootstrap/chat-agent-runtime-adapter.ts
+++ b/packages/server/src/bootstrap/chat-agent-runtime-adapter.ts
@@ -32,6 +32,10 @@ import {
 
 configureChatAgentRuntime({
   createPrimaryAgentBridge: options => new AgentBridgeClient(options),
+  listPrimaryImageProviders: profile => new AgentBridgeClient({ timeoutMs: 15000 }).imageProviders(profile),
+  generatePrimaryImage: (profile, payload, options) => new AgentBridgeClient({
+    timeoutMs: Number(options?.timeoutMs) || 10 * 60 * 1000,
+  }).imageGenerate(profile, payload, options),
   getPrimaryAgentBridgeManager: getAgentBridgeManager,
   redactPrimaryAgentBridgeError: redactAgentBridgeError,
   codingAgentRunManager,

--- a/packages/server/src/modules/hermes/services/bridge/client.ts
+++ b/packages/server/src/modules/hermes/services/bridge/client.ts
@@ -150,6 +150,33 @@ export interface AgentBridgeProviderCredentials extends AgentBridgeResponse {
   relogin_required?: boolean
 }
 
+export interface AgentBridgeImageProvider {
+  name: string
+  display_name: string
+  available: boolean
+  active: boolean
+  default_model?: string | null
+  models: Array<{ id: string; display?: string; [key: string]: unknown }>
+  capabilities: { modalities?: string[]; max_reference_images?: number; [key: string]: unknown }
+  setup: { badge?: string; tag?: string; required_env_vars?: string[] }
+}
+
+export interface AgentBridgeImageProviders extends AgentBridgeResponse {
+  providers: AgentBridgeImageProvider[]
+}
+
+export interface AgentBridgeImageGenerateResult extends AgentBridgeResponse {
+  provider: string
+  result: {
+    success: boolean
+    image?: string | null
+    model?: string
+    error?: string
+    error_type?: string
+    [key: string]: unknown
+  }
+}
+
 export interface AgentBridgeCommandResult extends AgentBridgeResponse {
   session_id: string
   command: string
@@ -562,6 +589,22 @@ export class AgentBridgeClient {
       provider,
       ...(model ? { model } : {}),
     })
+  }
+
+  imageProviders(profile: string): Promise<AgentBridgeImageProviders> {
+    return this.request<AgentBridgeImageProviders>({ action: 'image_providers', profile })
+  }
+
+  imageGenerate(
+    profile: string,
+    payload: Record<string, unknown>,
+    options: AgentBridgeRequestOptions = {},
+  ): Promise<AgentBridgeImageGenerateResult> {
+    return this.request<AgentBridgeImageGenerateResult>({
+      action: 'image_generate',
+      profile,
+      ...payload,
+    }, options)
   }
 
   command(sessionId: string, command: string, profile?: string): Promise<AgentBridgeCommandResult> {

--- a/packages/server/src/modules/hermes/services/bridge/python/bridge_broker.py
+++ b/packages/server/src/modules/hermes/services/bridge/python/bridge_broker.py
@@ -249,7 +249,7 @@ class BridgeBroker:
             profile = self._normalize_profile(req.get("profile"))
             return self._forward(profile, req, self._normalize_worker_key(profile, req.get("worker_key")))
 
-        if action == "provider_credentials":
+        if action in {"provider_credentials", "image_providers", "image_generate"}:
             profile = self._normalize_profile(req.get("profile"))
             return self._forward(profile, req, self._normalize_worker_key(profile, req.get("worker_key")))
 

--- a/packages/server/src/modules/hermes/services/bridge/python/bridge_server.py
+++ b/packages/server/src/modules/hermes/services/bridge/python/bridge_server.py
@@ -177,6 +177,88 @@ class BridgeServer:
                     "relogin_required": bool(getattr(exc, "relogin_required", False)),
                 }
 
+        if action == "image_providers":
+            _ensure_agent_imports()
+            from hermes_cli.plugins import _ensure_plugins_discovered
+            from agent.image_gen_registry import get_active_provider, list_providers
+
+            _ensure_plugins_discovered()
+            active = get_active_provider()
+            providers = []
+            for provider in list_providers():
+                try:
+                    available = bool(provider.is_available())
+                except Exception:
+                    available = False
+                try:
+                    models = provider.list_models() or []
+                except Exception:
+                    models = []
+                try:
+                    default_model = provider.default_model()
+                except Exception:
+                    default_model = None
+                try:
+                    capabilities = provider.capabilities() or {}
+                except Exception:
+                    capabilities = {}
+                try:
+                    setup = provider.get_setup_schema() or {}
+                except Exception:
+                    setup = {}
+                providers.append({
+                    "name": provider.name,
+                    "display_name": provider.display_name,
+                    "available": available,
+                    "active": active is not None and active.name == provider.name,
+                    "default_model": default_model,
+                    "models": models,
+                    "capabilities": capabilities,
+                    "setup": {
+                        "badge": setup.get("badge", ""),
+                        "tag": setup.get("tag", ""),
+                        "required_env_vars": [
+                            item.get("key")
+                            for item in setup.get("env_vars", [])
+                            if isinstance(item, dict) and item.get("key")
+                        ],
+                    },
+                })
+            return {"providers": _jsonable(providers)}
+
+        if action == "image_generate":
+            prompt = str(req.get("prompt") or "").strip()
+            if not prompt:
+                raise ValueError("prompt is required")
+            _ensure_agent_imports()
+            from hermes_cli.plugins import _ensure_plugins_discovered
+            from agent.image_gen_registry import get_active_provider, get_provider
+
+            _ensure_plugins_discovered()
+            requested_provider = str(req.get("provider") or "").strip()
+            provider = get_provider(requested_provider) if requested_provider else get_active_provider()
+            if provider is None:
+                raise ValueError(
+                    f"image provider '{requested_provider}' is not registered"
+                    if requested_provider else "no active image provider is configured"
+                )
+            if not provider.is_available():
+                raise ValueError(f"image provider '{provider.name}' is not configured")
+            kwargs = {}
+            for key in ("model", "quality", "output_format", "upscale"):
+                if req.get(key) is not None:
+                    kwargs[key] = req.get(key)
+            result = provider.generate(
+                prompt,
+                str(req.get("aspect_ratio") or "landscape"),
+                image_url=req.get("image_url"),
+                reference_image_urls=req.get("reference_image_urls"),
+                **kwargs,
+            )
+            if not isinstance(result, dict):
+                raise RuntimeError(f"image provider '{provider.name}' returned an invalid result")
+            return {"provider": provider.name, "result": _jsonable(result)}
+
         if action == "get_result":
             return self.pool.get_result(str(req.get("run_id") or ""))
 

--- a/packages/server/src/modules/studio/controllers/media.ts
+++ b/packages/server/src/modules/studio/controllers/media.ts
@@ -5,6 +5,7 @@ import { getActiveProfileName, getProfileDir, listProfileNamesFromDisk } from '.
 import { readConfigYamlForProfile } from '../public/media-profile-config'
 import { config } from '../public/config'
 import { getCompatibleCustomProviders } from '../contracts/provider-compat'
+import { generatePrimaryImage, listPrimaryImageProviders } from '../public/chat-agent-runtime'
 
 const XAI_VIDEO_GENERATIONS_URL = 'https://api.x.ai/v1/videos/generations'
 const XAI_VIDEO_STATUS_URL = 'https://api.x.ai/v1/videos'
@@ -57,6 +58,8 @@ type ApiKeyImageProvider = {
   baseUrl: string
   model: string
 }
+
+const NATIVE_IMAGE_PROVIDER_PREFIX = 'image:'
 
 function requestedProfileName(ctx: Context): string {
   const headerProfile = ctx.get('x-hermes-profile')
@@ -123,6 +126,13 @@ function requestedApiKeyImageProviderName(body: any): string {
   // No fallback to the built-in name here: resolveApiKeyImageProvider consults
   // the profile's configured provider before reaching for the constant.
   return normalizeCustomProviderName(body?.provider || body?.provider_name || body?.custom_provider)
+}
+
+function nativeImageProviderName(value: unknown): string {
+  const provider = String(value || '').trim()
+  return provider.startsWith(NATIVE_IMAGE_PROVIDER_PREFIX)
+    ? provider.slice(NATIVE_IMAGE_PROVIDER_PREFIX.length).trim()
+    : ''
 }
 
 /**
@@ -629,6 +639,116 @@ function saveGeneratedImages(images: string[], requestedOutputPath?: string): st
   })
 }
 
+function requestedAspectRatio(body: any): 'landscape' | 'square' | 'portrait' {
+  const explicit = String(body.aspect_ratio || '').trim().toLowerCase()
+  if (explicit === 'landscape' || explicit === 'square' || explicit === 'portrait') return explicit
+  const match = String(body.size || '').match(/^(\d+)x(\d+)$/)
+  if (!match) return 'landscape'
+  const width = Number(match[1])
+  const height = Number(match[2])
+  return width === height ? 'square' : width > height ? 'landscape' : 'portrait'
+}
+
+async function nativeImageInput(body: any): Promise<string | undefined> {
+  if (!body.image_url && !body.image_base64 && !body.image_path) return undefined
+  if (typeof body.image_path === 'string' && body.image_path.trim()) {
+    const path = isAbsolute(body.image_path) ? body.image_path : resolve(process.cwd(), body.image_path)
+    if (!existsSync(path)) {
+      const err: any = new Error('image_path does not exist')
+      err.status = 404
+      throw err
+    }
+    return path
+  }
+  return normalizeImageInput(body)
+}
+
+async function saveNativeImage(image: string, outputPath: string): Promise<void> {
+  let buffer: Buffer
+  if (image.startsWith('data:image/')) {
+    buffer = imageDataUriToBytes(image).buffer
+  } else if (/^https?:\/\//i.test(image)) {
+    buffer = (await fetchImageBytes(image)).buffer
+  } else {
+    const source = isAbsolute(image) ? image : resolve(process.cwd(), image)
+    if (!existsSync(source)) throw new Error('image provider returned a file that does not exist')
+    buffer = readFileSync(source)
+  }
+  if (buffer.length > MAX_IMAGE_BYTES) {
+    const err: any = new Error(`image is too large (max ${MAX_IMAGE_BYTES} bytes)`)
+    err.status = 413
+    throw err
+  }
+  mkdirSync(dirname(outputPath), { recursive: true })
+  writeFileSync(outputPath, buffer)
+}
+
+async function requestNativeImages(
+  profile: string,
+  provider: string,
+  mode: ApiKeyImageMode,
+  body: any,
+  configuredModel: string,
+  configuredTimeoutMs?: number,
+): Promise<{ outputPaths: string[]; model?: string }> {
+  const prompt = typeof body.prompt === 'string' ? body.prompt.trim() : ''
+  if (!prompt) {
+    const err: any = new Error('prompt is required')
+    err.status = 400
+    throw err
+  }
+  const count = normalizePositiveInt(body.n, 1, 'n')
+  const timeoutMs = body.timeout_ms === undefined || body.timeout_ms === null || body.timeout_ms === ''
+    ? configuredTimeoutMs || DEFAULT_TIMEOUT_MS
+    : normalizePositiveInt(body.timeout_ms, DEFAULT_TIMEOUT_MS, 'timeout_ms')
+  const source = mode === 'text' ? undefined : await nativeImageInput(body)
+  const references = Array.isArray(body.reference_image_urls)
+    ? body.reference_image_urls.filter((item: unknown) => typeof item === 'string' && item.trim())
+    : undefined
+  const outputPaths: string[] = []
+  let model: string | undefined
+  for (let index = 0; index < count; index += 1) {
+    const response = await generatePrimaryImage(profile, {
+      provider,
+      prompt,
+      aspect_ratio: requestedAspectRatio(body),
+      ...(source ? { image_url: source } : {}),
+      ...(references?.length ? { reference_image_urls: references } : {}),
+      ...((body.model || configuredModel) ? { model: body.model || configuredModel } : {}),
+      ...(body.quality ? { quality: body.quality } : {}),
+      ...(body.output_format ? { output_format: body.output_format } : {}),
+      ...(body.upscale !== undefined ? { upscale: Boolean(body.upscale) } : {}),
+    }, { timeoutMs })
+    if (!response.result?.success || !response.result?.image) {
+      const err: any = new Error(response.result?.error || `image provider '${provider}' did not return an image`)
+      err.status = 502
+      err.code = response.result?.error_type || 'native_image_generation_failed'
+      throw err
+    }
+    model = response.result.model || model
+    const requestedOutputPath = typeof body.output_path === 'string' ? body.output_path.trim() : ''
+    const outputPath = requestedOutputPath && count === 1
+      ? requestedOutputPath
+      : requestedOutputPath
+        ? requestedOutputPath.replace(/(\.[^.\\/]+)?$/, `${index > 0 ? `-${index + 1}` : ''}$1`)
+        : defaultImageOutputPath(`image_${Date.now()}`, index)
+    await saveNativeImage(response.result.image, outputPath)
+    outputPaths.push(outputPath)
+  }
+  return { outputPaths, model }
+}
+
+export async function getImageProviders(ctx: Context) {
+  try {
+    const profile = resolveMediaProfile(ctx)
+    const response = await listPrimaryImageProviders(profile)
+    ctx.body = { ok: true, profile, providers: response.providers || [] }
+  } catch (err: any) {
+    ctx.status = err.status || 503
+    ctx.body = { error: err.message || String(err), code: err.code || 'image_providers_unavailable' }
+  }
+}
+
 export async function apiKeyImageGenerate(ctx: Context) {
   let profile: string
   try {
@@ -653,6 +773,36 @@ export async function apiKeyImageGenerate(ctx: Context) {
     const activeSettings = mode === 'image' ? editSettings : generationSettings
     const configuredProvider = activeSettings.provider
       || (mode === 'image' ? generationSettings.provider : editSettings.provider)
+    const requestedProvider = String(body?.provider || body?.provider_name || '').trim()
+    let nativeProvider = nativeImageProviderName(requestedProvider || configuredProvider)
+    if (!requestedProvider && !configuredProvider) {
+      try {
+        const nativeProviders = await listPrimaryImageProviders(profile)
+        nativeProvider = nativeProviders.providers?.find((entry: any) => entry.active && entry.available)?.name || ''
+      } catch {
+        // The existing OpenAI-compatible Studio route remains the fallback
+        // when the bundled Hermes runtime predates image provider discovery.
+      }
+    }
+    if (nativeProvider) {
+      const native = await requestNativeImages(
+        profile,
+        nativeProvider,
+        mode,
+        body,
+        activeSettings.model,
+        activeSettings.timeoutMs,
+      )
+      ctx.body = {
+        ok: true,
+        mode,
+        output_paths: native.outputPaths,
+        provider: `${NATIVE_IMAGE_PROVIDER_PREFIX}${nativeProvider}`,
+        model: native.model,
+        profile,
+      }
+      return
+    }
     const providerName = requestedApiKeyImageProviderName(body)
     const resolution = resolveApiKeyImageProvider(hermesConfig, providerName, configuredProvider)
     if (!resolution.provider) {

--- a/packages/server/src/modules/studio/public/chat-agent-runtime.ts
+++ b/packages/server/src/modules/studio/public/chat-agent-runtime.ts
@@ -19,6 +19,8 @@ export type ChatModelResponse = any
 
 export interface ChatAgentRuntimeDependencies {
   createPrimaryAgentBridge(options?: Record<string, unknown>): PrimaryAgentBridgeClient
+  listPrimaryImageProviders(profile: string): Promise<any>
+  generatePrimaryImage(profile: string, payload: Record<string, unknown>, options?: Record<string, unknown>): Promise<any>
   getPrimaryAgentBridgeManager(): any
   redactPrimaryAgentBridgeError(error: string | undefined, endpoint?: string, replacement?: string): string | undefined
   codingAgentRunManager: Record<string, any>
@@ -58,6 +60,12 @@ function configured(): ChatAgentRuntimeDependencies {
 export const createPrimaryAgentBridge = (options?: Record<string, unknown>) => (
   configured().createPrimaryAgentBridge(options)
 )
+export const listPrimaryImageProviders = (profile: string) => configured().listPrimaryImageProviders(profile)
+export const generatePrimaryImage = (
+  profile: string,
+  payload: Record<string, unknown>,
+  options?: Record<string, unknown>,
+) => configured().generatePrimaryImage(profile, payload, options)
 export const getPrimaryAgentBridgeManager = () => configured().getPrimaryAgentBridgeManager()
 export const redactPrimaryAgentBridgeError = (
   error: string | undefined,

--- a/packages/server/src/modules/studio/routes/media.ts
+++ b/packages/server/src/modules/studio/routes/media.ts
@@ -4,5 +4,6 @@ import * as ctrl from '../controllers/media'
 export const mediaRoutes = new Router()
 
 mediaRoutes.post('/api/studio/media/grok-image-to-video', ctrl.grokImageToVideo)
+mediaRoutes.get('/api/studio/media/image-providers', ctrl.getImageProviders)
 mediaRoutes.post('/api/studio/media/apikey-image-generate', ctrl.apiKeyImageGenerate)
 mediaRoutes.post('/api/studio/media/minimax-image-to-video', ctrl.miniMaxImageToVideo)

--- a/packages/skills/apikey-image-gen/SKILL.md
+++ b/packages/skills/apikey-image-gen/SKILL.md
@@ -16,12 +16,12 @@ prerequisites:
 
 Use this skill when the user wants to generate an image or edit an existing image.
 
-Always call Ekko Studio's media endpoint. Do not call an upstream image API directly, and do not ask the user for an API key. The server reads the selected/requested profile's `config.yaml` and uses a configured custom provider. By default it uses the provider named `fun-codex`, but callers may request another configured provider by sending `provider`, `provider_name`, or `custom_provider`.
+Always call Ekko Studio's media endpoint. Do not call an upstream image API directly, and do not ask the user for an API key. The server reads the selected/requested profile's `config.yaml` and routes through either Hermes Agent's native image-provider registry or a configured OpenAI-compatible custom provider. If the Studio auxiliary route is automatic, its active native Hermes image provider is preferred; `fun-codex` remains the compatibility fallback.
 
-This skill is separate from Hermes Agent's native `image_generate` tool. The
-native tool reads `image_gen` from `config.yaml`; this Studio-managed endpoint
-reads the `auxiliary.image_generation` and `auxiliary.image_edit` routes below.
-Changing one does not change the other.
+Studio stores explicit native selections as `image:<provider>` under
+`auxiliary.image_generation` and `auxiliary.image_edit`. The server resolves
+the provider through Hermes Agent's `ImageGenProvider` registry, so provider
+credentials, capabilities, and model catalogs continue to be owned by Hermes.
 
 Do not use any built-in image generation tool as a fallback. If the Hermes Web UI endpoint returns `401`, `403`, connection failure, or any other error, stop and report the Hermes Web UI error to the user.
 
@@ -120,9 +120,9 @@ Use when there is no input image.
 }
 ```
 
-The server calls `POST /v1/images/generations` against the configured
-`auxiliary.image_generation` provider, then falls back to `fun-codex`.
-If `provider`, `provider_name`, or `custom_provider` is present, the server calls the requested provider's base URL instead.
+For `image:<provider>`, the server invokes the corresponding native Hermes
+image provider. For a custom provider, it calls `POST /v1/images/generations`
+against `auxiliary.image_generation`, then falls back to `fun-codex`.
 
 ### Image To Image
 
@@ -138,10 +138,10 @@ Use when the user provides an existing image and wants the model to modify or re
 }
 ```
 
-The server calls `POST /v1/responses` against the configured
-`auxiliary.image_edit` provider, then the image-generation provider, then
-`fun-codex`.
-If `provider`, `provider_name`, or `custom_provider` is present, the server calls the requested provider's base URL instead.
+For `image:<provider>`, the same native Hermes provider handles the source
+image according to its advertised capabilities. For a custom provider, the
+server calls `POST /v1/responses` against `auxiliary.image_edit`, then the
+image-generation provider, then `fun-codex`.
 
 ### Image Edit
 
@@ -157,15 +157,15 @@ Use when the user wants to modify an existing image while preserving parts of it
 }
 ```
 
-The server calls `POST /v1/images/edits` against the configured
-`auxiliary.image_generation` provider, then falls back to `fun-codex`.
-If `provider`, `provider_name`, or `custom_provider` is present, the server calls the requested provider's base URL instead.
+For `image:<provider>`, the same native Hermes provider performs the edit. For
+a custom provider, the server calls `POST /v1/images/edits` against
+`auxiliary.image_generation`, then falls back to `fun-codex`.
 
 ## Request Fields
 
 - `mode`: `text`, `image`, or `edit`.
 - `prompt`: required.
-- `provider`: optional configured custom provider name. Defaults to `fun-codex`. `custom:<name>` is accepted and normalized to `<name>`.
+- `provider`: optional provider selection. Use `image:<name>` for a registered native Hermes image provider. Custom provider names and `custom:<name>` remain supported. When omitted, Studio uses the configured auxiliary route, then the active native Hermes image provider, then `fun-codex`.
 - `provider_name`: optional alias for `provider`.
 - `custom_provider`: optional alias for `provider`.
 - `image_path`: local png, jpeg, or webp path. Required for `image` and `edit` unless using `image_url` or `image_base64`.

--- a/tests/client/auxiliary-models-panel.test.ts
+++ b/tests/client/auxiliary-models-panel.test.ts
@@ -5,6 +5,7 @@ import { flushPromises, mount } from '@vue/test-utils'
 const apiMocks = vi.hoisted(() => ({
   fetchAuxiliaryModels: vi.fn(),
   fetchDelegationModel: vi.fn(),
+  fetchStudioImageProviders: vi.fn(),
   saveAuxiliaryModels: vi.fn(),
   saveDelegationModel: vi.fn(),
 }))
@@ -106,6 +107,7 @@ describe('AuxiliaryModelsPanel', () => {
     apiMocks.fetchDelegationModel.mockResolvedValue({
       delegation: { provider: 'openrouter', model: 'old-model', reasoning_effort: 'low' },
     })
+    apiMocks.fetchStudioImageProviders.mockResolvedValue({ ok: true, profile: 'default', providers: [] })
     apiMocks.saveDelegationModel
       .mockResolvedValueOnce({
         success: true,
@@ -205,6 +207,50 @@ describe('AuxiliaryModelsPanel', () => {
     await wrapper.findAll('.auxiliary-row')[1].get('button').trigger('click')
 
     expect(wrapper.getComponent('[data-testid="auxiliary-provider"]').props('value')).toBe('auto')
+  })
+
+  it('uses Hermes native image providers and filters them by task capability', async () => {
+    apiMocks.fetchAuxiliaryModels.mockResolvedValueOnce({
+      tasks: [
+        { key: 'image_generation', label: 'Image generation', default_timeout: 600 },
+        { key: 'image_edit', label: 'Image edit', default_timeout: 600 },
+      ],
+      auxiliary: {},
+    })
+    apiMocks.fetchStudioImageProviders.mockResolvedValueOnce({
+      ok: true,
+      profile: 'default',
+      providers: [
+        {
+          name: 'openai', display_name: 'OpenAI Images', available: true, active: true,
+          default_model: 'gpt-image-2', models: [{ id: 'gpt-image-2' }],
+          capabilities: { modalities: ['text', 'image'] },
+        },
+        {
+          name: 'deepinfra', display_name: 'DeepInfra', available: false, active: false,
+          default_model: 'flux', models: [{ id: 'flux' }], capabilities: { modalities: ['text'] },
+        },
+      ],
+    })
+
+    const wrapper = mount(AuxiliaryModelsPanel)
+    await flushPromises()
+    await wrapper.findAll('.auxiliary-row')[1].get('button').trigger('click')
+
+    const generationOptions = wrapper.getComponent('[data-testid="auxiliary-provider"]').props('options')
+    expect(generationOptions).toContainEqual({ label: 'OpenAI Images', value: 'image:openai', disabled: false })
+    expect(generationOptions).toContainEqual({ label: 'DeepInfra', value: 'image:deepinfra', disabled: true })
+    wrapper.getComponent('[data-testid="auxiliary-provider"]').vm.$emit('update:value', 'image:openai')
+    await wrapper.vm.$nextTick()
+    expect(wrapper.getComponent('[data-testid="auxiliary-model"]').props('value')).toBe('gpt-image-2')
+
+    wrapper.getComponent('[data-testid="auxiliary-provider"]').vm.$emit('update:value', 'auto')
+    await wrapper.vm.$nextTick()
+    await wrapper.get('.modal-stub button').trigger('click')
+    await wrapper.findAll('.auxiliary-row')[2].get('button').trigger('click')
+    const editOptions = wrapper.getComponent('[data-testid="auxiliary-provider"]').props('options')
+    expect(editOptions).toContainEqual({ label: 'OpenAI Images', value: 'image:openai', disabled: false })
+    expect(editOptions).not.toContainEqual(expect.objectContaining({ value: 'image:deepinfra' }))
   })
 
   it('labels an unconfigured Studio image route as the Studio default', async () => {

--- a/tests/server/agent-bridge-image-providers.test.ts
+++ b/tests/server/agent-bridge-image-providers.test.ts
@@ -1,0 +1,81 @@
+import { execFileSync } from 'node:child_process'
+import { describe, expect, it, vi } from 'vitest'
+
+function runPython(script: string): Record<string, any> {
+  return JSON.parse(execFileSync('python3', ['-c', script], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    stdio: 'pipe',
+  }))
+}
+
+describe('Agent Bridge image providers', () => {
+  it('discovers provider metadata and generates through the requested provider', () => {
+    const result = runPython(String.raw`
+import json
+import sys
+import types
+from pathlib import Path
+
+bridge_dir = Path("packages/server/src/modules/hermes/services/bridge/python").resolve()
+sys.path.insert(0, str(bridge_dir))
+import bridge_server
+
+class Provider:
+    name = "openai"
+    display_name = "OpenAI Images"
+    def is_available(self): return True
+    def list_models(self): return [{"id": "gpt-image-2", "display": "GPT Image 2"}]
+    def default_model(self): return "gpt-image-2"
+    def capabilities(self): return {"modalities": ["text", "image"], "max_reference_images": 1}
+    def get_setup_schema(self):
+        return {"badge": "paid", "tag": "OpenAI image generation", "env_vars": [{"key": "OPENAI_API_KEY", "prompt": "secret"}]}
+    def generate(self, prompt, aspect_ratio, **kwargs):
+        return {"success": True, "image": "/tmp/result.png", "model": kwargs.get("model"), "prompt": prompt, "aspect_ratio": aspect_ratio}
+
+provider = Provider()
+plugins = types.ModuleType("hermes_cli.plugins")
+plugins._ensure_plugins_discovered = lambda: None
+registry = types.ModuleType("agent.image_gen_registry")
+registry.list_providers = lambda: [provider]
+registry.get_active_provider = lambda: provider
+registry.get_provider = lambda name: provider if name == "openai" else None
+sys.modules["hermes_cli"] = types.ModuleType("hermes_cli")
+sys.modules["hermes_cli.plugins"] = plugins
+sys.modules["agent"] = types.ModuleType("agent")
+sys.modules["agent.image_gen_registry"] = registry
+bridge_server._ensure_agent_imports = lambda: None
+server = object.__new__(bridge_server.BridgeServer)
+listed = server.handle({"action": "image_providers"})
+generated = server.handle({
+    "action": "image_generate", "provider": "openai", "prompt": "icon",
+    "aspect_ratio": "square", "model": "gpt-image-2",
+})
+print(json.dumps({"listed": listed, "generated": generated}))
+`)
+
+    expect(result.listed.providers[0]).toMatchObject({
+      name: 'openai', display_name: 'OpenAI Images', available: true, active: true,
+      default_model: 'gpt-image-2', capabilities: { modalities: ['text', 'image'] },
+      setup: { required_env_vars: ['OPENAI_API_KEY'] },
+    })
+    expect(result.generated).toMatchObject({
+      provider: 'openai',
+      result: { success: true, image: '/tmp/result.png', model: 'gpt-image-2', aspect_ratio: 'square' },
+    })
+  })
+
+  it('forwards list and generation payloads from the TypeScript client', async () => {
+    const { AgentBridgeClient } = await import('../../packages/server/src/modules/hermes/services/bridge/client')
+    const client = new AgentBridgeClient({ endpoint: 'tcp://127.0.0.1:1', connectRetryMs: 0, timeoutMs: 1 })
+    const request = vi.spyOn(client, 'request').mockResolvedValue({ ok: true, providers: [] })
+
+    await client.imageProviders('default')
+    await client.imageGenerate('design', { provider: 'openai', prompt: 'icon' }, { timeoutMs: 9000 })
+
+    expect(request).toHaveBeenNthCalledWith(1, { action: 'image_providers', profile: 'default' })
+    expect(request).toHaveBeenNthCalledWith(2, {
+      action: 'image_generate', profile: 'design', provider: 'openai', prompt: 'icon',
+    }, { timeoutMs: 9000 })
+  })
+})

--- a/tests/server/media-controller.test.ts
+++ b/tests/server/media-controller.test.ts
@@ -21,6 +21,60 @@ afterEach(() => {
 })
 
 describe('media controller', () => {
+  it('lists and generates through the profile-scoped Hermes image provider registry', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'hermes-native-image-'))
+    temporaryProfileDirs.push(directory)
+    const outputPath = join(directory, 'native.png')
+    const listPrimaryImageProviders = vi.fn(async () => ({
+      providers: [{
+        name: 'openai', display_name: 'OpenAI Images', available: true, active: true,
+        default_model: 'gpt-image-2', models: [{ id: 'gpt-image-2' }],
+        capabilities: { modalities: ['text', 'image'] }, setup: {},
+      }],
+    }))
+    const generatePrimaryImage = vi.fn(async () => ({
+      provider: 'openai',
+      result: {
+        success: true,
+        image: 'data:image/png;base64,aW1hZ2UtYnl0ZXM=',
+        model: 'gpt-image-2',
+      },
+    }))
+    vi.doMock('../../packages/server/src/modules/studio/public/profile-config', () => ({
+      getActiveProfileName: () => 'default',
+      getProfileDir: () => directory,
+      listProfileNamesFromDisk: () => ['default'],
+    }))
+    vi.doMock('../../packages/server/src/modules/studio/public/media-profile-config', () => ({
+      readConfigYamlForProfile: vi.fn(async () => ({
+        auxiliary: { image_generation: { provider: 'image:openai', model: 'gpt-image-2', timeout: 45 } },
+      })),
+    }))
+    vi.doMock('../../packages/server/src/modules/studio/public/chat-agent-runtime', () => ({
+      listPrimaryImageProviders,
+      generatePrimaryImage,
+    }))
+    const { apiKeyImageGenerate, getImageProviders } = await import('../../packages/server/src/modules/studio/controllers/media')
+    const baseCtx: any = {
+      state: { serverTokenAuth: true }, query: {}, request: {}, get: vi.fn(() => ''), status: 200, body: undefined,
+    }
+    await getImageProviders({ ...baseCtx })
+    expect(listPrimaryImageProviders).toHaveBeenCalledWith('default')
+
+    const ctx: any = {
+      ...baseCtx,
+      request: { body: { mode: 'text', prompt: 'make an icon', output_path: outputPath, size: '1024x1024' } },
+    }
+    await apiKeyImageGenerate(ctx)
+
+    expect(ctx.body).toMatchObject({
+      ok: true, provider: 'image:openai', model: 'gpt-image-2', output_paths: [outputPath], profile: 'default',
+    })
+    expect(generatePrimaryImage).toHaveBeenCalledWith('default', expect.objectContaining({
+      provider: 'openai', prompt: 'make an icon', model: 'gpt-image-2', aspect_ratio: 'square',
+    }), { timeoutMs: 45_000 })
+  })
+
   it('uses Hermes Web UI media directory as the default generated video output path', async () => {
     process.env.HERMES_WEB_UI_HOME = '/tmp/hermes-web-ui-test-home'
     const { defaultImageOutputPath, defaultMediaOutputPath } = await import('../../packages/server/src/modules/studio/controllers/media')


### PR DESCRIPTION
## Summary

Hermes Agent releases now expose image generation through the pluggable `ImageGenProvider` registry. This change connects the existing Studio image generation and image-to-image routes to that native registry while preserving the current OpenAI-compatible custom-provider path.

- discovers image providers, model catalogs, availability, and capabilities from the selected Hermes profile
- shows native providers in the Studio auxiliary image selectors and filters them by text-to-image or image-input capability
- routes generation and editing through the selected native provider in the profile worker
- supports model overrides, aspect ratios, quality, multiple outputs, reference images, and provider-returned URLs, data URIs, or local files
- keeps `custom:*` providers and the existing `fun-codex` behavior as a compatibility fallback
- prefers the active Hermes image provider when the Studio route remains automatic
- updates the bundled Studio image skills and OpenAPI output

Native selections use an explicit `image:<provider>` namespace so they cannot collide with LLM or custom provider identifiers. Provider credentials stay inside the Hermes profile runtime and are never returned to the client.

## Compatibility

Profiles already using `custom:*` or `fun-codex` continue through the same OpenAI-compatible endpoints. If the bundled Hermes runtime does not expose image-provider discovery, the automatic route falls back to the existing Studio behavior.

## Validation

- production build completed successfully
- harness and Ekko public API documentation checks passed
- Python bridge modules compile successfully
- verified provider discovery against the bundled Hermes Agent `v0.20.6` runtime
- focused server, client, bridge, and module-boundary tests: 28 passed