### PR TITLE
fix(desktop): honor system proxy and fall back for browser links

### DIFF
--- a/packages/client/src/utils/desktop-browser.ts
+++ b/packages/client/src/utils/desktop-browser.ts
@@ -43,7 +43,18 @@ export async function openUrlInDesktopBrowser(url: string): Promise<boolean> {
   if (!browser) return false
   const tabCreation = browser.createTab(url, true)
   revealDesktopBrowserPanel()
-  await tabCreation
+  try {
+    await tabCreation
+  } catch (error) {
+    if (typeof bridge.openExternalUrl === 'function') {
+      try {
+        if (await bridge.openExternalUrl(url)) return true
+      } catch {
+        // Preserve the embedded-browser error when the fallback also fails.
+      }
+    }
+    throw error
+  }
   return true
 }
 

--- a/packages/client/src/views/hermes/DesktopBrowserView.vue
+++ b/packages/client/src/views/hermes/DesktopBrowserView.vue
@@ -13,7 +13,7 @@ const settingsProfileId = ref('')
 const profileDraft = ref<DesktopBrowserProfile | null>(null)
 const profileName = ref('')
 const profileRootPath = ref('')
-const profileProxyMode = ref<'direct' | 'system' | 'fixed_servers'>('direct')
+const profileProxyMode = ref<'direct' | 'system' | 'fixed_servers'>('system')
 const profileProxyRules = ref('')
 const profileModalMode = ref<'create' | 'edit'>('create')
 const showProfileModal = ref(false)
@@ -51,7 +51,7 @@ function openCreateProfile(): void {
   profileModalMode.value = 'create'
   profileName.value = ''
   profileRootPath.value = ''
-  profileProxyMode.value = 'direct'
+  profileProxyMode.value = 'system'
   profileProxyRules.value = ''
   profileDraft.value = null
   showProfileModal.value = true

--- a/packages/desktop/src/main/browser/browser-profile-store.ts
+++ b/packages/desktop/src/main/browser/browser-profile-store.ts
@@ -77,7 +77,7 @@ export class BrowserProfileStore {
     const document = this.requireDocument()
     const profileName = safeName(input.name)
     const profileRoot = await this.validateProfileRoot(input.rootDirectory)
-    const proxyMode = safeProxyMode(input.proxyMode)
+    const proxyMode = input.proxyMode === undefined ? 'system' : safeProxyMode(input.proxyMode)
     const proxyRules = safeProxyRules(input.proxyRules, proxyMode)
     const id = randomUUID()
     const createdAt = now()
@@ -195,7 +195,7 @@ export class BrowserProfileStore {
         rootPath: join(this.root, 'profiles', id),
         sessionPath: join(this.root, 'profiles', id, 'data'),
         downloadPath: join(this.root, 'profiles', id, 'download'),
-        proxyMode: 'direct',
+        proxyMode: 'system',
         proxyRules: '',
         askBeforeDownload: true,
         downloadConflictPolicy: 'uniquify',

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -1109,7 +1109,10 @@ ipcMain.handle('hermes-desktop:browser-navigation-action', (event, tabId?: unkno
 })
 ipcMain.handle('hermes-desktop:browser-create-profile', (event, input?: unknown) => {
   const value = input && typeof input === 'object' ? input as Record<string, unknown> : {}
-  const proxyMode = value.proxyMode === 'system' || value.proxyMode === 'fixed_servers' ? value.proxyMode : 'direct'
+  let proxyMode: 'direct' | 'system' | 'fixed_servers' = 'system'
+  if (value.proxyMode !== undefined) {
+    proxyMode = value.proxyMode === 'system' || value.proxyMode === 'fixed_servers' ? value.proxyMode : 'direct'
+  }
   return browserForEvent(event).createProfile({
     name: String(value.name || ''),
     rootDirectory: String(value.rootDirectory || ''),

--- a/tests/client/desktop-browser-open.test.ts
+++ b/tests/client/desktop-browser-open.test.ts
@@ -72,6 +72,39 @@ describe('desktop browser open helpers', () => {
     window.removeEventListener(OPEN_DESKTOP_BROWSER_PANEL_EVENT, listener)
   })
 
+  it('opens a link externally when the embedded browser cannot create a tab', async () => {
+    const browser = browserBridge()
+    browser.createTab.mockRejectedValue(new Error('Browser supports at most 8 tabs per profile'))
+    const openExternalUrl = vi.fn().mockResolvedValue(true)
+    ;(window as typeof window & { hermesDesktop?: unknown }).hermesDesktop = {
+      isDesktop: true,
+      browser,
+      openExternalUrl,
+    }
+    const { openUrlInDesktopBrowser } = await import('../../packages/client/src/utils/desktop-browser')
+
+    await expect(openUrlInDesktopBrowser('https://example.com/full')).resolves.toBe(true)
+
+    expect(openExternalUrl).toHaveBeenCalledWith('https://example.com/full')
+  })
+
+  it('keeps the embedded-browser error when external fallback fails', async () => {
+    const browser = browserBridge()
+    const embeddedError = new Error('Browser supports at most 8 tabs per profile')
+    browser.createTab.mockRejectedValue(embeddedError)
+    const openExternalUrl = vi.fn().mockResolvedValue(false)
+    ;(window as typeof window & { hermesDesktop?: unknown }).hermesDesktop = {
+      isDesktop: true,
+      browser,
+      openExternalUrl,
+    }
+    const { openUrlInDesktopBrowser } = await import('../../packages/client/src/utils/desktop-browser')
+
+    await expect(openUrlInDesktopBrowser('https://example.com/full')).rejects.toBe(embeddedError)
+
+    expect(openExternalUrl).toHaveBeenCalledWith('https://example.com/full')
+  })
+
   it('leaves a message URL for the system browser when that target is stored', async () => {
     const browser = browserBridge()
     ;(window as typeof window & { hermesDesktop?: unknown }).hermesDesktop = {

--- a/tests/desktop/browser-security.test.ts
+++ b/tests/desktop/browser-security.test.ts
@@ -135,6 +135,17 @@ describe('desktop browser security primitives', () => {
     expect(restarted.active().tabs).toEqual([])
   })
 
+  it('uses the system proxy for a newly initialized default profile', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'hermes-browser-system-proxy-'))
+    roots.push(root)
+    const store = new BrowserProfileStore(join(root, 'state'))
+
+    await store.initialize()
+
+    expect(store.active().proxyMode).toBe('system')
+    expect(store.active().proxyRules).toBe('')
+  })
+
   it('switches to a new empty root without migrating old browser data', async () => {
     const root = await mkdtemp(join(tmpdir(), 'hermes-browser-profile-switch-'))
     roots.push(root)


### PR DESCRIPTION
## Summary
- Default new embedded browser profiles to the system proxy so desktop proxy settings are honored.
- Fall back to the system browser when an embedded chat link cannot create a tab, while preserving the embedded error if the fallback fails.

Closes #2967

## Validation
- `npm run test -- tests/client/desktop-browser-open.test.ts tests/desktop/browser-security.test.ts`
- `npm run harness:check`
- `npm run build`
- `git diff --check`