### PR TITLE
fix(group-chat): stop roster @mentions from re-dispatching agents

### DIFF
--- a/packages/server/src/modules/studio/services/group-chat/agent-clients.ts
+++ b/packages/server/src/modules/studio/services/group-chat/agent-clients.ts
@@ -568,9 +568,13 @@ export class AgentClient implements GroupAgentExecutor {
             matches.push({ agentId: participantId, name: displayName })
             byName.set(displayName, matches)
         }
-        return [...byName.values()]
+        const mentions = [...byName.values()]
             .filter(matches => matches.length === 1 && isAgentMentioned(content, matches[0].name))
             .map(matches => ({ type: 'agent' as const, participantId: matches[0].agentId, displayName: matches[0].name }))
+        // Self-intros often list peers as "@A、@B、@C". That is informational, not a handoff.
+        // Only a single peer @mention is treated as Agent-to-Agent routing intent.
+        if (mentions.length > 1) return []
+        return mentions
     }
 
     startTyping(roomId: string): void {

--- a/packages/server/src/modules/studio/services/group-chat/agent-prompt.ts
+++ b/packages/server/src/modules/studio/services/group-chat/agent-prompt.ts
@@ -76,6 +76,7 @@ Rules:
 - When another Agent must collaborate or a specific participant must answer, mention them with @name and state the requested task clearly.
 - Do not proactively mention anyone unless the latest message explicitly asks you to hand off to, invite, or ask a specific participant.
 - If you are only answering a question, answer it directly and do not end by mentioning another participant.
+- When introducing yourself or listing other Agents' names, write plain names without @. Using @name routes the message to that Agent.
 - Do not mention Agents or users merely to keep the conversation active, solicit optional additions, or ask someone else to take a look.
 - Mention someone only when they genuinely need to perform an action, supply information, or confirm a decision.
 - Decide when the conversation is complete. If the issue is resolved, consensus has been reached, or the other participant made a statement that needs no reply, end your response without mentioning anyone so the room does not enter a pointless loop.`

--- a/packages/server/src/modules/studio/services/group-chat/mention-routing.ts
+++ b/packages/server/src/modules/studio/services/group-chat/mention-routing.ts
@@ -16,7 +16,7 @@ type MentionRange = {
     end: number
 }
 
-const AFTER_BOUNDARY = new Set(['.', ',', '!', '?', ';', ':', '，', '。', '！', '？', '；', '：', ')', ']', '}', '>'])
+const AFTER_BOUNDARY = new Set(['.', ',', '!', '?', ';', ':', '，', '、', '。', '！', '？', '；', '：', ')', ']', '}', '>'])
 const QUOTED_MESSAGE_BLOCK_RE = /<quoted_message(?:\s[^>]*)?>[\s\S]*?<\/quoted_message>/gi
 
 function maskQuotedMessageBlocks(content: string): string {

--- a/tests/server/group-chat-mention-routing.test.ts
+++ b/tests/server/group-chat-mention-routing.test.ts
@@ -39,6 +39,13 @@ describe('group chat mention routing', () => {
     expect(isAgentMentioned('mailto@Alice.example', 'Alice')).toBe(false)
   })
 
+  it('treats CJK enumeration顿号 as a safe after-boundary', () => {
+    expect(isAgentMentioned('与其他智能体（@Hermes、@Claude、@Codex、@OpenCode 等）协作', 'Hermes')).toBe(true)
+    expect(isAgentMentioned('与其他智能体（@Hermes、@Claude、@Codex、@OpenCode 等）协作', 'Claude')).toBe(true)
+    expect(isAgentMentioned('与其他智能体（@Hermes、@Claude、@Codex、@OpenCode 等）协作', 'Codex')).toBe(true)
+    expect(isAgentMentioned('与其他智能体（@Hermes、@Claude、@Codex、@OpenCode 等）协作', 'OpenCode')).toBe(true)
+  })
+
   it('routes mentions after CJK speaker prefixes, emoji, and punctuation', () => {
     expect(isAgentMentioned('hermes：@Bob 老板喊你，出来露个脸。', 'Bob')).toBe(true)
     expect(isAgentMentioned('老板喊你@Bob 出来露个脸。', 'Bob')).toBe(true)


### PR DESCRIPTION
## Summary
- Agent self-intros that list peers as `@A、@B、@C` were treated as Agent-to-Agent handoffs. In practice only names followed by a space (e.g. `@OpenCode`) matched, so `@all` 自我介绍 could make OpenCode run twice.
- Treat CJK顿号 `、` as a mention after-boundary.
- In agent reply mention extraction, ignore multi-peer `@` lists (informational roster); keep single `@name` as intentional handoff.
- Clarify the group-chat system prompt: do not use `@` when merely listing other Agents.

## Test plan
- [x] Unit: CJK enumeration string matches Hermes/Claude/Codex/OpenCode with顿号 boundaries
- [ ] Manual: in a room with Pi + OpenCode, `@all` ask for self-intros → OpenCode replies once
- [ ] Manual: agent intentionally hands off with a single `@Codex please …` → Codex still routes


Made with [Cursor](https://cursor.com)