### PR TITLE
fix: keep Agent Bridge workers responsive during slow requests

### DIFF
--- a/packages/server/src/modules/hermes/services/bridge/python/bridge_server.py
+++ b/packages/server/src/modules/hermes/services/bridge/python/bridge_server.py
@@ -31,12 +31,38 @@ from bridge_transport import _make_listen_socket, _read_json_request, _write_jso
 class BridgeServer:
     IDLE_TIMEOUT_SECONDS = 30 * 60  # 30 minutes
     GC_INTERVAL_SECONDS = 60  # check every minute
+    REQUEST_LOCK_STRIPES = 64
+    CONTROL_ACTIONS = {
+        "interrupt",
+        "request_boundary_interrupt",
+        "steer",
+        "approval_respond",
+        "clarify_respond",
+        "compression_respond",
+        "goal_pause",
+        "destroy",
+    }
 
     def __init__(self, endpoint: str) -> None:
         self.endpoint = endpoint
         self.pool = AgentPool()
         self._stop = threading.Event()
         self._last_gc = time.time()
+        self._request_locks = [threading.Lock() for _ in range(self.REQUEST_LOCK_STRIPES)]
+
+    def _request_lock(self, req: dict[str, Any]) -> threading.Lock | None:
+        if str(req.get("action") or "").strip() in self.CONTROL_ACTIONS:
+            return None
+        session_id = str(req.get("session_id") or "").strip()
+        if not session_id:
+            run_id = str(req.get("run_id") or "").strip()
+            if run_id:
+                with self.pool._lock:
+                    record = self.pool._runs.get(run_id)
+                session_id = str(record.session_id) if record is not None else ""
+        if not session_id:
+            return None
+        return self._request_locks[hash(session_id) % len(self._request_locks)]
 
     def handle(self, req: dict[str, Any]) -> dict[str, Any]:
         action = str(req.get("action") or "").strip()
@@ -745,6 +771,32 @@ class BridgeServer:
                 continue
             self.pool.destroy(sid)
 
+    def _handle_connection(self, conn: socket.socket) -> None:
+        try:
+            req = self._read_request(conn)
+            request_lock = self._request_lock(req)
+            if request_lock is None:
+                data = self.handle(req)
+            else:
+                with request_lock:
+                    data = self.handle(req)
+            resp = {"ok": True, **_jsonable(data)}
+        except Exception as exc:
+            resp = {
+                "ok": False,
+                "error": str(exc),
+                "error_type": exc.__class__.__name__,
+            }
+        try:
+            self._write_response(conn, resp)
+        except Exception as exc:
+            print(f"[hermes-bridge] response error: {exc}", file=sys.stderr, flush=True)
+        finally:
+            try:
+                conn.close()
+            except OSError:
+                pass
+
     def serve_forever(self) -> None:
         server = self._make_server_socket()
         restore_signals = _install_stop_signal_handlers(self._stop)
@@ -754,7 +806,7 @@ class BridgeServer:
             f"worker:{_worker_profile() or 'default'}",
         )
         try:
-            server.listen(16)
+            server.listen(1024)
             server.settimeout(0.2)
             print(json.dumps({"event": "ready", "endpoint": self.endpoint}), flush=True)
 
@@ -766,22 +818,16 @@ class BridgeServer:
                     except socket.timeout:
                         self._gc_idle_sessions()
                         continue
-                    try:
-                        req = self._read_request(conn)
-                        data = self.handle(req)
-                        resp = {"ok": True, **_jsonable(data)}
-                    except Exception as exc:
-                        resp = {
-                            "ok": False,
-                            "error": str(exc),
-                            "error_type": exc.__class__.__name__,
-                        }
-                    self._write_response(conn, resp)
+                    threading.Thread(
+                        target=self._handle_connection,
+                        args=(conn,),
+                        daemon=True,
+                        name="hermes-bridge-worker-connection",
+                    ).start()
                 except KeyboardInterrupt:
                     break
                 except Exception as exc:
                     print(f"[hermes-bridge] server loop error: {exc}", file=sys.stderr, flush=True)
-                finally:
                     if conn is not None:
                         try:
                             conn.close()

--- a/tests/server/agent-bridge-python-concurrency.test.ts
+++ b/tests/server/agent-bridge-python-concurrency.test.ts
@@ -242,6 +242,119 @@ def wait_for(condition, timeout=20):
 `
 
 describe('agent bridge Python session concurrency', () => {
+  it('continues accepting worker requests while another request is running', () => {
+    runPython(String.raw`
+import importlib.util
+import json
+import socket
+import sys
+import threading
+import types
+
+ready = threading.Event()
+
+class ReadySocket(socket.socket):
+    def listen(self, backlog=0):
+        result = super().listen(backlog)
+        ready.set()
+        return result
+
+transport = types.ModuleType("bridge_transport")
+listener = ReadySocket(socket.AF_INET, socket.SOCK_STREAM)
+listener.bind(("127.0.0.1", 0))
+transport._make_listen_socket = lambda _endpoint: listener
+transport._read_json_request = lambda conn: json.loads(conn.recv(65536).split(b"\n", 1)[0])
+transport._write_json_response = lambda conn, response: conn.sendall((json.dumps(response) + "\n").encode())
+sys.modules["bridge_transport"] = transport
+
+runtime = types.ModuleType("bridge_runtime")
+runtime._agent_root = lambda: None
+runtime._apply_profile_env = lambda _profile: None
+runtime._ensure_agent_imports = lambda: None
+runtime._hermes_home = lambda: None
+runtime._install_stop_signal_handlers = lambda _stop: lambda: None
+runtime._jsonable = lambda value: value
+runtime._positive_int = lambda _value: None
+runtime._profile_env = lambda _profile: None
+runtime._profile_home = lambda _profile: None
+runtime._resolve_runtime = lambda *_args: {}
+runtime._restore_profile_env = lambda _original: None
+runtime._start_parent_process_watchdog = lambda *_args: None
+runtime._worker_profile = lambda: "default"
+sys.modules["bridge_runtime"] = runtime
+
+pool_module = types.ModuleType("bridge_pool")
+pool_module.AgentPool = type("AgentPool", (), {"__init__": lambda self: None})
+sys.modules["bridge_pool"] = pool_module
+
+spec = importlib.util.spec_from_file_location(
+    "bridge_server",
+    "packages/server/src/modules/hermes/services/bridge/python/bridge_server.py",
+)
+bridge_server = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(bridge_server)
+
+server = bridge_server.BridgeServer("tcp://127.0.0.1:0")
+started = threading.Event()
+release = threading.Event()
+server.handle = lambda request: (
+    (started.set(), release.wait(5), {"request": request["action"]})[2]
+    if request["action"] == "slow"
+    else {"request": request["action"]}
+)
+thread = threading.Thread(target=server.serve_forever, daemon=True)
+thread.start()
+assert ready.wait(2)
+port = listener.getsockname()[1]
+
+slow = socket.create_connection(("127.0.0.1", port), timeout=1)
+slow.sendall(b'{"action":"slow","session_id":"slow-session"}\n')
+assert started.wait(2)
+
+fast = socket.create_connection(("127.0.0.1", port), timeout=1)
+fast.settimeout(1)
+fast.sendall(b'{"action":"fast","session_id":"fast-session"}\n')
+response = json.loads(fast.recv(65536).split(b"\n", 1)[0])
+assert response == {"ok": True, "request": "fast"}
+
+release.set()
+slow.settimeout(2)
+slow_response = json.loads(slow.recv(65536).split(b"\n", 1)[0])
+assert slow_response == {"ok": True, "request": "slow"}
+
+same_started = threading.Event()
+same_release = threading.Event()
+server.handle = lambda request: (
+    (same_started.set(), same_release.wait(5), {"request": request["action"]})[2]
+    if request["action"] == "same-slow"
+    else {"request": request["action"]}
+)
+same_slow = socket.create_connection(("127.0.0.1", port), timeout=1)
+same_slow.sendall(b'{"action":"same-slow","session_id":"same-session"}\n')
+assert same_started.wait(2)
+same_fast = socket.create_connection(("127.0.0.1", port), timeout=1)
+same_fast.settimeout(0.2)
+same_fast.sendall(b'{"action":"same-fast","session_id":"same-session"}\n')
+try:
+    same_fast.recv(65536)
+    raise AssertionError("same-session request was not serialized")
+except TimeoutError:
+    pass
+same_release.set()
+same_slow.settimeout(2)
+same_fast.settimeout(2)
+assert json.loads(same_slow.recv(65536).split(b"\n", 1)[0]) == {"ok": True, "request": "same-slow"}
+assert json.loads(same_fast.recv(65536).split(b"\n", 1)[0]) == {"ok": True, "request": "same-fast"}
+server._stop.set()
+thread.join(timeout=2)
+slow.close()
+fast.close()
+same_slow.close()
+same_fast.close()
+`)
+  })
+
   it('denies only the interrupted session run generation approval queues', () => {
     runPython(String.raw`
 ${harness}


### PR DESCRIPTION
## Summary
- Dispatch each Agent Bridge worker connection independently so a slow request does not block later group-chat requests.
- Serialize ordinary requests by session while keeping control actions reachable.
- Add a socket-level regression covering cross-session progress and same-session serialization.

Closes #2883

## Validation
- `npm run test -- tests/server/agent-bridge-python-concurrency.test.ts`
- `npm run test -- tests/server/agent-bridge-worker-endpoint.test.ts tests/server/agent-bridge-manager.test.ts tests/server/group-chat-execution-queue.test.ts tests/server/group-chat-agent-routing-baseline.test.ts tests/server/group-chat-agent-disconnect.test.ts`
- `npm run harness:check`
- `npm run build`
- `python3 -m py_compile packages/server/src/modules/hermes/services/bridge/python/bridge_server.py`

Windows-native recovery and shutdown-drain behavior still require platform-specific validation.