### PR TITLE
fix(bridge): import session-key helpers from tools.approval_context with fallback

### DIFF
--- a/packages/server/src/modules/hermes/services/bridge/python/bridge_pool.py
+++ b/packages/server/src/modules/hermes/services/bridge/python/bridge_pool.py
@@ -1748,7 +1748,13 @@ class AgentPool:
                 except Exception:
                     self._run_context.session_id = session.session_id
                 try:
-                    from tools.approval import register_gateway_notify, set_current_session_key
+                    from tools.approval import register_gateway_notify
+                    try:
+                        from tools.approval_context import set_current_session_key
+                    except ModuleNotFoundError as exc:
+                        if exc.name != "tools.approval_context":
+                            raise
+                        from tools.approval import set_current_session_key
 
                     approval_session_token = set_current_session_key(session.session_id)
                     register_gateway_notify(session.session_id, self._gateway_approval_notify(session.session_id))
@@ -1933,7 +1939,13 @@ class AgentPool:
                     pass
                 if approval_session_token is not None:
                     try:
-                        from tools.approval import reset_current_session_key, unregister_gateway_notify
+                        from tools.approval import unregister_gateway_notify
+                        try:
+                            from tools.approval_context import reset_current_session_key
+                        except ModuleNotFoundError as exc:
+                            if exc.name != "tools.approval_context":
+                                raise
+                            from tools.approval import reset_current_session_key
 
                         if registered_gateway_approval_session is not None:
                             unregister_gateway_notify(registered_gateway_approval_session)


### PR DESCRIPTION
## Problem

hermes-agent 0.21+ moved `set_current_session_key` / `reset_current_session_key` from `tools.approval` to `tools.approval_context` (same move that `bridge_runtime.py` and `bridge_server.py` already handle). `bridge_pool.py` still imports them from the old module, so on upgraded agent runtimes the session-key registration silently no-ops:

- session keys are never set → approval flows that depend on the current session key break
- the setup/teardown blocks swallow the `ImportError` in their `except Exception`, making the failure invisible

## Fix

Import from `tools.approval_context` first, falling back to the legacy `tools.approval` path when the new module does not exist (older hermes-agent). This mirrors the exact pattern already used in `bridge_runtime.py` and `bridge_server.py`.

## Validation

- Tested in production (Android/Termux + chroot Debian, hermes-agent 0.21.x): before the patch the bridge shows import errors and approval session keys never register; after, both code paths work.
- Python syntax/lint clean.

## Notes

Only touches `bridge_pool.py`, no unrelated refactor.