### PR TITLE
fix: restore DSH plugin settings and Agent presets startup on Windows

### DIFF
--- a/packages/server/src/modules/coding-agents/services/dsh/host.ts
+++ b/packages/server/src/modules/coding-agents/services/dsh/host.ts
@@ -20,8 +20,11 @@ interface DshHostCommands {
 export function createDshHost(host: DshHostCommands) {
   async function runtimeInput() {
     const env = await host.commandEnv()
-    const command = (await host.findCommandPaths('dsh', env))[0]
-    if (!command) throw new DshPluginError(503, 'DSH_DEPENDENCY_UNAVAILABLE', 'DSH is not installed')
+    const discovered = (await host.findCommandPaths('dsh', env))[0]
+    if (!discovered) throw new DshPluginError(503, 'DSH_DEPENDENCY_UNAVAILABLE', 'DSH is not installed')
+    // Windows lookup can return npm's Unix shim before dsh.cmd. Use the shared
+    // execution resolver there; POSIX discovery still needs an absolute path.
+    const command = process.platform === 'win32' ? await host.resolveCommandForExecution('dsh', env) : discovered
     return { installationCommand: command, launchPath: env.PATH,
       sourceHome: process.env.DSH_HOME?.trim() || host.getSourceHome() }
   }

--- a/packages/server/src/modules/coding-agents/services/dsh/management.ts
+++ b/packages/server/src/modules/coding-agents/services/dsh/management.ts
@@ -78,25 +78,32 @@ export class DshManagement {
     try {
       const target = await new Promise<DshUiTarget>((resolve, reject) => {
         let output = ''; let settled = false; let probing = false
-        const timeout = setTimeout(fail, 30_000)
-        function fail() { if (!settled) { settled = true; clearTimeout(timeout); reject(new DshPluginError(503, 'DSH_UI_UNAVAILABLE', 'Unable to start the DSH configuration runtime')) } }
-        child.once('error', fail); child.once('close', fail)
+        const timeout = setTimeout(() => fail('readiness timed out after 30 seconds'), 30_000)
+        function fail(reason: string) { if (!settled) { settled = true; clearTimeout(timeout); reject(new DshPluginError(503, 'DSH_UI_UNAVAILABLE', `Unable to start the DSH configuration runtime (${reason})`)) } }
+        child.once('error', (error: NodeJS.ErrnoException) => {
+          // Only expose OS error identifiers, never command paths or plugin logs.
+          const code = error.code && /^[A-Z][A-Z0-9_]{0,63}$/.test(error.code) ? `: ${error.code}` : ''
+          fail(`process launch failed${code}`)
+        })
+        child.once('close', code => fail(`process exited before readiness${typeof code === 'number' ? `: ${code}` : ''}`))
         child.stderr?.resume() // Native plugins may log private configuration.
         child.stdout?.on('data', chunk => {
           output = (output + String(chunk)).slice(-4096)
           const found = output.match(/STUDIO_DSH_UI_READY:(http:\/\/127\.0\.0\.1:\d+\/\?token=[^\s]+)/)
           if (!found || settled || probing) return
           probing = true
+          let stage = 'native authentication'
           void (async () => {
             const endpoint = new URL(found[1]).origin
             const exchange = await fetch(found[1], { redirect: 'manual', signal: AbortSignal.timeout(5000) })
             const cookie = exchange.headers.getSetCookie().map(value => value.split(';')[0]).join('; ')
             if (exchange.status !== 303 || !cookie) throw new Error('Native authentication failed')
+            stage = 'native frontend probe'
             const probe = await fetch(endpoint, { headers: { cookie }, signal: AbortSignal.timeout(5000) })
             if (!probe.ok) throw new Error('Native frontend unavailable')
             await probe.body?.cancel()
             if (!settled) { settled = true; clearTimeout(timeout); resolve({ endpoint, cookie, generation: randomUUID() }) }
-          })().catch(fail)
+          })().catch(() => fail(`${stage} failed`))
         })
       })
       this.target = target; this.touch(target.generation); return target

--- a/tests/server/dsh-host.test.ts
+++ b/tests/server/dsh-host.test.ts
@@ -1,11 +1,28 @@
-import { expect, it, vi } from 'vitest'
+import { afterEach, expect, it, vi } from 'vitest'
 import { createDshHost } from '../../packages/server/src/modules/coding-agents/services/dsh/host'
 
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!
+afterEach(() => { Object.defineProperty(process, 'platform', originalPlatform) })
+
 it('uses the discovered toolchain PATH for ACP and rejects missing DSH before launch', async () => {
+  Object.defineProperty(process, 'platform', { value: 'darwin' })
   const find = vi.fn().mockResolvedValue(['/tools/dsh'])
   const host = createDshHost({ commandEnv: async () => ({ PATH: '/tools:/pnpm' }), findCommandPaths: find,
     resolveCommandForExecution: async command => command, commandExecution: (command, args) => ({ command, args }), getSourceHome: () => '/native/.dsh' })
   expect(await host.runtimeInput()).toMatchObject({ installationCommand: '/tools/dsh', launchPath: '/tools:/pnpm' })
   find.mockResolvedValue([])
   await expect(host.runtimeInput()).rejects.toMatchObject({ code: 'DSH_DEPENDENCY_UNAVAILABLE' })
+})
+
+it('uses the Windows execution resolver when lookup returns the npm Unix shim first', async () => {
+  Object.defineProperty(process, 'platform', { value: 'win32' })
+  const directory = 'C:\\Users\\测试 User\\AppData\\Roaming\\npm'
+  const env = { PATH: directory }
+  const resolve = vi.fn().mockResolvedValue(`${directory}\\dsh.cmd`)
+  const host = createDshHost({ commandEnv: async () => env,
+    findCommandPaths: async () => [`${directory}\\dsh`, `${directory}\\dsh.cmd`],
+    resolveCommandForExecution: resolve, commandExecution: (command, args) => ({ command, args }),
+    getSourceHome: () => 'C:\\Users\\测试 User\\.dsh' })
+  expect(await host.runtimeInput()).toMatchObject({ installationCommand: `${directory}\\dsh.cmd`, launchPath: directory })
+  expect(resolve).toHaveBeenCalledWith('dsh', env)
 })

--- a/tests/server/dsh-management.test.ts
+++ b/tests/server/dsh-management.test.ts
@@ -1,0 +1,95 @@
+import { EventEmitter } from 'node:events'
+import { PassThrough } from 'node:stream'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import { windowsCmdShimExecution } from '../../packages/server/src/modules/studio/public/windows-command'
+
+const mocks = vi.hoisted(() => ({ spawn: vi.fn(), prepare: vi.fn(), home: '' }))
+vi.mock('node:child_process', () => ({ spawn: mocks.spawn }))
+vi.mock('../../packages/server/src/modules/studio/public/config', () => ({ getWebUiHome: () => mocks.home }))
+vi.mock('../../packages/server/src/modules/coding-agents/services/dsh/management-profile', () => ({ prepareDshManagementProfile: mocks.prepare }))
+import { DshManagement } from '../../packages/server/src/modules/coding-agents/services/dsh/management'
+
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!
+let child: EventEmitter & { stdout: PassThrough; stderr: PassThrough; exitCode: number | null; signalCode: null }
+let management: DshManagement
+
+beforeEach(async () => {
+  mocks.home = await mkdtemp(join(tmpdir(), 'dsh-management-test-'))
+  child = Object.assign(new EventEmitter(), { stdout: new PassThrough(), stderr: new PassThrough(), exitCode: null, signalCode: null })
+  mocks.spawn.mockReset().mockReturnValue(child)
+  mocks.prepare.mockReset().mockResolvedValue({ profile: 'studio-plugins', patch: join(mocks.home, 'management.patch.yml') })
+  management = new DshManagement({
+    runtimeInput: async () => ({ installationCommand: 'C:\\Users\\测试 User\\npm\\dsh.cmd', sourceHome: join(mocks.home, 'source') }),
+    commandEnv: async () => ({ PATH: 'fixture-toolchain' }), commandExecution: windowsCmdShimExecution,
+  })
+})
+afterEach(async () => {
+  vi.useRealTimers()
+  await management.close()
+  child.stdout.destroy(); child.stderr.destroy()
+  Object.defineProperty(process, 'platform', originalPlatform)
+  vi.unstubAllGlobals()
+  await rm(mocks.home, { recursive: true, force: true })
+})
+
+async function start() {
+  // Observe the rejection immediately, including failures emitted before awaiting.
+  const result = management.open().catch(error => error)
+  await vi.waitFor(() => expect(child.listenerCount('error')).toBe(1))
+  return { result }
+}
+
+it('launches a Windows shim through the platform helper with verbatim argv and isolated state', async () => {
+  Object.defineProperty(process, 'platform', { value: 'win32' })
+  const { result } = await start()
+  const [command, args, options] = mocks.spawn.mock.calls[0]
+  expect(command).toBe(process.env.comspec || 'cmd.exe')
+  expect(args.slice(0, 3)).toEqual(['/d', '/s', '/c'])
+  expect(args[3]).toContain('测试^ User\\npm\\dsh.cmd')
+  expect(args[3]).toContain('^"--profile^" ^"studio-plugins^"')
+  expect(options).toMatchObject({ detached: false, windowsHide: true, windowsVerbatimArguments: true,
+    cwd: join(mocks.home, 'source'), env: { PATH: 'fixture-toolchain', ELECTRON_RUN_AS_NODE: '1' } })
+  expect(options.env.DSH_HOME).toContain(join(mocks.home, 'coding-agents/dsh/management/host-'))
+  child.emit('error', Object.assign(new Error('private command path'), { code: 'ENOENT' }))
+  expect(await result).toMatchObject({ status: 503, code: 'DSH_UI_UNAVAILABLE',
+    message: 'Unable to start the DSH configuration runtime (process launch failed: ENOENT)' })
+})
+
+it('reports early exit without exposing native plugin output', async () => {
+  const { result } = await start()
+  child.stderr.write('plugin secret=private-api-key')
+  child.exitCode = 127
+  child.emit('close', 127)
+  expect(await result).toMatchObject({ message: 'Unable to start the DSH configuration runtime (process exited before readiness: 127)' })
+})
+
+it('reports a bounded readiness timeout', async () => {
+  vi.useFakeTimers()
+  const { result } = await start()
+  await vi.advanceTimersByTimeAsync(30_000)
+  expect(await result).toMatchObject({ message: 'Unable to start the DSH configuration runtime (readiness timed out after 30 seconds)' })
+})
+
+it.each(['authentication', 'frontend probe'])('reports native %s failure without token or cookie values', async stage => {
+  const fetch = vi.fn().mockRejectedValue(new Error('private-token private-cookie'))
+  if (stage === 'frontend probe') fetch.mockResolvedValueOnce(new Response(null, { status: 303, headers: { 'set-cookie': 'auth=private-cookie' } }))
+  vi.stubGlobal('fetch', fetch)
+  const { result } = await start()
+  child.stdout.write('STUDIO_DSH_UI_READY:http://127.0.0.1:12345/?token=private-token\n')
+  expect(await result).toMatchObject({ message: `Unable to start the DSH configuration runtime (native ${stage} failed)` })
+})
+
+it('returns the authenticated target and reuses the running host', async () => {
+  vi.stubGlobal('fetch', vi.fn()
+    .mockResolvedValueOnce(new Response(null, { status: 303, headers: { 'set-cookie': 'auth=fixture; HttpOnly' } }))
+    .mockResolvedValueOnce(new Response('native frontend')))
+  const { result } = await start()
+  child.stdout.write('STUDIO_DSH_UI_READY:http://127.0.0.1:12345/?token=fixture\n')
+  const target = await result
+  expect(target).toMatchObject({ endpoint: 'http://127.0.0.1:12345', cookie: 'auth=fixture' })
+  expect(await management.open()).toEqual(target)
+  expect(mocks.spawn).toHaveBeenCalledTimes(1)
+})


### PR DESCRIPTION
## Summary
- Fix Windows startup for the DSH configuration runtime shared by plugin settings and Agent presets. PATH discovery can return npm's extensionless Unix shim before `dsh.cmd`; use the existing Windows execution resolver so the selected shim runs through the existing `cmd.exe` argument handling. Preserve absolute installation discovery on POSIX.
- Include the failed startup stage and safe OS/exit codes in the 503 response. Keep native plugin output, command paths, authentication tokens and cookies out of error messages.
- Keep production changes inside the DSH module. Add regression coverage for Windows shim selection, paths containing spaces/Chinese characters, process failures, timeout, authentication/frontend failures and host reuse.

## Validation
- Focused Vitest: DSH host, management, Agent presets, plugin routes, Web profile and shared Windows command execution tests passed.
- `DSH_WEB_COMMAND=/absolute/path/to/dsh npx vitest run tests/server/dsh-settings-real.test.ts` passed with installed DSH rc.2 on macOS: native plugin configuration, Agent preset persistence and restart retention.
- `npx playwright test tests/e2e/dsh-plugins.spec.ts --workers=2` — 4 passed (desktop/mobile plugin and Agent preset pages).
- `npm run harness:check` and `npm run build` passed.
- Windows behavior is covered with platform/spawn regression tests; native Windows verification is still needed. The user's exact Windows failure has not been reproduced on a Windows host.
